### PR TITLE
Add definition for "absolute row number" (French)

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -294,6 +294,11 @@
     term: ፍጹም ረድፍ ቁጥር
     def: የትኞቹም ክፍሎች ቢኖሩ በሠንጠረዥ ውስጥ የአንድ ረድፍ ቅደም ተከተል ማውጫ ጠረጴዛ እየታየ ነው ፡፡
 
+  pt:
+    term: "numéro de ligne absolu"
+    def: >
+      L'index séquentiel d'une ligne dans une table, quelles que soient les sections de la table affichées.
+      
 - slug: abstract_method
   de:
     term: "Abstrakte Methode"


### PR DESCRIPTION
<!-- If you are adding terms, change the pull request title to mention the terms added and language, or if there are a lot of them, the number of terms and language.

Examples:

Add definition for 'byte' (English)
Add definitions for 'agrégation', 'commentaire' (French)
Translate 5 terms (Spanish)
-->

Fill in each of the sections (using NA for those that are not applicable).

## Author: 

- Mouna Belaid

## Language: 

- French

## Terms defined:

- absolute row number
