### PR TITLE
Add 'clustering' in Japanese and change style

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -1348,6 +1348,10 @@
     def: >
       O processo de dividir os dados em grupos quando os grupos em si não são conhecidos
       antecipadamente.
+  ja:
+    term: "クラスタリング"
+    def: >
+      データをどのように分類するかは不明のまま、グループに分割するプロセスのこと。
 
 
 - slug: code_coverage
@@ -2552,7 +2556,7 @@
   ja:
     term: "Git(ギット)"
     def: >
-       プロジェクトなどの変更履歴を記録・追跡するための分散型バージョン管理システムです。
+       プロジェクトなどの変更履歴を記録・追跡するための分散型バージョン管理システムのこと。
   pt:
     term: "Git"
     def: >


### PR DESCRIPTION
1. Added a Japanese translation in 'clustering'.
2. Changed 'masu' to '... no koto' for 'git'.

## Author: 

- @masamiy 

## Language: 

- Japanese

## Terms defined:

- Clustering
- Git entry minor change
- 

## Editor

Assign the PR based on the language to the following person:

| Language   | Person                       |
|:----------:|:----------------------------:|
| Afrikaans  | @jsteyn, @elletjies          |
| Arabic     | @BatoolMM                    |
| English    | @baileythegreen, @zkamvar    |
| French     | @fmichonneau                 |
| Japanese   | @tomkellygenetics, @masamiy  |
| Portuguese | @beatrizmilz                 |
| Spanish    | @ian-flores                  |
