### PR TITLE
Add definitions for 'test_data', 'training_data' (English)

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -5898,9 +5898,9 @@
     term: "test data"
     def: >
       Test data is a portion of a dataset used to evaluate the correctness of a 
-      [machine learning](#machine_learning) algorithm after it has been trained. It should always
-      be separated from the [training data](#training_data) to ensure that the model is 
-      properly tested with unseen data.
+      [machine learning](#machine_learning) algorithm after it has been trained.
+      It should always be separated from the [training data](#training_data) to
+      ensure that the model is properly tested with unseen data.
 
 - slug: test_runner
   en:
@@ -6041,10 +6041,10 @@
   en:
     term: "training data"
     def: >
-      Training data is a portion of a dataset used to train a
-      [machine learning](#machine_learning) algorithm to recognize similar data. It should always
-      be separated from the [test data](#test_data) to ensure that the model is 
-      properly tested with data it has never seen before.
+      Training data is a portion of a dataset used to train [machine learning](#machine_learning)
+      algorithm to recognise similar data. It should always be separated from the
+      [test data](#test_data) to ensure that the model is properly tested with data it has
+      never seen before.
 
 - slug: transitive_dependency
   en:

--- a/glossary.yml
+++ b/glossary.yml
@@ -6036,7 +6036,7 @@
 
 
 - slug: training_data
- ref:
+  ref:
     - machine_learning
   en:
     term: "training data"

--- a/glossary.yml
+++ b/glossary.yml
@@ -5892,7 +5892,7 @@
 
 
 - slug: test_data
- ref:
+  ref:
     - machine_learning
   en:
     term: "test data"

--- a/glossary.yml
+++ b/glossary.yml
@@ -5892,7 +5892,15 @@
 
 
 - slug: test_data
-
+ ref:
+    - machine_learning
+  en:
+    term: "test data"
+    def: >
+      Test data is a portion of a dataset used to evaluate the correctness of a 
+      [machine learning](#machine_learning) algorithm after it has been trained. It should always
+      be separated from the [training data](#training_data) to ensure that the model is 
+      properly tested with unseen data.
 
 - slug: test_runner
   en:
@@ -6028,7 +6036,15 @@
 
 
 - slug: training_data
-
+ ref:
+    - machine_learning
+  en:
+    term: "training data"
+    def: >
+      Training data is a portion of a dataset used to train a
+      [machine learning](#machine_learning) algorithm to recognize similar data. It should always
+      be separated from the [test data](#test_data) to ensure that the model is 
+      properly tested with data it has never seen before.
 
 - slug: transitive_dependency
   en:


### PR DESCRIPTION
added test_data and training_data definitions

<!-- If you are adding terms, change the pull request title to mention the terms added and language, or if there are a lot of them, the number of terms and language.

Examples:

Add definition for 'byte' (English)
Add definitions for 'agrégation', 'commentaire' (French)
Translate 5 terms (Spanish)
-->

Fill in each of the sections (using NA for those that are not applicable).

## Author: 
Mike Ramshaw
- 

## Language: 
English
- 

## Terms defined:
test_data, training_data
- 
- 
- 
