### PR TITLE
Adding Croatian language site and adding one term to the glossary

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -124,6 +124,19 @@ languages:
       dove possono trovare tali informazioni. 
       Gli autori possono anche usare le funzioni della libreria per inserire collegamenti ipertestuali
       ai termini e alle definizioni nella lezione in una qualsiasi tra le diverse lingue.
+  - key: hr
+    name: Hrvatski
+    title: Rječnik
+    blurb: >
+       `glosario` je rječnik otvorenog koda ("open source") koji se koristi u podatkovnoj znanosti ("data science"), 
+       a koji je dostupan online i kao korisnički paket u jezicima
+       [R](https://github.com/carpentries/glosario-r/) i
+       [Python](https://github.com/carpentries/glosario-py/). Dodavanjem pojmova iz rječnika
+       u metapodatake lekcija, autori mogu naznačiti što lekcija podučava,
+       što bi učenici trebali znati prije nego što počnu i gdje mogu ići pronaći
+       to znanje. Autori također mogu koristiti funkcije rječnika za umetanje
+       dosljedne hiperveze za pojmove i definicije u svojim lekcijama na bilo kojem od
+       nekoliko jezika.
   - key: ko
     name: 한국어
     title: 용어 사전

--- a/glossary.yml
+++ b/glossary.yml
@@ -4476,7 +4476,10 @@
     term: "전역 변수"
     def: >
       소스 코드 상의 모든 곳에서 접근할 수 있는 변수.
-
+ hr:
+    term: "globalna varijabla"
+    def: >
+      Varijabla definirana izvan bilo koje određene funkcije, koja je stoga vidljiva svim funkcijama.
   am:
     term: ዓለም አቀፍ ተለዋዋጭ
     def: 'ከማንኛውም የተለየ ተግባር ወይም [ጥቅል](#package) የስም ቦታ ውጭ የተገለጸ ተለዋዋጭ ፣ ስለሆነም የሚታየው

--- a/hr.md
+++ b/hr.md
@@ -1,0 +1,7 @@
+---
+permalink: /hr/
+layout: glossary
+direction: ltr
+---
+
+{% include glossary.html %}

--- a/utils/check-glossary.py
+++ b/utils/check-glossary.py
@@ -30,7 +30,7 @@ from collections import Counter
 # Keys for entries and definitions.
 ENTRY_REQUIRED_KEYS = {'slug'}
 ENTRY_OPTIONAL_KEYS = {'ref'}
-ENTRY_LANGUAGE_KEYS = {'af', 'am', 'ar', 'bn', 'de', 'el', 'en', 'es', 'fr', 'he', 'id', 'it', 'ja', 'ko', 'nl', 'pt', 'st', 'sw', 'tn', 'xh', 'zu'}
+ENTRY_LANGUAGE_KEYS = {'af', 'am', 'ar', 'bn', 'de', 'el', 'en', 'es', 'fr', 'he','hr', 'id', 'it', 'ja', 'ko', 'nl', 'pt', 'st', 'sw', 'tn', 'xh', 'zu'}
 ENTRY_KEYS = ENTRY_REQUIRED_KEYS | \
              ENTRY_OPTIONAL_KEYS | \
              ENTRY_LANGUAGE_KEYS


### PR DESCRIPTION
<!-- If you are adding terms, change the pull request title to mention the terms added and language, or if there are a lot of them, the number of terms and language.

Examples:

Add definition for 'byte' (English)
Add definitions for 'agrégation', 'commentaire' (French)
Translate 5 terms (Spanish)
-->

Fill in each of the sections (using NA for those that are not applicable).

## Author: 

- 

## Language: 

- 

## Terms defined:

- 
- 
- 
