### PR TITLE
move ref: nearer to slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ A glossary entry is structured like this:
 
 ```
 - slug: cran
+  ref:
+    - base_r
+    - tidyverse
   en:
     term: "Comprehensive R Archive Network"
     acronym: "CRAN"
     def: >
       A public repository of R [packages](#package).
-  ref:
-    - base_r
-    - tidyverse
 ```
 
 -   The value associated with the `slug` key identifies the entry.


### PR DESCRIPTION
having the ref: key next to the slug makes it easier to visually detect what terms are related as discussed at https://swcarpentry.slack.com/archives/C01G4HYGAQ6/p1631243913000800
