### PR TITLE
add direction entry to ltr pages

### DIFF
--- a/af.md
+++ b/af.md
@@ -1,5 +1,6 @@
 ---
 permalink: /af/
 layout: glossary-ltr
+direction: ltr
 ---
 {% include glossary.html %}

--- a/am.md
+++ b/am.md
@@ -1,5 +1,6 @@
 ---
 permalink: /am/
 layout: glossary-ltr
+direction: ltr
 ---
 {% include glossary.html %}

--- a/bn.md
+++ b/bn.md
@@ -1,5 +1,6 @@
 ---
 permalink: /bn/
 layout: glossary-ltr
+direction: ltr
 ---
 {% include glossary.html %}

--- a/de.md
+++ b/de.md
@@ -1,5 +1,6 @@
 ---
 permalink: /de/
 layout: glossary-ltr
+direction: ltr
 ---
 {% include glossary.html %}

--- a/en.md
+++ b/en.md
@@ -1,5 +1,6 @@
 ---
 permalink: /en/
 layout: glossary-ltr
+direction: ltr
 ---
 {% include glossary.html %}

--- a/es.md
+++ b/es.md
@@ -1,5 +1,6 @@
 ---
 permalink: /es/
 layout: glossary-ltr
+direction: ltr
 ---
 {% include glossary.html %}

--- a/fr.md
+++ b/fr.md
@@ -1,5 +1,6 @@
 ---
 permalink: /fr/
 layout: glossary-ltr
+direction: ltr
 ---
 {% include glossary.html %}

--- a/it.md
+++ b/it.md
@@ -1,5 +1,6 @@
 ---
 permalink: /it/
 layout: glossary-ltr
+direction: ltr
 ---
 {% include glossary.html %}

--- a/ja.md
+++ b/ja.md
@@ -1,5 +1,6 @@
 ---
 permalink: /ja/
 layout: glossary-ltr
+direction: ltr
 ---
 {% include glossary.html %}

--- a/ko.md
+++ b/ko.md
@@ -1,4 +1,6 @@
 ---
 permalink: /ko/
+layout: glosary-ltr
+direction: ltr
 ---
 {% include glossary.html %}

--- a/nl.md
+++ b/nl.md
@@ -1,5 +1,6 @@
 ---
 permalink: /nl/
 layout: glossary-ltr
+direction: ltr
 ---
 {% include glossary.html %}

--- a/pt.md
+++ b/pt.md
@@ -1,5 +1,6 @@
 ---
 permalink: /pt/
 layout: glossary-ltr
+direction: ltr
 ---
 {% include glossary.html %}

--- a/zu.md
+++ b/zu.md
@@ -1,5 +1,6 @@
 ---
 permalink: /zu/
 layout: glossary-ltr
+direction: ltr
 ---
 {% include glossary.html %}


### PR DESCRIPTION
add `direction: ltr` entry to pages where `direction` was missing.