### PR TITLE
Display acronyms in term headings

### DIFF
--- a/_includes/glossary.html
+++ b/_includes/glossary.html
@@ -25,7 +25,7 @@ Cross-references are displayed in __bold__ if that term is missing.
 {%- for slug in actual -%}
   {% assign item = gloss | where: "slug", slug | first %}
   {% if item[language] %}
-  <dt id="{{item.slug}}">{{item[language].term}}</dt>
+  <dt id="{{item.slug}}">{{item[language].term}}{% if item[language].acronym %} ({{item[language].acronym}}){% endif %}</dt>
   <dd>
     {{item[language].def | markdownify | replace: '<p>', '' | replace: '</p>', ''}}
     {%- comment -%} Explicit cross-references {%- endcomment -%}


### PR DESCRIPTION
This is not an update to the definitions list, but rather a suggestion to slightly alter the display of terms in the glossary.

I think it might be useful to display acronyms in the term headings. For example, someone looking up JSON might want to search for the acronym instead of JavaScript Object Notation.
I suggest adding the acronym in parentheses after the term heading, e.g.

JavaScript Object Notation (JSON)

## Author: 

@timtomch 

## Language: 

- All

## Editor

@zkamvar ?

