### PR TITLE
Improving glossary checks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ clean :
 check :
 	@python utils/check-glossary.py _config.yml glossary.yml
 
+## checkall : check glossary consistency including missing terms in all languages.
+checkall :
+	@python utils/check-glossary.py -A _config.yml glossary.yml
+
 # Create copy of glossary file for GitHub Pages site.
 _data/glossary.yml : ./glossary.yml
 	@mkdir -p _data

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ clean :
 	@find . -name '*~' -exec rm {} \;
 	@rm -f _data/glossary.yml
 
+## check : check glossary consistency.
+check :
+	@python utils/check-glossary.py _config.yml glossary.yml
+
 # Create copy of glossary file for GitHub Pages site.
 _data/glossary.yml : ./glossary.yml
 	@mkdir -p _data

--- a/glossary.yml
+++ b/glossary.yml
@@ -194,9 +194,9 @@
     def: >
       A system which can have one of two possible states. In computing often represented as being in the state 0 or 1.
       Represented in [Boolean](#boolean) logic as [False](#false) (0) or [True](#true) (1). Computers are built upon systems which store 0s and 1s as "[bits](#bit)"
-    ref:
-      - boolean
-      - bit
+  ref:
+    - boolean
+    - bit
 
 - slug: bit
   en:
@@ -220,10 +220,10 @@
        Relating to a variable or data type that can have either a logical value of [true](#true) or a value of [false](#false). Named for George Boole,
        a mathemetician who lived in the 19th Century. Binary systems, like all computers are built on this foundation of systems of logical evaluations between
        states of true and false, 1 or 0.
-    ref:
-      - truthy
-      - falsy
-      - binary
+  ref:
+    - truthy
+    - falsy
+    - binary
 
 - slug: branch
   en:
@@ -629,11 +629,11 @@
     term: "false"
     def: >
        The logical ([Boolean](#boolean)) state opposite of "[true](#true)". Used in logic and programming to represent [binary](#binary) state of something.
-    ref:
-      - boolean
-      - "true"
-      - truthy
-      - falsy
+  ref:
+    - boolean
+    - "true"
+    - truthy
+    - falsy
 
 - slug: falsy
   en:

--- a/utils/check-glossary.py
+++ b/utils/check-glossary.py
@@ -12,7 +12,7 @@ from collections import Counter
 # Keys for entries and definitions.
 ENTRY_REQUIRED_KEYS = {'slug'}
 ENTRY_OPTIONAL_KEYS = {'ref'}
-ENTRY_LANGUAGE_KEYS = {'en', 'es', 'fr'}
+ENTRY_LANGUAGE_KEYS = {'af', 'en', 'es', 'fr', 'pt', 'zu'}
 ENTRY_KEYS = ENTRY_REQUIRED_KEYS | \
              ENTRY_OPTIONAL_KEYS | \
              ENTRY_LANGUAGE_KEYS
@@ -28,13 +28,27 @@ LINK_PAT = re.compile(r'\[.+?\]\(#(.+?)\)')
 def main():
     '''Main driver.'''
     with open(sys.argv[1], 'r') as reader:
+        config = yaml.load(reader, Loader=yaml.FullLoader)
+    with open(sys.argv[2], 'r') as reader:
         data = yaml.load(reader, Loader=yaml.FullLoader)
+
+    checkLanguages(config)
     for entry in data:
         checkEntry(entry)
     checkSlugs(data)
     checkDuplicates(data)
+
     forward = buildForward(data)
     backward = buildBackward(forward)
+
+
+def checkLanguages(config):
+    '''Compare configuration with this script's settings.'''
+    actual = set([c['key'] for c in config['languages']])
+    if actual - ENTRY_LANGUAGE_KEYS:
+        print(f'unexpected languages in configuration: {actual - ENTRY_LANGUAGE_KEYS}')
+    if ENTRY_LANGUAGE_KEYS - actual:
+        print(f'missing languages in configuration: {ENTRY_LANGUAGE_KEYS - actual}')
 
 
 def checkEntry(entry):

--- a/utils/check-glossary.py
+++ b/utils/check-glossary.py
@@ -1,10 +1,28 @@
 #!/usr/bin/env python
 
 '''
-Check YAML file. Each _entry_ contains one or more _definitions_.
+Check glossary YAML file.
+
+Usage: check-glossary.py [-A] [-c LL] yaml-config-file glossary-file
+
+Flags:
+-   `-A`: report all missing definitions for all languages.
+-   `-c LL`: report missing definitions for language with code `LL` (e.g., 'fr').
+
+Checks always performed:
+-   Only languages listed in `_config.yml` appear in glossary.
+-   Entries have all required keys (`ENTRY_REQUIRED_KEYS`).
+-   Only known keys are present at the top level of each entry (`ENTRY_KEYS`).
+-   Entries are ordered by unique slugs.
+-   Every definition has the required keys (`DEFINITION_REQUIRED_KEYS`).
+-   Definitions only have allowed keys (`DEFINITION_KEYS`).
+-   No duplicate definitions.
+
+Checks performed 
 '''
 
 import sys
+import getopt
 import re
 import yaml
 from collections import Counter
@@ -27,19 +45,55 @@ LINK_PAT = re.compile(r'\[.+?\]\(#(.+?)\)')
 
 def main():
     '''Main driver.'''
-    with open(sys.argv[1], 'r') as reader:
+    checkLang, configFile, glossaryFile = parseArgs()
+    with open(configFile, 'r') as reader:
         config = yaml.load(reader, Loader=yaml.FullLoader)
-    with open(sys.argv[2], 'r') as reader:
-        data = yaml.load(reader, Loader=yaml.FullLoader)
+    with open(glossaryFile, 'r') as reader:
+        gloss = yaml.load(reader, Loader=yaml.FullLoader)
 
     checkLanguages(config)
-    for entry in data:
+    for entry in gloss:
         checkEntry(entry)
-    checkSlugs(data)
-    checkDuplicates(data)
+    checkSlugs(gloss)
+    checkDuplicates(gloss)
 
-    forward = buildForward(data)
+    if checkLang == 'ALL':
+        for lang in sorted(ENTRY_LANGUAGE_KEYS):
+            checkMissingDefs(lang, gloss)
+    elif checkLang:
+        checkMissingDefs(checkLang, gloss)
+
+    forward = buildForward(gloss)
     backward = buildBackward(forward)
+
+
+def parseArgs():
+    '''
+    Parse command-line arguments, returning language to check,
+    configuration file path, and glossary file path.  The language
+    to check may be 'ALL' (to check all), None (to check none), or
+    a known 2-letter language code.
+    '''
+    options, filenames = getopt.getopt(sys.argv[1:], 'Ac:')
+    if (len(filenames) != 2):
+        print(f'Usage: check [-A] [-c LL] configFile glossFile')
+        sys.exit(1)
+    configFile, glossFile = filenames
+
+    checkLang = None
+    for (opt, args) in options:
+        if opt == '-A':
+            checkLang = 'ALL'
+        elif opt == '-c':
+            checkLang = arg
+            if checkLang not in ENTRY_LANGUAGE_KEYS:
+                print(f'Unknown language {checkLang}', file=sys.stderr)
+                sys.exit(1)
+        else:
+            print(f'Unknown flag {opt}', file=sys.stderr)
+            sys.exit(1)
+
+    return checkLang, configFile, glossFile
 
 
 def checkLanguages(config):
@@ -77,9 +131,9 @@ def checkLanguage(slug, lang, definition):
         print(f'Unknown keys in {slug}/{lang}: {unknown_keys}')
 
 
-def checkSlugs(data):
+def checkSlugs(gloss):
     '''Check that entries have unique slugs and are ordered by slug.'''
-    slugs = [entry['slug'] for entry in data if 'slug' in entry]
+    slugs = [entry['slug'] for entry in gloss if 'slug' in entry]
     for (i, slug) in enumerate(slugs):
         if (i > 0) and (slug < slugs[i-1]):
             print(f'slug {slug} out of order')
@@ -89,10 +143,10 @@ def checkSlugs(data):
         print(f'duplicate keys: {dups}')
 
 
-def checkDuplicates(data):
+def checkDuplicates(gloss):
     '''Check for duplicate definitions in each language.'''
     for lang in ENTRY_LANGUAGE_KEYS:
-        terms = [entry[lang]['term'] for entry in data
+        terms = [entry[lang]['term'] for entry in gloss
                  if ((lang in entry) and 'term' in entry[lang])]
         counts = Counter(terms)
         dups = [s for s in counts.keys() if counts[s] > 1]
@@ -100,10 +154,18 @@ def checkDuplicates(data):
             print(f'duplicate definitions for {lang}: {dups}')
 
 
-def buildForward(data):
+def checkMissingDefs(lang, gloss):
+    '''Check for missing definitions in the given language.'''
+    missing = []
+    for entry in gloss:
+        if lang not in entry:
+            print(f"{lang}: {entry['slug']}")
+
+
+def buildForward(gloss):
     '''Build graph of forward references.'''
     result = {}
-    for entry in data:
+    for entry in gloss:
         record = set()
         if 'see' in entry:
             record.update(entry['see'])


### PR DESCRIPTION
1.  Add `make check` target to `Makefile` to do high-level glossary consistency check.
1.  Add `make checkall` target to `Makefile` to report missing entries in all languages.
1.  Teach `utils/check-glossary.py` to read `_config.yml` configuration as well as glossary in order to check for unknown languages.