### PR TITLE
Adding 'de' to list of accepted languages in utilities

### DIFF
--- a/utils/check-glossary.py
+++ b/utils/check-glossary.py
@@ -30,7 +30,7 @@ from collections import Counter
 # Keys for entries and definitions.
 ENTRY_REQUIRED_KEYS = {'slug'}
 ENTRY_OPTIONAL_KEYS = {'ref'}
-ENTRY_LANGUAGE_KEYS = {'af', 'ar', 'en', 'es', 'fr', 'ja', 'nl', 'pt', 'zu'}
+ENTRY_LANGUAGE_KEYS = {'af', 'ar', 'de', 'en', 'es', 'fr', 'ja', 'nl', 'pt', 'zu'}
 ENTRY_KEYS = ENTRY_REQUIRED_KEYS | \
              ENTRY_OPTIONAL_KEYS | \
              ENTRY_LANGUAGE_KEYS


### PR DESCRIPTION
`make check` was reporting `de` as an unknown language. (Every time a new language is added, `utils/check-glossary.py` must be updated accordingly.)