### PR TITLE
Added Afrikaans terms

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -1806,7 +1806,7 @@
       A combinação de estatística, programação e trabalho duro usados para extrair
       conhecimento a partir de dados.
   af:
-    term: "data wetenskap"
+    term: "datawetenskap"
     def: >
       Die kombinasie van statistiek en programmering wat gebruik word om kennis vanuit data te ontgin.
 
@@ -1821,7 +1821,7 @@
     def: >
       Alguém que usa habilidades de programação para resolver problemas estatísticos.
   af:
-    term: "data wetenskaplike"
+    term: "datawetenskaplike"
     def: >
       Iemand wat programmeringsvaardighede gebruik om statistiese probleme op te los.
 

--- a/glossary.yml
+++ b/glossary.yml
@@ -1378,6 +1378,10 @@
     term: "cognitive load"
     def: >
       The amount of working memory needed to accomplish a set of simultaneous tasks.
+  af:
+    term: "kognitiewe lading"
+    def: >
+      Die hoeveelheid werkgeheue wat nodig is om 'n stel gelyktydige take te verrig.
 
 
 - slug: command
@@ -1801,6 +1805,10 @@
     def: >
       A combinação de estatística, programação e trabalho duro usados para extrair
       conhecimento a partir de dados.
+  af:
+    term: "data wetenskap"
+    def: >
+      Die kombinasie van statistiek en programmering wat gebruik word om kennis vanuit data te ontgin.
 
 
 - slug: data_scientist
@@ -1812,6 +1820,10 @@
     term: "cientista de dados"
     def: >
       Alguém que usa habilidades de programação para resolver problemas estatísticos.
+  af:
+    term: "data wetenskaplike"
+    def: >
+      Iemand wat programmeringsvaardighede gebruik om statistiese probleme op te los.
 
 
 - slug: data_wrangling
@@ -2898,6 +2910,10 @@
     def: >
       A graphical representation of the distribution of a set of numeric data, usually
       a vertical bar graph.
+  af:
+    term: "histogram"
+    def: >
+     'n Grafiese voorstelling van die verspreiding van 'n data, gewoonlik 'n vertikale staafgrafiek.
 
 
 - slug: hitchhiker


### PR DESCRIPTION
## Language: 

Afrikaans

## Terms defined:

data science - data wetenskap
data scientist - data wetenskaplike
histogram - histogram
cognitive load - kognitiewe lading

## Editor

Assign the PR based on the language to the following person:

| Language   | Person                       |
|:----------:|:----------------------------:|
| Afrikaans  | @jsteyn, @elletjies          |
| Arabic     | @BatoolMM                    |
| English    | @baileythegreen, @zkamvar    |
| French     | @fmichonneau                 |
| Japanese   | @tomkellygenetics, @masamiy  |
| Portuguese | @beatrizmilz                 |
| Spanish    | @ian-flores                  |
