### PR TITLE
Fixes for check-glossary.py

### DIFF
--- a/utils/check-glossary.py
+++ b/utils/check-glossary.py
@@ -82,7 +82,7 @@ def parseArgs():
     configFile, glossFile = filenames
 
     checkLang = None
-    for (opt, args) in options:
+    for (opt, arg) in options:
         if opt == '-A':
             checkLang = 'ALL'
         elif opt == '-c':

--- a/utils/check-glossary.py
+++ b/utils/check-glossary.py
@@ -75,7 +75,12 @@ def parseArgs():
     to check may be 'ALL' (to check all), None (to check none), or
     a known 2-letter language code.
     '''
-    options, filenames = getopt.getopt(sys.argv[1:], 'Ac:')
+    try:
+        options, filenames = getopt.getopt(sys.argv[1:], 'Ac:')
+    except getopt.GetoptError as error:
+        print(f'Unknown flag {error.opt}', file=sys.stderr)
+        sys.exit(1)
+
     if (len(filenames) != 2):
         print(f'Usage: check [-A] [-c LL] configFile glossFile')
         sys.exit(1)
@@ -90,9 +95,6 @@ def parseArgs():
             if checkLang not in ENTRY_LANGUAGE_KEYS:
                 print(f'Unknown language {checkLang}', file=sys.stderr)
                 sys.exit(1)
-        else:
-            print(f'Unknown flag {opt}', file=sys.stderr)
-            sys.exit(1)
 
     return checkLang, configFile, glossFile
 


### PR DESCRIPTION
I noticed a couple of things that I believe were not working as intended in `check-glossary.py`:

1. There was a typo that resulted in an (unexpected) error when someone used the `-c` option.
<details>
<summary>Before</summary>

```bash
$ python utils/check-glossary.py -c en _config.yml glossary.yml
Traceback (most recent call last):
  File "utils/check-glossary.py", line 230, in <module>
    main()
  File "utils/check-glossary.py", line 48, in main
    checkLang, configFile, glossaryFile = parseArgs()
  File "utils/check-glossary.py", line 89, in parseArgs
    checkLang = arg
NameError: name 'arg' is not defined
```
</details>


2. It was never possible to print the error message for unknown flags, as `getopt` already exited before reaching that.
<details>
<summary>Before</summary>

```bash
$ python utils/check-glossary.py -b
Traceback (most recent call last):
  File "utils/check-glossary.py", line 230, in <module>
    main()
  File "utils/check-glossary.py", line 48, in main
    checkLang, configFile, glossaryFile = parseArgs()
  File "utils/check-glossary.py", line 78, in parseArgs
    options, filenames = getopt.getopt(sys.argv[1:], 'Ac:')
  File "/Users/ageorgou/anaconda3/envs/glosario/lib/python3.8/getopt.py", line 95, in getopt
    opts, args = do_shorts(opts, args[0][1:], shortopts, args[1:])
  File "/Users/ageorgou/anaconda3/envs/glosario/lib/python3.8/getopt.py", line 195, in do_shorts
    if short_has_arg(opt, shortopts):
  File "/Users/ageorgou/anaconda3/envs/glosario/lib/python3.8/getopt.py", line 211, in short_has_arg
    raise GetoptError(_('option -%s not recognized') % opt, opt)
getopt.GetoptError: option -b not recognized
```
</details>
<details>
<summary>After</summary>

```bash
$  python utils/check-glossary.py -b
Unknown flag b
```
</details>