### PR TITLE
Add definition for 'python', 'algorithm' (Italian)

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -628,6 +628,11 @@
       Αλγόριθμος είναι ένα σύνολο από βήματα ή κανόνες για τη διεκπεραίωση μιας συγκεκριμένης εργασίας.
       Στην πληροφορική, αλγόριθμος είναι ένα σύνολο από εντολές σε κάποιο πρόγραμμα οι οποίες επιλύουν κάποιο
       υπολογιστικό πρόβλημα.
+  it:
+    term: "algoritmo"
+    def: >
+      Un algoritmo è una sequenza finita di regole ed operazioni da eseguire al fine di realizzare un certo compito.
+      In informatica, un algoritmo è un insieme di istruzioni presenti in un programma che permette di risolvere un problema computazionale.
       
 - slug: algorithmic_bias
   ref:
@@ -7247,6 +7252,11 @@
     def: >
       Uma popular linguagem de programação interpretada, de código aberto,  que
       depende de indentação para definir a estrutura de controle.
+  it:
+    term: "Python"
+    def: >
+      Un linguaggio di programmazione open-source (pubblicamente accessibile), orientato a oggetti, interpretato (non necessita di compilazione) e 
+      che utlizza l'indentazione per definire le strutture di controllo.
 
 
 - slug: quantile

--- a/glossary.yml
+++ b/glossary.yml
@@ -632,7 +632,7 @@
     term: "algoritmo"
     def: >
       Un algoritmo è una sequenza finita di regole ed operazioni da eseguire al fine di realizzare un certo compito.
-      In informatica, un algoritmo è un insieme di istruzioni presenti in un programma che permette di risolvere un problema computazionale.
+      In informatica, un algoritmo è una sequenza finita di istruzioni presenti in un programma che permette di risolvere un problema computazionale.
       
 - slug: algorithmic_bias
   ref:

--- a/glossary.yml
+++ b/glossary.yml
@@ -631,7 +631,7 @@
   it:
     term: "algoritmo"
     def: >
-      Un algoritmo è una sequenza finita di regole ed operazioni da eseguire al fine di realizzare un certo compito.
+      Un algoritmo è una sequenza finita di operazioni da eseguire al fine di realizzare un certo compito.
       In informatica, un algoritmo è una sequenza finita di istruzioni presenti in un programma che permette di risolvere un problema computazionale.
       
 - slug: algorithmic_bias


### PR DESCRIPTION
Add definition of "python" and "algorithm" in Italian

<!-- If you are adding terms, change the pull request title to mention the terms added and language, or if there are a lot of them, the number of terms and language.

Examples:

Add a definition for 'byte' (English)
Add definitions for 'agrégation', 'commentaire' (French)
Translate 5 terms (Spanish)
-->

## Author: 

- Donatella Cea

## Language: 

- it

## Terms defined:

- algoritmo
- python
