### PR TITLE
change arrow direction for rtl

### DIFF
--- a/_includes/glossary.html
+++ b/_includes/glossary.html
@@ -32,7 +32,11 @@ Cross-references are displayed in __bold__ if that term is missing.
     {%- if item.ref -%}
     <br/>
     <em>
+    {% if direction == 'ltr' %}
     &rarr;
+    {% else %}
+    &larr;
+    {% endif %}
     {% for other_key in item.ref -%}
     {%- assign other = gloss | where: "slug", other_key | first -%}
     <a href="#{{other_key}}">


### PR DESCRIPTION
@BatoolMM does it make sense to change the direction of the arrow used to link to related terms?

## Before:

![Screenshot from 2020-10-20 12-01-59](https://user-images.githubusercontent.com/5502922/96571617-ca675d00-1299-11eb-8ff8-ce58677bf61b.png)

## After:

![Screenshot from 2020-10-20 11-58-37](https://user-images.githubusercontent.com/5502922/96571499-a4da5380-1299-11eb-9456-9ecde201a656.png)
