### PR TITLE
Fix rendering of Bayes' Theorem equation

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -790,14 +790,14 @@
     term: "Bayes' Theorem"
     def: >
       An equation for calculating the probability that something is [true](#true) if something
-      related to it is true. If P(X) is the probability that X is true and P(X|Y) is
-      the probability that X is true given Y is true, then P(X|Y) = P(Y|X) * P(X) / P(Y).
+      related to it is true. If P(X) is the probability that X is true and \$$P(X\vertY)$$ is
+      the probability that X is true given Y is true, then \$$P(X\vertY) = P(Y\vertX) * P(X) / P(Y)$$.
   es:
     term: "Teorema de Bayes"
     def: >
       Una ecuación para calcular la probabilidad de que algo sea [verdadero](#true) si algo    
-      relacionado con ello es verdadero. Si P(X) es la probabilidad de que X is verdadero y P(X|Y) es    
-      la probabilidad de que X es verdadero dado que Y sea verdadero, entonces P(X|Y) = P(Y|X) * P(X) / P(Y).
+      relacionado con ello es verdadero. Si P(X) es la probabilidad de que X is verdadero y \$$P(X\vertY)$$ es    
+      la probabilidad de que X es verdadero dado que Y sea verdadero, entonces \$$P(X\vertY) = P(Y\vertX) * P(X) / P(Y)$$.
 
 
 - slug: bayesian_network


### PR DESCRIPTION
The ever frustrating kramdown parser is to tables what Microsoft Excel is to dates: it thinks anything that has two or more `|` characters is a table, which creates problems for math, which is documented: https://kramdown.gettalong.org/syntax.html#math-blocks

This adds math blocks and replaces `|` with `\vert` to avoid overzealous tabulation.