### PR TITLE
Add definitions in Korean to two existing terms 

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -2748,6 +2748,10 @@
     def: >
       Une variable définie en dehors d'une fonction donnée, qui est par conséquent
       visible pour toutes les fonctions.
+  ko:
+    term: "전역 변수"
+    def: >
+      소스 코드 상의 모든 곳에서 접근할 수 있는 변수.
 
 
 - slug: globbing
@@ -3470,6 +3474,10 @@
     def: >
       Una variable definida dentro de una función, por lo que solo es visible dentro
       de ella.
+  ko:
+    term: "지역 변수"
+    def: >
+      특정 함수 내에서 정의되고 그 함수 내에서만 유효한 변수. 
 
 
 - slug: log


### PR DESCRIPTION
Korean (ko) definitions are added to global_variable and local_variable.

## Author: 

- Youngjun Choe

## Language: 

- Korean

## Terms defined:

- local_variable
- global_variable

## Editor

Assign the PR based on the language to the following person: N/A

| Language   | Person                       |
|:----------:|:----------------------------:|
| Afrikaans  | @jsteyn, @elletjies          |
| Arabic     | @BatoolMM                    |
| English    | @baileythegreen, @zkamvar    |
| French     | @fmichonneau                 |
| Japanese   | @masamiy, @naoe-tatara       |
| Portuguese | @beatrizmilz                 |
| Spanish    | @ian-flores                  |

Please remove the lines not relevant to the language submitted.
