### PR TITLE
Add definition for 'tuple' in French and slightly modify it in English

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -6399,8 +6399,16 @@
     term: "tuple"
     def: >
       A data type that has a fixed number of parts, such as the three color components of a
-      red-green-blue color specification. Tuples are immutable (their values cannot be reset.)
-
+      red-green-blue color specification. In "[Python](#python)", tuples are immutable (their
+      values cannot be reset.)
+  fr:
+    term: "tuple"
+    def: >
+      Un type de donnée correspondant à une collection d'objets en nombre fixé, par exemple
+      les trois composantes de la spécification rouge-vert-bleu d'une couleur. En "[Python](#python)",
+      les tuples sont immuables (leurs valeurs sont fixées à l'initialisation et ne peuvent plus être
+      modifiées par la suite). 
+      Les tuples contenant n objets sont aussi appelés n-uplets.
 
 - slug: two_hard_problems
   en:

--- a/glossary.yml
+++ b/glossary.yml
@@ -4216,6 +4216,10 @@
     term: "NA"
     def: >
       A special value used to represent data that is not available.
+  fr:
+    term: "NA"
+    def: >
+      Une valeur spéciale utilisée pour représenter des données qui ne sont pas disponibles.
   af:
     term: "NA"
     def: >
@@ -4355,8 +4359,13 @@
   en:
     term: "null"
     def: >
-      A special value used to represent a missing object. Null is not the same as NA,
+      A special value used to represent a missing object. Null is not the same as [NA](#na),
       and neither is it the same as an [empty vector](#empty_vector).
+  fr:
+    term: "null"
+    def: >
+      Une valeur spéciale utilisée pour représenter l'absence de valeur. Null n'est pas équivalent à [NA](#na),
+      ni à un [vecteur vide](#empty_vector).
 
 
 - slug: null_hypothesis


### PR DESCRIPTION
Add a definition for tuple in French
Precise the definition for tuple in English

## Author: 

- Marie Houillon (@MarieHouillon)

## Language: 

- French (fr)
- English (en)

## Terms defined:

- tuple
