### PR TITLE
Removing redundant definition of 'interpreter'

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -2791,12 +2791,6 @@
     def: >
       A test that checks whether the parts of a system work properly when put together.
 
-- slug: interpreter
-  en:
-    term: "interpreter"
-    def: >
-      A program that runs other programs interactively. [FIXME]
-
 - slug: interpreted_language
   en:
     term: "interpreted language"
@@ -2811,6 +2805,7 @@
     term: "interpreter"
     def: >
       A program whose job it is to run programs written in a high-level [interpreted language](#interpreted_language).
+      Interpreters can run interactively, but may also execute commands saved in a file.
 
 
 - slug: invariant


### PR DESCRIPTION
The term `interpreter` was defined twice - this PR removes one and adds a few words to the other.