### PR TITLE
Update Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -1,0 +1,8 @@
+---
+name: Default Template
+about: Use this template if you don't know which template to use
+title: "[DATE]: [QUESTION or ISSUE]"
+labels: question
+---
+
+This is the default template is to ask questions, report bugs, or request changes in the `glosario` repo and not in the R or Python packages. 

--- a/.github/ISSUE_TEMPLATE/language_template.md
+++ b/.github/ISSUE_TEMPLATE/language_template.md
@@ -2,7 +2,7 @@
 name: Language Support Template
 about: Use this template for requesting language support.
 title: "[DATE]: [LANG NAME]"
-labels: bug
+labels: enhancement 
 ---
 
 This template is to request language support in the `glosario` repo and not in the R or Python packages. 


### PR DESCRIPTION
A couple of the previous issues for language enhancements had been labeled "bug" (e.g. https://github.com/carpentries/glosario/issues/53#issuecomment-674407329), so I updated that issue template to use the "enhancement" label.

I also attempted to add a default template that is more relevant to this repo than the [Carpentries default](https://github.com/carpentries/.github/blob/master/ISSUE_TEMPLATE.md)