### PR TITLE
update linter to catch incorrect indentation

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -4,3 +4,5 @@ rules:
   document-start:
     present: false
   line-length: disable
+  empty-values: 
+    forbid-in-block-mappings: true


### PR DESCRIPTION
This would be able to catch the problems that were fixed in #45 (ideally)

https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.empty_values