### PR TITLE
Removing unneeded ref to mean in definition of median.

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -3396,7 +3396,6 @@
 
 - slug: median
   ref:
-    - mean
     - mode
   en:
     term: "median"


### PR DESCRIPTION
The definitions of `median` include an explicit reference to `mean` so it isn't needed under the `ref` sub-key.