### PR TITLE
Adding German for While

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -8896,6 +8896,11 @@
     def: >
       A statement in a program that repeats one or more other statements (the [loop
       body](#loop_body)) as long as a condition is [true](#true).
+  de:
+    term: "while Schleife"
+    def: >
+      Eine Kontrollstruktur, die Anweisungs-Block oder [Schleifenkörper](#loop_body) wiederholt,
+      solange die Schleifenbedingung als Laufbedingung gültig oder [wahr](#true) bleibt.
 
 
 - slug: whitespace

--- a/glossary.yml
+++ b/glossary.yml
@@ -8899,7 +8899,7 @@
   de:
     term: "while Schleife"
     def: >
-      Eine Kontrollstruktur, die Anweisungs-Block oder [Schleifenkörper](#loop_body) wiederholt,
+      Eine Anweisung, die einen Anweisungs-Block oder [Schleifenkörper](#loop_body) wiederholt,
       solange die Schleifenbedingung als Laufbedingung gültig oder [wahr](#true) bleibt.
 
 


### PR DESCRIPTION
## Author: Kolja Kauder

- 

## Language: German

- 

## Terms defined: while loop

**QUESTION: I'm using references to loop_body and true, but they probably point to the English ones if anything. Do I need to add a slug: Schleifenkörper, or add a "de" section to slug: loop_body?**

- 
- 
- 
