### PR TITLE
Checking for empty entries

### DIFF
--- a/utils/check-glossary.py
+++ b/utils/check-glossary.py
@@ -119,6 +119,8 @@ def checkEntry(entry):
     unknown_keys = keys - ENTRY_KEYS
     if unknown_keys:
         print(f'Unknown keys in {slug}: {unknown_keys}')
+    if (len(ENTRY_LANGUAGE_KEYS - keys) == len(ENTRY_LANGUAGE_KEYS)):
+        print(f'No language entries for entry {entry}')
     result = {}
     crossrefs = set(entry['ref']) if ('ref' in entry) else set()
     for lang in ENTRY_LANGUAGE_KEYS:


### PR DESCRIPTION
The glossary currently contains several entries with a slug but no other content, presumably to keep `make check` from complaining about missing cross-references. These cause problems downstream, where applications (reasonably) assume that if an entry is in the glossary, it has a definition. This PR adds a test to `check-glossary.py` to find and report these cases. Its current output is:

```
No language entries for entry {'slug': 'causation'}
No language entries for entry {'slug': 'constant'}
No language entries for entry {'slug': 'degrees_of_freedom'}
No language entries for entry {'slug': 'directory'}
No language entries for entry {'slug': 'geometric_mean'}
No language entries for entry {'slug': 'harmonic_mean'}
No language entries for entry {'slug': 'independent_variable'}
No language entries for entry {'slug': 'masking'}
No language entries for entry {'slug': 'posterior_distribution'}
No language entries for entry {'slug': 'shiny'}
No language entries for entry {'slug': 'test_data'}
No language entries for entry {'slug': 'training_data'}
```