### PR TITLE
Translate: raster image (Spanish)

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -5636,6 +5636,10 @@
     term: "raster image"
     def: >
       An image stored as a matrix of pixels.
+  es:
+    term: "imagen rasterizada"
+    def: >
+      Una imagen almacenada como una matriz de píxeles.
 
 
 - slug: reactive_programming


### PR DESCRIPTION
Translated "raster image" ("imagen rasterizada") to Spanish

<!-- If you are adding terms, change the pull request title to mention the terms added and language, or if there are a lot of them, the number of terms and language.

Examples:

Add definition for 'byte' (English)
Add definitions for 'agrégation', 'commentaire' (French)
Translate 5 terms (Spanish)
-->

Fill in each of the sections (using NA for those that are not applicable).

## Author: 

- Nicolas Palopoli (@NPalopoli)

## Language: 

- Spanish

## Terms defined:

- raster image (imagen rasterizada)