### PR TITLE
Add definitions for `geometric_mean`, `arithmetic_mean`, and 3 more (English)

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -2695,7 +2695,27 @@
   en:
     term: "Geometric Mean"
     def: >
-       Calculated from a set of n numbers by first computing the product of those numbers, and then computing the n-th root of the result. In contrast to the [arithmetic mean](#arithmetic_mean), which measures central tendancy in an "additive" way, the geometric mean measures central tendancy in a "multiplicative" way, and hence is often appropriate when estimating an average rates of change or some other multiplicative constant. 
+      Calculated from a set of n numbers by first computing the product of those numbers, and then computing the n-th [root](#root_math) of the result. In contrast to the [arithmetic mean](#arithmetic_mean), which measures central tendancy in an "additive" way, the geometric mean measures central tendancy in a "multiplicative" way, and hence is often appropriate when estimating an average rates of change or some other multiplicative constant. 
+
+- slug: square_root
+  en:
+    term: "Square root"
+    def: >
+      A special case of the [n-th root](#root_math) for which n = 2, i.e. the 2-nd root has the special name "square root".
+
+- slug: root_math
+  ref: 
+    - square_root
+  en:
+    term: n-th root
+    def: >
+      The n-th root of a positive number x is the number that when multiplied by itself n times produces x. This can commonly be calculated by raising x to the power of the [reciprocal](#reciprocal) of n.
+
+- slug: reciprocal
+  en:
+    term: reciprocal
+    def: > 
+      The reciprocal of a number x is 1 / x, or alternatively x raised to the power of -1.
 
 - slug: git
   en:
@@ -2993,7 +3013,7 @@
   en:
     term: "Harmonic Mean"
     def: >
-       Calculated from a set of n numbers by first computing the sum of the reciprocals of those numbers, and then dividing n by the resulting sum. Alternatively, it can be computed as the reciprocal of the [arithmetic mean](#arithmetic_mean) of the reciprocal values. Similarly to the [geometric mean](#geometric_mean), the harmonic mean is often used as an alternative measure of central tendancy to the usual [arithmetic mean](#arithmetic_mean) when estimating an average rates of change or some other multiplicative constant. For a set of positive numbers that are not all equal, the min < HM < GM < AM < max where min is the minimum value, max is the maximum value, and HM GM and AM are the harmonic, [geometric](#geometric_mean), and [arithmetic](#arithmetic_mean) means respectively.
+      Calculated from a set of n numbers by first computing the sum of the [reciprocals](#reciprocal) of those numbers, and then dividing n by the resulting sum. Alternatively, it can be computed as the [reciprocal](#reciprocal) of the [arithmetic mean](#arithmetic_mean) of the [reciprocal](#reciprocal) values. Similarly to the [geometric mean](#geometric_mean), the harmonic mean is often used as an alternative measure of central tendancy to the usual [arithmetic mean](#arithmetic_mean) when estimating an average rates of change or some other multiplicative constant. For a set of positive numbers that are not all equal, the min < HM < GM < AM < max where min is the minimum value, max is the maximum value, and HM GM and AM are the harmonic, [geometric](#geometric_mean), and [arithmetic](#arithmetic_mean) means respectively.
 
 
 - slug: hardware
@@ -5375,7 +5395,7 @@
     term: "root mean squared error"
     acronym: "RMSE"
     def: >
-      The square root of the [mean squared error](#mean_squared_error). Like the
+      The [square root](#square_root) of the [mean squared error](#mean_squared_error). Like the
       [standard deviation](#standard_deviation), it is in the same units as the
       original data.
   es:
@@ -5808,7 +5828,7 @@
     term: "standard deviation"
     def: >
       How widely values in a dataset differ from the [mean](#mean). It is calculated
-      as the square root of the [variance](#variance).
+      as the [square root](#square_root) of the [variance](#variance).
   es:
     term: "desviación estándar"
     def: >

--- a/glossary.yml
+++ b/glossary.yml
@@ -612,7 +612,8 @@
   en:
     term: "arithmetic mean"
     def: >
-      See [mean](#mean). Calculated from a set of n numbers by summing those numbers, and dividing the result by n.
+      See [mean](#mean). Calculated from a set of n numbers by summing those 
+      numbers, and dividing the result by n.
   pt:
     term: "média aritmética"
     def: >
@@ -2695,13 +2696,20 @@
   en:
     term: "Geometric Mean"
     def: >
-      Calculated from a set of n numbers by first computing the product of those numbers, and then computing the n-th [root](#root_math) of the result. In contrast to the [arithmetic mean](#arithmetic_mean), which measures central tendancy in an "additive" way, the geometric mean measures central tendancy in a "multiplicative" way, and hence is often appropriate when estimating an average rates of change or some other multiplicative constant. 
+      Calculated from a set of n numbers by first computing the product of those
+      numbers, and then computing the n-th [root](#root_math) of the result. In 
+      contrast to the [arithmetic mean](#arithmetic_mean), which measures 
+      central tendancy in an "additive" way, the geometric mean measures central
+      tendancy in a "multiplicative" way, and hence is often appropriate when 
+      estimating an average rates of change or some other multiplicative 
+      constant. 
 
 - slug: square_root
   en:
     term: "Square root"
     def: >
-      A special case of the [n-th root](#root_math) for which n = 2, i.e. the 2-nd root has the special name "square root".
+      A special case of the [n-th root](#root_math) for which n = 2, i.e. the 
+      2-nd root has the special name "square root".
 
 - slug: root_math
   ref: 
@@ -2709,13 +2717,16 @@
   en:
     term: n-th root
     def: >
-      The n-th root of a positive number x is the number that when multiplied by itself n times produces x. This can commonly be calculated by raising x to the power of the [reciprocal](#reciprocal) of n.
+      The n-th root of a positive number x is the number that when multiplied by
+      itself n times produces x. This can commonly be calculated by raising x to
+      the power of the [reciprocal](#reciprocal) of n.
 
 - slug: reciprocal
   en:
     term: reciprocal
     def: > 
-      The reciprocal of a number x is 1 / x, or alternatively x raised to the power of -1.
+      The reciprocal of a number x is 1 / x, or alternatively x raised to the 
+      power of -1.
 
 - slug: git
   en:
@@ -3013,7 +3024,19 @@
   en:
     term: "Harmonic Mean"
     def: >
-      Calculated from a set of n numbers by first computing the sum of the [reciprocals](#reciprocal) of those numbers, and then dividing n by the resulting sum. Alternatively, it can be computed as the [reciprocal](#reciprocal) of the [arithmetic mean](#arithmetic_mean) of the [reciprocal](#reciprocal) values. Similarly to the [geometric mean](#geometric_mean), the harmonic mean is often used as an alternative measure of central tendancy to the usual [arithmetic mean](#arithmetic_mean) when estimating an average rates of change or some other multiplicative constant. For a set of positive numbers that are not all equal, the min < HM < GM < AM < max where min is the minimum value, max is the maximum value, and HM GM and AM are the harmonic, [geometric](#geometric_mean), and [arithmetic](#arithmetic_mean) means respectively.
+      Calculated from a set of n numbers by first computing the sum of the 
+      [reciprocals](#reciprocal) of those numbers, and then dividing n by the 
+      resulting sum. Alternatively, it can be computed as the 
+      [reciprocal](#reciprocal) of the [arithmetic mean](#arithmetic_mean) of 
+      the [reciprocal](#reciprocal) values. Similarly to the 
+      [geometric mean](#geometric_mean), the harmonic mean is often used as an 
+      alternative measure of central tendancy to the usual 
+      [arithmetic mean](#arithmetic_mean) when estimating an average rates of 
+      change or some other multiplicative constant. For a set of positive 
+      numbers that are not all equal, the min < HM < GM < AM < max where min is 
+      the minimum value, max is the maximum value, and HM GM and AM are the 
+      harmonic, [geometric](#geometric_mean), and [arithmetic](#arithmetic_mean)
+      means respectively.
 
 
 - slug: hardware

--- a/glossary.yml
+++ b/glossary.yml
@@ -612,7 +612,7 @@
   en:
     term: "arithmetic mean"
     def: >
-      See [mean](#mean).
+      See [mean](#mean). Calculated from a set of n numbers by summing those numbers, and dividing the result by n.
   pt:
     term: "média aritmética"
     def: >
@@ -2688,7 +2688,14 @@
 
 
 - slug: geometric_mean
-
+  ref:
+    - mean
+    - arithmetic_mean
+    - harmonic_mean
+  en:
+    term: "Geometric Mean"
+    def: >
+       Calculated from a set of n numbers by first computing the product of those numbers, and then computing the n-th root of the result. In contrast to the [arithmetic mean](#arithmetic_mean), which measures central tendancy in an "additive" way, the geometric mean measures central tendancy in a "multiplicative" way, and hence is often appropriate when estimating an average rates of change or some other multiplicative constant. 
 
 - slug: git
   en:
@@ -2979,6 +2986,14 @@
 
 
 - slug: harmonic_mean
+  ref:
+    - mean
+    - arithmetic_mean
+    - geometric_mean
+  en:
+    term: "Harmonic Mean"
+    def: >
+       Calculated from a set of n numbers by first computing the sum of the reciprocals of those numbers, and then dividing n by the resulting sum. Alternatively, it can be computed as the reciprocal of the [arithmetic mean](#arithmetic_mean) of the reciprocal values. Similarly to the [geometric mean](#geometric_mean), the harmonic mean is often used as an alternative measure of central tendancy to the usual [arithmetic mean](#arithmetic_mean) when estimating an average rates of change or some other multiplicative constant. For a set of positive numbers that are not all equal, the min < HM < GM < AM < max where min is the minimum value, max is the maximum value, and HM GM and AM are the harmonic, [geometric](#geometric_mean), and [arithmetic](#arithmetic_mean) means respectively.
 
 
 - slug: hardware


### PR DESCRIPTION
Hello, first time contributor sorry if I've messed up any etiquette, I'm here to learn and I figure better to learn by doing right? In particular aside from the definitions I filled for existing empty slugs for `geometric_mean` and `harmonic_mean`, and adding the three new slugs, I also touched `arithmetic_mean` to try and maintain consistency, but I notice this already has non-english versions, is there a way to flag this? I'm happy to just reverse the change and leave `arithmetic_mean` as it was if not. Similarly I added a few more simple terms (like `square_root`) and then touched `RMSE` and `standard deviation` to link them, but this would also not translate to the other languanges. I did this kinda deliberately because I want to learn what the ettiquette for these kinds of changes is here, because I was thinking about maybe taking on adding more comprehensive statistical terminology (things like posterior_distribution, likelihood, etc.). Thanks for your time and attention!

## Author: 

-  Lyron Winderbaum

## Language: 

- English

## Terms defined:

- geometric_mean
- arithmetic_mean
- square_root
- root_math
- reciprocal