### PR TITLE
Removed whitespace from R hyperlink in Español glosario definition

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,7 @@ languages:
     blurb: >
       `glosario` es un glosario de fuente abierta de términos utilizados en la
       ciencia de datos que esta disponible en línea y también como libreria en
-      [R] (https://github.com/carpentries/glosario-r/) y
+      [R](https://github.com/carpentries/glosario-r/) y
       [Python](https://github.com/carpentries/glosario-py/). Añadiendo entradas de
       glosario a los metadatos de una lección, las autoras pueden indicar lo que
       enseña la lección, lo que las alumnas deben saber antes de comenzar y adónde


### PR DESCRIPTION
## Author: 

- callumrollo

## Language: 

- español

## Terms defined:

Typo corrected in definition of glosario. Removed whitespace between [R] and its hyperlink.

## Editor

Assign the PR based on the language to the following person:
@ian-flores

