### PR TITLE
Fix typo in Spanish description 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,8 +16,9 @@
 
 Assign the PR based on the language to the following person:
 
-| Language | Person | 
-|:--------:|:------:|
-| English  | @zkamvar |
-| Spanish  | @ian-flores |
-| French   | @fmichonneau |
+| Language  | Person        | 
+|:---------:|:-------------:|
+| Afrikaans | @jsteyn       |
+| English   | @zkamvar      |
+| Spanish   | @ian-flores   |
+| French    | @fmichonneau  |

--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,7 @@ languages:
     blurb: >
       `glosario` es un glosario de fuente abierta de términos utilizados en la
       ciencia de datos que esta disponible en línea y también como libreria en
-      [R] (https://github.com/carpentries/glosario-r/) y
+      [R](https://github.com/carpentries/glosario-r/) y
       [Python](https://github.com/carpentries/glosario-py/). Añadiendo entradas de
       glosario a los metadatos de una lección, las autoras pueden indicar lo que
       enseña la lección, lo que las alumnas deben saber antes de comenzar y adónde


### PR DESCRIPTION
remove extra space in Spanish description that broke link to R package repository