### PR TITLE
Fixing several warnings from checking (others still remain)

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -402,7 +402,6 @@
 
 
 - slug: aliasing
-- slug: aliasing
   en:
     term: "aliasing"
     def: >
@@ -1381,6 +1380,12 @@
       The amount of working memory needed to accomplish a set of simultaneous tasks.
 
 
+- slug: command
+  en:
+    term: "command"
+    def: >
+      An instruction telling a computer program to perform a specific task.
+
 - slug: command_history
   en:
     term: "command history"
@@ -1388,12 +1393,6 @@
       An automatically-created list of previously-executed commands. Most read-eval-print loops
       ([REPLs](#repl)), including the [Unix shell](#shell), record history and allow
       users to play back recent commands.
-
-- slug: command
-  en:
-    term: "command"
-    def: >
-      An instruction telling a computer program to perform a specific task.
 
 - slug: command_line_argument
   en:
@@ -2463,7 +2462,6 @@
 
 - slug: function
   ref:
-    - functions
     - command
   en:
     term: "function"
@@ -3177,7 +3175,6 @@
 
 - slug: jupyter_notebook
   ref:
-    - computational_notebook
     - jupyter
   en:
     term: "Jupyter Notebook"

--- a/utils/check-glossary.py
+++ b/utils/check-glossary.py
@@ -30,7 +30,7 @@ from collections import Counter
 # Keys for entries and definitions.
 ENTRY_REQUIRED_KEYS = {'slug'}
 ENTRY_OPTIONAL_KEYS = {'ref'}
-ENTRY_LANGUAGE_KEYS = {'af', 'ar', 'de', 'en', 'es', 'fr', 'ja', 'nl', 'pt', 'zu'}
+ENTRY_LANGUAGE_KEYS = {'af', 'ar', 'de', 'en', 'es', 'fr', 'he', 'ja', 'nl', 'pt', 'zu'}
 ENTRY_KEYS = ENTRY_REQUIRED_KEYS | \
              ENTRY_OPTIONAL_KEYS | \
              ENTRY_LANGUAGE_KEYS


### PR DESCRIPTION
1.  `aliasing` slug defined twice.
1.  `command` out of order.
1.  `function` had a cross-ref to `functions`.
1.  `he` (Hebrew) missing from `utils/check-glossary.py`

`make check` still reports these errors---the first comes from no Hebrew section in the configuration, while the others are empty terms.

```
missing languages in configuration: {'he'}
No language entries for entry {'slug': 'causation'}
No language entries for entry {'slug': 'constant'}
No language entries for entry {'slug': 'degrees_of_freedom'}
No language entries for entry {'slug': 'directory'}
No language entries for entry {'slug': 'geometric_mean'}
No language entries for entry {'slug': 'harmonic_mean'}
No language entries for entry {'slug': 'independent_variable'}
No language entries for entry {'slug': 'masking'}
No language entries for entry {'slug': 'posterior_distribution'}
No language entries for entry {'slug': 'shiny'}
No language entries for entry {'slug': 'test_data'}
No language entries for entry {'slug': 'training_data'}
```
