### PR TITLE
Translation of seed (Spanish)

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -7882,8 +7882,11 @@
     term: "saadjie"
     def: >
       'n Waarde wat gebruik word om 'n [pseudolukrakenommergenereerder](#prng) te begin.
+  es:
+    term: "semilla"
+    def: >
+      Un valor utilizado para inicializar un [generador de números pseudoaleatorios](#prng).
       
-
 - slug: select
   en:
     term: "select"


### PR DESCRIPTION
Translation of seed (Spanish)

<!-- If you are adding terms, change the pull request title to mention the terms added and language, or if there are a lot of them, the number of terms and language.

Examples:

Add definition for 'byte' (English)
Add definitions for 'agrégation', 'commentaire' (French)
Translate 5 terms (Spanish)
-->

Fill in each of the sections (using NA for those that are not applicable).

## Author: 

- Sebastián Ayala Ruano

## Language: 

- Spanish

## Terms translated:

- seed
