### PR TITLE
hard code repo URL instead of using the GitHub API

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: "Glossary"
-repository: <USERNAME>/<PROJECT>
+repository_url: "https://github.com/carpentries/glosario"
 defaults:
   - scope:
       path: ""

--- a/_includes/title.html
+++ b/_includes/title.html
@@ -14,7 +14,7 @@
 <div class="row" dir="auto">
   <div class="left">
     <a href="{{'/' | relative_url}}"><img class="logo" src="{{'/static/parrot.svg' | relative_url}}" alt="Parrot logo"/></a>
-    <a href="{{ site.github.repository_url }}" class="button-ltr"><small><small>View project on </small></small>GitHub</a>
+    <a href="{{ site.repository_url }}" class="button-ltr"><small><small>View project on </small></small>GitHub</a>
   </div>
   <div class="right">
     <font class="title_font">

--- a/_layouts/glossary-rtl.html
+++ b/_layouts/glossary-rtl.html
@@ -29,7 +29,7 @@
                      class="logo"
                      alt="Parrot logo"/>
             </a>
-            <a href="{{ site.github.repository_url }}"
+            <a href="{{ site.repository_url }}"
                class="button-rtl"><small>View project on</small>GitHub
             </a>
         </div>
@@ -69,7 +69,7 @@
         -
         <a href="{{'/license/' | relative_url}}">License</a>
         -
-        <a href="https://github.com/carpentries/glosario/">GitHub</a>
+        <a href="{{ site.repository_url }}">GitHub</a>
       </p>
 </footer>
 </body>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -33,7 +33,7 @@
         -
         <a href="{{'/license/' | relative_url}}">License</a>
         -
-        <a href="https://github.com/carpentries/glosario/">GitHub</a>
+        <a href="{{ site.repository_url }}">GitHub</a>
       </p>
     </footer>
   </body>


### PR DESCRIPTION
Relying on the GitHub API made the site at https://glosario.carpentries.org broken.
Using the API also makes it more difficult for contributors as additional steps are needed to make the site work without error message. Given that the API is only used here to return the URL of the repository, it's easier to hard code the URL and to directly reference it in the code.