### PR TITLE
Add readme definition

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -4575,6 +4575,15 @@
       A variable whose value is automatically updated when some other value or values
       change. Reactive variables are used extensively in [Shiny](#shiny).
 
+- slug: readme
+  ref:
+    - markdown
+    - vignette
+  en:
+    term: "README"
+    def: >
+      A file which contains the important information about a project or software package.
+
 
 - slug: record
   en:

--- a/glossary.yml
+++ b/glossary.yml
@@ -4582,7 +4582,7 @@
   en:
     term: "README"
     def: >
-      A file which contains the important information about a project or software package.
+      A plain text file containing important information about a project or software package.
 
 
 - slug: record


### PR DESCRIPTION
## Author: 

- Sarah Stevens

## Language: 

- English

## Terms defined:

- README

## Editor

Assign the PR based on the language to the following person:

@zkamvar  


Not sure this a great definition but thought it might be a good start to getting `README` added.  We'd like to link to the definition in the [Jekyll Pages Lesson Glossary](https://carpentries-incubator.github.io/building-websites-with-jekyll-and-github-or-gitlab/reference.html)

