### PR TITLE
add English terms in other language entries

### DIFF
--- a/_includes/glossary.html
+++ b/_includes/glossary.html
@@ -21,7 +21,7 @@ Cross-references are displayed in __bold__ if that term is missing.
 {%- for slug in actual -%}
   {% assign item = gloss | where: "slug", slug | first %}
   {% if item[language] %}
-  <dt id="{{item.slug}}">{{item[language].term}}</dt>
+<dt id="{{item.slug}}">{{item[language].term}} {% if language != 'en' %}<span class="in-english">(in English: {{item['en'].term}})</span>{% endif %}</dt>
   <dd>
     {{item[language].def | markdownify | replace: '<p>', '' | replace: '</p>', ''}}
     {%- comment -%} Explicit cross-references {%- endcomment -%}

--- a/static/site.css
+++ b/static/site.css
@@ -34,3 +34,9 @@ footer {
     text-align: center;
     border-top: 1px solid black;
 }
+
+.in-english {
+    font-weight: normal;
+    font-style: italic;
+    color: #666xx;
+}


### PR DESCRIPTION
possible solution for #53 

We may need to add a check on the glossary.yml to ensure that all entries have at least the term entered in English.