### PR TITLE
Added DOI definition in Japanese

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -1978,11 +1978,11 @@
     def: >
       A unique persistent identifier for a book, paper, report, dataset, software release, or
       other digital artefact.
- ja:
+  ja:
     term: "デジタルオブジェクト識別子"
     acronym: "DOI"
     def: >
-     本、文献、レポート、ソフトウェアリリースや他のデジタル媒体が持つ、固有かつ恒久的な識別子のこと。
+      本、文献、レポート、ソフトウェアリリースや他のデジタル媒体が持つ、固有かつ恒久的な識別子のこと。
 
 
 - slug: dom

--- a/glossary.yml
+++ b/glossary.yml
@@ -1978,6 +1978,11 @@
     def: >
       A unique persistent identifier for a book, paper, report, dataset, software release, or
       other digital artefact.
+ ja:
+    term: "デジタルオブジェクト識別子"
+    acronym: "DOI"
+    def: >
+     本、文献、レポート、ソフトウェアリリースや他のデジタル媒体が持つ、固有かつ恒久的な識別子のこと。
 
 
 - slug: dom


### PR DESCRIPTION
Added Japanese to 'DOI'.

## Author: 

- @masamiy 

## Language: 

- Japanese

## Terms defined:

- DOI
- 
- 

## Editor

Assign the PR based on the language to the following person:

| Language   | Person                       |
|:----------:|:----------------------------:|
| Afrikaans  | @jsteyn, @elletjies          |
| Arabic     | @BatoolMM                    |
| English    | @baileythegreen, @zkamvar    |
| French     | @fmichonneau                 |
| Japanese   | @tomkellygenetics, @masamiy  |
| Portuguese | @beatrizmilz                 |
| Spanish    | @ian-flores                  |
