### PR TITLE
attempt to make things true

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -2131,9 +2131,9 @@
 
 - slug: "true"
   en:
-  term: "true"
-  def: >
-     The logical ([Boolean](#boolean)) state opposite of "[false](#false)". Used in logic and programming to represent [binary](#binary) state of something.
+    term: "true"
+    def: >
+       The logical ([Boolean](#boolean)) state opposite of "[false](#false)". Used in logic and programming to represent [binary](#binary) state of something.
   ref:
     - "false"
     - boolean


### PR DESCRIPTION
From @ian-flores, the current document of glosario is causing errors in the R code. I believe it's stemming from faulty indentation of the "true" english definition, which is ultimately my fault for not noticing since I am the editor for the section :flushed:

When I look at the parsed entry from R, it looks like this:

```r
$slug
[1] "true"

$en
NULL

$term
[1] "true"

$def
[1] "blah blah blah"

$ref
[1] "is" "out" "there"
```

This PR will fix the issue:

``` r
library("glosario")
get_glossary("https://raw.githubusercontent.com/carpentries/glosario/zkamvar-patch-1/glossary.yml")
#> A glossary with 287 entries.
```

<sup>Created on 2020-08-12 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
