### PR TITLE
Revert "Translate 5 terminos a español"

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -122,11 +122,6 @@
        مع العِلم أن
        الخطأ المُطلق عادة مايكون أقل فائدة من
        [الخطأ النسبي](#relative_error).
-  es:
-    term: "error absoluto"
-    def: >
-      El valor absoluto de la diferença entre un valor observado y el valor correto. El error
-      absoluto es normalmente menos útil que el [erreo relativo](#relative_error).
 
 
 - slug: absolute_path
@@ -395,12 +390,7 @@
       Um método de desenvolvimento de software que enfatiza vários passos pequenos e
       feedback contínuo ao invés de planejamento de longo prazo. [Programação exploratória](#exploratory_programming)
       costuma ser ágil.
-  es:
-    term: "desenvolvimiento ágil"
-    def: >
-      Un método de desenvolvimiento de software que enfatiza varios pasos pequeños y
-      feedback continuo en lugar de planificacion a largo plazo. [Programación exploratoria](#exploratory_programming)
-      suele ser ágil.
+
 
 - slug: aliasing
   en:
@@ -512,13 +502,7 @@
       webdiens voorsien word vir gebruik deur ander toepassings om met die
       programmateek of webdiens te kommunikeer. Die API is nie die kode, die databasis
       of die bediener nie, dit is die koppelvlak.
-  es:
-    term: "Interfaz de Programación de Aplicaciones"
-    acronym: "API"
-    def: >
-      Un conjunto de funciones y procedimientos proporcionados por una libreria de softtware o servicio web
-      atraves del cual otra aplicación se puede comunicar. Una API no es el código, la base de datos o el servidor;
-      es el punto de acceso.
+
 
 - slug: append_mode
   en:
@@ -586,10 +570,7 @@
     term: "rekenkundige gemiddelde"
     def: >
       Sien [gemiddelde](#mean).
-  es:
-    term: "média aritmética"
-    def: >
-      Vea [média](#mean).
+
 
 - slug: ascii
   en:
@@ -796,12 +777,7 @@
       An equation for calculating the probability that something is [true](#true) if something
       related to it is true. If P(X) is the probability that X is true and P(X|Y) is
       the probability that X is true given Y is true, then P(X|Y) = P(Y|X) * P(X) / P(Y).
-  es:
-    term: "Teorema de Bayes"
-    def: >
-      Una ecuación para calcular la probabilidad de que algo sea [verdadero](#true) si algo
-      relacionado con ello es verdadero. Si P(X) es la probabilidad de que X is verdadero y P(X|Y) es
-      la probabilidad de que X es verdadero dado que Y sea verdadero, entonces P(X|Y) = P(Y|X) * P(X) / P(Y).
+
 
 - slug: bayesian_network
   ref:
@@ -812,10 +788,7 @@
     term: "Bayesian network"
     def: >
       A graph that represents the relationships between random variables for a given problem.
-  es:
-    term: "Red Bayesiana"
-    def: >
-      Una gráfica que representa la relacion entre las variables aleatorias para un determinado problema.
+
 
 - slug: bias
   ref:
@@ -3666,12 +3639,6 @@
       O valor médio de um conjunto de dados, mais apropriadamente conhecido como
       [média aritmética](#arithmetic_mean) para que seja distinguido da média
       [geométrica](#geometric_mean) e da [harmônica](#harmonic_mean).
-  es:
-    term: "media"
-    def: >
-      El valor medio de un conjunto de datos, mas apropriadamente conocido como
-      [média aritmética](#arithmetic_mean) para distinguirla de la media
-      [geométrica](#geometric_mean) y [harmónica](#harmonic_mean).
 
 
 - slug: mean_absolute_error
@@ -4702,10 +4669,6 @@
     term: "R (linguagem de programação)"
     def: >
       Uma linguagem de programação de código aberto usada principalmente para ciência de dados.
-  es:
-    term: "R (lenguaje de programación)"
-    def: >
-      Un lenguaje de programación de código abierto usado principalmente para ciencia de datos.
 
 
 - slug: r_markdown
@@ -5499,10 +5462,6 @@
     term: "Stack Overflow"
     def: >
       Um site de perguntas e respostas popular entre pessoas programadoras.
-  es:
-    term: "Stack Overflow"
-    def: >
-      Un sitio de preguntas y respuestas popular entre personas programadoras.
 
 
 - slug: standard_deviation
@@ -5518,11 +5477,6 @@
     def: >
       O quanto os valores de um conjunto de dados diferem da [média](#mean). É calculado
       como a raiz quadrada da [variância](#variance).
-  es:
-    term: "desviación estandar"
-    def: >
-      Por cuanto los valores de un conjunto de datos se differencian de la [media](#mean). Es calculado
-      como la raiz cuadrada de la [varianza](#variance).
 
 
 - slug: standard_normal_distribution
@@ -6327,11 +6281,3 @@
       no lugar de parênteses e vírgulas usados em [JSON](#json). YAML é frequentemente usado em 
       arquivos de configuração e na definição de [parâmetros](#parameter) para vários estilos
       de documentos em [Markdown](#markdown).
-  es:
-    term: "YAML"
-    def: >
-      Acrónimo recursivo de "YAML Ain't Markup Language" (YAML no es un lenguaje de marcación), 
-      es una manera de representar datos anidados usando identación en lugar de paréntesis
-      y comillas usadas en [JSON](#json). YAML es usado frequentemente en
-      archivos de configuración y en para definir [parámetros](#parameter) en varios estilos
-      de documentos en [Markdown](#markdown).


### PR DESCRIPTION
Reverts carpentries/glosario#242

This merge introduced duplicate definitions for two terms, causing other PRs to fail lint checks:

> This is failing the linter check because two terms, absolute error and agile development, have two entries for the Spanish definition.
> 
> Absolute error: lines 97 and 125
> Agile development: lines 380 and 398
> 
> Please remove the duplicate entries, taking into consideration which of the given definitions is more complete.