### PR TITLE
Update Pull Request template for clarifications.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Assign the PR based on the language to the following person:
 | Arabic     | @BatoolMM                    |
 | English    | @baileythegreen, @zkamvar    |
 | French     | @fmichonneau                 |
-| Japanese   | @tomkellygenetics, @masamiy  |
+| Japanese   | @masamiy, @naoe-tatara       |
 | Portuguese | @beatrizmilz                 |
 | Spanish    | @ian-flores                  |
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,3 +25,5 @@ Assign the PR based on the language to the following person:
 | Japanese   | @tomkellygenetics, @masamiy  |
 | Portuguese | @beatrizmilz                 |
 | Spanish    | @ian-flores                  |
+
+Please remove the lines not relevant to the language submitted.


### PR DESCRIPTION
### Suggested changes

Adds the following line to the Pull Request template to avoid notifying all editors.

```diff
+Please remove the lines not relevant to the language submitted.
```

### Proposal

Add @naoe-tatara as Japanese editor if she agrees to it.

### Question for admins

We've discussed style for Japanese contributions and decided to use 体言止め(taigen-dome) which more concise and is commonly dictionaries. We'll submit PRs to update the existing Japanese entries (e.g., PR #255). Is there a style guide to notify new contributors of this or do we bring it up when reviewing each `lang-ja` PR?

### Assign admins and notify Japanese contributors

Assign this PR based on the language to the following person:

| Language   | Person                                   |
|:----------:|:----------------------------:|
| English    | @baileythegreen, @zkamvar   |
| French     | @fmichonneau  |
| Japanese | @masamiy, @naoe-tatara |


