### PR TITLE
simply copy content of repo (with _data) to gh-pages branch

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -11,14 +11,8 @@ jobs:
       with:
           persist-credentials: false
 
-    - name: Setup Ruby and Bundler
-      uses: ruby/setup-ruby@v1
-      with:
-        bundler-cache: true
-        ruby-version: 2.6 # Not needed with a .ruby-version file
-
     - name: Build site
-      run: bundle install && make site
+      run: make gh-site
 
     - name: Deploy
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
@@ -26,4 +20,4 @@ jobs:
       with:
         GITHUB_TOKEN: ${{ secrets.GH_PAT_DEPLOY }}
         BRANCH: gh-pages
-        FOLDER: _site
+        FOLDER: .

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ site : _data/glossary.yml
 	rm -rf .jekyll-cache .jekyll-metadata _site
 	bundle exec jekyll build
 
+## gh-site : builds the website for GitHub pages (part of the GH Actions workflow)
+gh-site : _data/glossary.yml
+
 ## serve : serve GitHub Pages site locally.
 serve : _data/glossary.yml
 	rm -rf _site


### PR DESCRIPTION
I was going to go down the route of deploying the static version of the site (see https://github.com/fmichonneau/glosario/tree/use-static-rendering) but realized that it was probably easier to simply copy the entire repo + `_data/glossary.yml` into gh-pages and let GitHub pages do the work.