### PR TITLE
Adding support for IsiZulu and Afrikaans.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,12 +13,23 @@ exclude:
 - "bin/*"
 - "vendor"
 languages:
+- key: af
+  name: Afrikaans
+  flag: south-africa
+  title: Woordelys
 - key: en
   name: English
   flag: united-kingdom
+  title: Glossary
 - key: es
   name: Español
   flag: spain
+  title: Glosario
 - key: fr
   name: Français
   flag: france
+  title: Glossaire
+- key: zu
+  name: IsiZulu
+  flag: south-africa
+  title: Uhlu Lwamagama

--- a/_includes/glossary.html
+++ b/_includes/glossary.html
@@ -1,61 +1,64 @@
-{% assign language = page.permalink | replace: '/', '' %}
 {% assign gloss = site.data.glossary %}
+{% assign language = page.permalink | replace: '/', '' %}
+{% assign language_info = site.languages | where: "key", language | first %}
 
-{% comment %}
+<h1>{{language_info.title}}</h1>
+
+{%- comment -%}
 Find terms defined in this language and sort alphabetically.
 - 'defined' is a string of (term-in-lower-case, slug) pairs.
 - 'sorted' is that list in sorted ordered.
 - 'ordered' is a string of slugs.
 - 'actual' is a list of slugs sorted by terms.
-{% endcomment %}
-{% capture defined %}{% for item in gloss %}{% if item[language] %}{{item[language].term | downcase}}IN_ITEM{{item.slug}}BETWEEN_ITEMS{% endif %}{% endfor %}{% endcapture %}
-{% assign sorted = defined | split: 'BETWEEN_ITEMS' | sort %}
-{% capture ordered %}{% for item in sorted %}{{item | split: 'IN_ITEM' | last}}BETWEEN_ITEMS{% endfor %}{% endcapture %}
-{% assign actual = ordered | split: 'BETWEEN_ITEMS' %}
+{%- endcomment -%}
+{%- capture defined -%}{%- for item in gloss -%}{%- if item[language] -%}{{item[language].term | downcase}}IN_ITEM{{item.slug}}BETWEEN_ITEMS{%- endif -%}{%- endfor -%}{%- endcapture -%}
+{%- assign sorted = defined | split: 'BETWEEN_ITEMS' | sort -%}
+{%- capture ordered -%}{%- for item in sorted -%}{{item | split: 'IN_ITEM' | last}}BETWEEN_ITEMS{%- endfor -%}{%- endcapture -%}
+{%- assign actual = ordered | split: 'BETWEEN_ITEMS' -%}
 
-{% comment %}
+{%- comment -%}
 Display glossary in alphabetical order.
 Cross-references are displayed in __bold__ if that term is missing.
-{% endcomment %}
+{%- endcomment -%}
 <dl>
-{% for slug in actual %}
+{%- for slug in actual -%}
   {% assign item = gloss | where: "slug", slug | first %}
   {% if item[language] %}
   <dt id="{{item.slug}}">{{item[language].term}}</dt>
   <dd>
     {{item[language].def | markdownify | replace: '<p>', '' | replace: '</p>', ''}}
-    {% if item.ref %}
+    {%- if item.ref -%}
     <br/>
     <em>
-    See also:
-    {% for other_key in item.ref %}
-    {% assign other = gloss | where: "slug", other_key | first %}
+    &rarr;
+    {%- for other_key in item.ref -%}
+    {%- assign other = gloss | where: "slug", other_key | first -%}
     <a href="#{{other_key}}">
-      {% if other[language] %}
+      {%- if other[language] -%}
         {{other[language].term}}
-      {% else %}
+      {%- else -%}
         <strong>{{other_key}}</strong>
-      {% endif %}
+      {%- endif -%}
     </a>
-    {% endfor %}
+    {%- endfor -%}
     </em>
-    {% endif %}
+    {%- endif -%}
     {% assign others = '' | split: ',' %}
     {% for lang in site.languages %}
       {% if lang.key != language and item[lang.key] %}
         {% assign others = others | push: lang %}
       {% endif %}
     {% endfor %}
-    {% if others %}
+    {%- if others -%}
     <br/>
     <em>
       &rarr;
-      {% for lang in others %}
-      <a href="../{{lang.key}}/#{{slug}}">{{lang.name}}</a>{% unless forloop.last %}, {% endunless %}
-      {% endfor %}
+      {%- for lang in others -%}
+      <a href="../{{lang.key}}/#{{slug}}">{{lang.name}}</a>{%- unless forloop.last -%}, {% endunless -%}
+      {%- endfor -%}
     </em>
-    {% endif %}
+    {%- endif -%}
   </dd>
   {% endif %}
-{% endfor %}
+{%- endfor -%}
 </dl>

--- a/af.md
+++ b/af.md
@@ -1,4 +1,4 @@
 ---
-permalink: /en/
+permalink: /af/
 ---
 {% include glossary.html %}

--- a/es.md
+++ b/es.md
@@ -1,5 +1,4 @@
 ---
 permalink: /es/
 ---
-<h1>Glossary</h1>
-{% include glossary.html language="es" %}
+{% include glossary.html %}

--- a/fr.md
+++ b/fr.md
@@ -1,5 +1,4 @@
 ---
 permalink: /fr/
 ---
-<h1>Glossary</h1>
-{% include glossary.html language="fr" %}
+{% include glossary.html %}

--- a/zu.md
+++ b/zu.md
@@ -1,4 +1,4 @@
 ---
-permalink: /en/
+permalink: /zu/
 ---
 {% include glossary.html %}


### PR DESCRIPTION
1.  Add language pages.
2.  Modify `_includes/glossary.html` to generate page title from metadata.
3.  Add metadata to `./_config.yml` to include glossary title in each language.
4.  Modify `en.md`, `es.md`, and `fr.md` to use that.
