### PR TITLE
[FIX] Security - useing Safeloader

### DIFF
--- a/utils/check-glossary.py
+++ b/utils/check-glossary.py
@@ -47,9 +47,9 @@ def main():
     '''Main driver.'''
     checkLang, configFile, glossaryFile = parseArgs()
     with open(configFile, 'r') as reader:
-        config = yaml.load(reader, Loader=yaml.FullLoader)
+        config = yaml.load(reader, Loader=yaml.SafeLoader)
     with open(glossaryFile, 'r') as reader:
-        gloss = yaml.load(reader, Loader=yaml.FullLoader)
+        gloss = yaml.load(reader, Loader=yaml.SafeLoader)
 
     checkLanguages(config)
     for entry in gloss:


### PR DESCRIPTION
Using SafeLoader instead of FullLoader to avoid security risks while loading grossery and config files

here is example for exploiting  :

![poc](https://user-images.githubusercontent.com/36979660/136080614-4cfaee3a-3d87-442a-b029-9697142a0a42.png)




Hacktoberfest