### PR TITLE
added greek definitions for "data engineer", "data science" and "data scientist"

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -2815,6 +2815,12 @@
     def: >
       The pragmatic steps taken to make data usable, such as writing short programs to
       put mailing addresses in a uniform format.
+  el:
+    term: "μηχανικός δεδομένων"
+    def: >
+      Ένα άτομο που υλοποιεί και τρέχει αναλύσεις δεδομένων. Οι μηχανικοί δεδομένων
+      είναι συνήθως υπεύθυνοι για την εγκατάσταση λογισμικού, τη διαχείριση βάσεων
+      δεδομένων, τη δημιουργία αναφορών και την αρχειοθέτηση των αποτελεσμάτων.
 
   am:
     term: የውሂብ ምህንድስና
@@ -2912,6 +2918,10 @@
     term: "ciencia de datos"
     def: >
       La combinación de estadísticas, programación y trabajo duro que se utiliza para extraer información de los datos.
+  el:
+    term: "επιστήμη δεδομένων"
+    def: >
+      Ο συνδυασμός στατιστικής, προγραμματισμού και σκληρής δουλειάς που χρειάζεται για να εξαχθούν συμπεράσματα από δεδομένα.
 
   am:
     term: የውሂብ ሳይንስ
@@ -2939,6 +2949,10 @@
     term: "cientifico/cientifica de datos"
     def: >
       Alguien que usa habilidades de programación para resolver problemas de estadísticas.
+  el:
+    term: "επιστήμονας δεδομένων"
+    def: >
+      Ένα άτομο που χρησιμοποιεί προγραμματισμό για να λύσει προβλήματα στατιστικής.
 
   am:
     term: የውሂብ ሳይንቲስት


### PR DESCRIPTION
<!-- If you are adding terms, change the pull request title to mention the terms added and language, or if there are a lot of them, the number of terms and language.

Examples:

Add definition for 'byte' (English)
Add definitions for 'agrégation', 'commentaire' (French)
Translate 5 terms (Spanish)
-->

Fill in each of the sections (using NA for those that are not applicable).

## Author: 
Aristotelis Misios aristotelis.t.misios@gmail.com 
(institution: MDC-Berlin)
(instructor checkout)

## Language: 
Greek Language (el)

## Terms defined:
data engineer = μηχανικός δεδομένων
data science = επιστήμη δεδομένων
data scientist = επιστήμονας δεδομένων

