### PR TITLE
Add Spanish for absolute and relative errors

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -75,6 +75,11 @@
     def: >
       The absolute value of the difference between the observed and the correct value.
       Absolute error is usually less useful than [relative error](#relative_error).
+  es:
+    term: "error absoluto"
+    def: >
+      El valor absoluto de la diferencia entre el valor observado y el valor correcto.
+      El error absoluto suele ser menos útil que el [error relativo](#relative_error).
   af:
     term: "absolute fout"
     def: >
@@ -4359,6 +4364,13 @@
       divided by the desired value. For example, if the actual value is 9 and the
       correct value is 10, the relative error is 0.1. Relative error is usually more
       useful than [absolute error](#absolute_error).
+  es:
+    term: "error relativo"
+    def: >
+      El valor absoluto de la diferencia entre el valor observado y el valor correcto,
+      dividido por el valor deseado. Por ejemplo, si el valor observado es 9 y el
+      valor correcto es 10, el error relativo es 0.1. El error relativo suele ser más
+      útil que el [error absoluto](#absolute_error).
   pt:
     term: "erro relativo"
     def: >


### PR DESCRIPTION
Added Spanish translations for absolute error and relative error.

## Author: 

Nicolas Palopoli

## Language: 

Spanish 

## Terms defined:

- Absolute error
- Relative error

## Editor

Assign the PR based on the language to the following person:

| Language   | Person              |
|:----------:|:-------------------:|
| Afrikaans  | @jsteyn, @elletjies |
| Arabic     | @BatoolMM           |
| English    | @zkamvar            |
| French     | @fmichonneau        |
| Portuguese | @beatrizmilz        |
| Spanish    | @ian-flores         |