### PR TITLE
Add two Afrikaans terms and some references

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -11,7 +11,7 @@
     term: "68-95-99.7 reël"
     def: >
       Beskryf die beginsel dat 68% van alle waardes binne een
-      [standaardafwyking](#standard_deviation) van die [gemiddelde](#mean) VAl, 
+      [standaardafwyking](#standard_deviation) van die [gemiddelde](#mean) val, 
       95% val binne twee en 99.7%
       val binne drie standaardafwykings. Omgekeerd, in die meeste gevalle 
       val 0.3% van die waardes meer as drie standaardafwykings bo of onder 
@@ -99,13 +99,13 @@
       defined but not implemented. Programmers will define an abstract method
       in a [parent class](#parent_class) to specify operations that
       [child classes](#child_class) must provide.
-   af:
-     term: "abstrakte metode"
-     def: >
-       'n [Metode](#method), in [objekgeoriënteerde programmering](#oop), wat gedefiniëer maar nie 
-       geïmplementeer is nie. Programmeerders sal 'n abstrakte metode in 'n 
-       [voorsaatklas](#parent_class) definiëer wat in [nasaatklasse](#child_class) 
-       geïmplementeer moet word.
+  af:
+    term: "abstrakte metode"
+    def: >
+      'n [Metode](#method), in [objekgeoriënteerde programmering](#oop), wat gedefiniëer maar nie 
+      geïmplementeer is nie. Programmeerders sal 'n abstrakte metode in 'n 
+      [voorsaatklas](#parent_class) definiëer wat in [nasaatklasse](#child_class) 
+      geïmplementeer moet word.
 
 - slug: abstract_syntax_tree
   en:

--- a/glossary.yml
+++ b/glossary.yml
@@ -1,4 +1,4 @@
-- slug: 68_95_997_rule
+- Slug: 68_95_997_rule
   en:
     term: "68-95-99.7 rule"
     def: >
@@ -11,7 +11,8 @@
     term: "68-95-99.7 reël"
     def: >
       Beskryf die beginsel dat 68% van alle waardes binne een
-      [standaardafwyking] van die gemiddelde val, 95% val binne twee en 99.7%
+      [standaardafwyking](#standard_deviation) van die [gemiddelde](#mean) VAl, 
+      95% val binne twee en 99.7%
       val binne drie standaardafwykings. Omgekeerd, in die meeste gevalle 
       val 0.3% van die waardes meer as drie standaardafwykings bo of onder 
       die gemiddelde.
@@ -37,7 +38,7 @@
     def: >
       Die absolute fout is die absolute waarde van die verskil tussen die waargenome- 
       en die korrekte waarde. Die absolute fout is gewoonlik van minder waarde as 
-      die relatiewe fout.
+      die [relatiewe](#relative_error) fout.
 
 - slug: absolute_path
   ref:
@@ -51,7 +52,7 @@
   af:
     term: "absolute roete"
     def: >
-      'n Roete wat dieselfde posisie in die lêerstelsel aandui ongeag die 
+      'n Roete wat dieselfde posisie in die [lêerstelsel](#filesystem) aandui ongeag die 
       posisie vanwaar dit geëvalueer word. Die absolute roete is die ekwivalent
       van lengtegraad en breedtegraad in geografie.
   fr:
@@ -98,6 +99,13 @@
       defined but not implemented. Programmers will define an abstract method
       in a [parent class](#parent_class) to specify operations that
       [child classes](#child_class) must provide.
+   af:
+     term: "abstrakte metode"
+     def: >
+       'n [Metode](#method), in [objekgeoriënteerde programmering](#oop), wat gedefiniëer maar nie 
+       geïmplementeer is nie. Programmeerders sal 'n abstrakte metode in 'n 
+       [voorsaatklas](#parent_class) definiëer wat in [nasaatklasse](#child_class) 
+       geïmplementeer moet word.
 
 - slug: abstract_syntax_tree
   en:
@@ -109,6 +117,15 @@
       For example, the AST might have a [node](#node) representing a [`while` loop](#while_loop)
       with one [child](#child_tree) representing the loop condition
       and another representing the [loop body](#loop_body).
+  af:
+    term: "abstrakte sintaksisontledingsboom"
+    def: >
+      'n Diepgeneste datastruktuur, of [boom](#tree),
+      wat die struktuur van 'n program verteenwoordig.
+      Byvoorbeeld, as die abstrakte sintaksontledingsboom 'n [nodus](#node) het wat
+      'n [`doen` terwyl-lus](#while_loop) verteenwoordig wat 
+      met een [naasaatontledingsboom](#child_tree) die lustoestand verteenwoordig en 'n ander nasaatontledingsboom
+      wat die [lusraam](#loop_body) verteenwoordig.
 
 - slug: actual_result
   en:

--- a/glossary.yml
+++ b/glossary.yml
@@ -1,4 +1,4 @@
-- Slug: 68_95_997_rule
+- slug: 68_95_997_rule
   en:
     term: "68-95-99.7 rule"
     def: >


### PR DESCRIPTION
## Author: 

jsteyn

## Language: 

Afrikaans

## Terms defined:

abstrakte metode
abstrakte sintaksontledingsboom
- 

## Editor

Assign the PR based on the language to the following person:

@jsteyn