### PR TITLE
Small tool for merging multiple glossary files.

### DIFF
--- a/utils/intersect-glossaries.py
+++ b/utils/intersect-glossaries.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+'''Find duplicate entries in two or more glossary files.'''
+
+import sys
+import getopt
+import yaml
+
+
+USAGE = 'intersect glossary [glossary...]'
+
+
+def main():
+    '''Main driver.'''
+    filenames = parseArgs()
+    seen = findSlugs(filenames)
+    showDuplicates(seen)
+
+
+def parseArgs():
+    '''Parse command-line arguments, reading keep list if provided.'''
+
+    options, filenames = getopt.getopt(sys.argv[1:], 'h')
+    for (opt, arg) in options:
+        if opt == '-h':
+            print(USAGE)
+            sys.exit(0)
+        else:
+            print(USAGE, sys.stderr)
+            sys.exit(1)
+
+    if not filenames:
+        print(USAGE, sys.stderr)
+        sys.exit(1)
+
+    return filenames
+
+
+def findSlugs(filenames):
+    '''Build table of files containing slugs.'''
+    seen = {}
+    for f in filenames:
+        with open(f, 'r') as reader:
+            for entry in yaml.load(reader, Loader=yaml.FullLoader):
+                slug = entry['slug']
+                if slug not in seen:
+                    seen[slug] = set()
+                seen[slug].add(f)
+    return seen
+
+
+def showDuplicates(seen):
+    '''Show entries that appear more than once.'''
+    for slug in sorted(seen.keys()):
+        if len(seen[slug]) > 1:
+            print(f'{slug}: {", ".join(sorted(seen[slug]))}')
+
+
+if __name__ == '__main__':
+    main()

--- a/utils/merge-glossaries.py
+++ b/utils/merge-glossaries.py
@@ -12,10 +12,11 @@ USAGE = 'merge [-h] [-w wordlist | -] glossary [glossary...]'
 
 def main():
     '''Main driver.'''
-    wordList, glossaryFiles = parseArgs()
-    glossary = readAndMerge(glossaryFiles)
+    wordList, filenames = parseArgs()
+    glossary = readAndMerge(filenames)
     if wordList:
-        glossary = keepOnly(glossary, wordList)
+        keep = readWordList(wordList)
+        glossary = keepOnly(glossary, keep)
     glossary = listSort(glossary)
     yaml.dump(glossary, sys.stdout, encoding='utf-8')
 
@@ -39,13 +40,15 @@ def parseArgs():
         print(USAGE, sys.stderr)
         sys.exit(1)
 
-    if wordList == '-':
-        wordList = [x.strip() for x in sys.stdin]
-    elif wordList is not None:
-        with open(wordList, 'r') as reader:
-            wordList = [x.strip() for x in reader]
-
     return wordList, filenames
+
+
+def readWordList(filename):
+    '''Read a list of slugs defining terms to keep.'''
+    if wordList == '-':
+        return [x.strip() for x in sys.stdin]
+    with open(wordList, 'r') as reader:
+        return [x.strip() for x in reader]
 
 
 def readAndMerge(filenames):

--- a/utils/merge.py
+++ b/utils/merge.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+'''Merge glossary files, optionally keeping only selected terms.'''
+
+import sys
+import getopt
+import yaml
+
+
+USAGE = 'merge [-h] [-w wordlist | -] glossary [glossary...]'
+
+
+def main():
+    '''Main driver.'''
+    wordList, glossaryFiles = parseArgs()
+    glossary = readAndMerge(glossaryFiles)
+    if wordList:
+        glossary = keepOnly(glossary, wordList)
+    glossary = listSort(glossary)
+    yaml.dump(glossary, sys.stdout, encoding='utf-8')
+
+
+def parseArgs():
+    '''Parse command-line arguments, reading keep list if provided.'''
+
+    wordList = None
+    options, filenames = getopt.getopt(sys.argv[1:], 'hw:')
+    for (opt, arg) in options:
+        if opt == '-h':
+            print(USAGE)
+            sys.exit(0)
+        elif opt == '-w':
+            wordList = arg
+        else:
+            print(USAGE, sys.stderr)
+            sys.exit(1)
+
+    if not filenames:
+        print(USAGE, sys.stderr)
+        sys.exit(1)
+
+    if wordList == '-':
+        wordList = [x.strip() for x in sys.stdin]
+    elif wordList is not None:
+        with open(wordList, 'r') as reader:
+            wordList = [x.strip() for x in reader]
+
+    return wordList, filenames
+
+
+def readAndMerge(filenames):
+    '''Read all glossaries, returning merged version.'''
+
+    combined = {}
+    for f in filenames:
+        with open(f, 'r', encoding='utf-8') as reader:
+            new = yaml.load(reader, Loader=yaml.FullLoader)
+            for entry in new:
+                for key in entry:
+                    if (type(entry[key]) == dict) and ('def' in entry[key]):
+                        entry[key]['def'] = entry[key]['def'].strip()
+                combined[entry['slug']] = entry
+    return combined
+
+
+def keepOnly(glossary, wordList):
+    '''Keep only the listed entries.'''
+    
+    result, missing = {}, False
+    for word in wordList:
+        if word not in glossary:
+            print(f'Unknown word {word}', file=sys.stderr)
+            missing = True
+        else:
+            result[word] = glossary[word]
+
+    if missing:
+        sys.exit(1)
+    return result
+
+
+def listSort(glossary):
+    '''Convert glossary to list sorted by slug.'''
+    glossary = [x for x in glossary.values()]
+    glossary.sort(key=lambda x: x['slug'])
+    return glossary
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Use cases:

1. The authors of a book want to combine this glossary with some terms they define themselves. Using `utils/merge-glossaries.py`, they can merge `glosario/glossary.yml` and `book/extra-terms.yml`.

2. The authors of the same book want to maintain their custom glossary file. Using `utils/intersect-glossaries.py`, they can check for duplicated entries and remove them from their custom glossary add-on file.

These tools are written in Python, but that is incidental to their use: they are not intended to be loaded into other programs, but are instead command-line utilities I've needed while working on two book projects.