### PR TITLE
Add definition in Portuguese for "default value"

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -3136,7 +3136,7 @@
     term: "default target"
     def: >
       The [build target](#build_target) that is used when none is specified explicitly.
-
+ 
   am:
     term: ነባሪ ዒላማ
     def: >
@@ -3153,6 +3153,11 @@
     term: ነባሪ እሴት
     def: >
       መቼ ለአንድ ተግባር [ልኬት](#parameter) የተመደበ እሴት ደዋዩ ዋጋ አይገልጽም። ነባሪ እሴቶች እንደ የተግባሩ አካል ሆነው ተገልፀዋል ትርጉም
+   pt:
+    term: "valor por defeito"
+    def: >
+      Valor associado ao [parâmetro](#parameter) de uma função quando o operador não especifica um
+      valor. Valores por defeito fazem parte da definição de uma função.
 
 - slug: defensive_programming
   en:


### PR DESCRIPTION
<!-- If you are adding terms, change the pull request title to mention the terms added and language, or if there are a lot of them, the number of terms and language.

Examples:

Add definition for 'byte' (English)
Add definitions for 'agrégation', 'commentaire' (French)
Translate 5 terms (Spanish)
-->

Fill in each of the sections (using NA for those that are not applicable).

## Author: Sandra Silva

- 

## Language: Portuguese

- 

## Terms defined: default value

- 
- 
- 
