### PR TITLE
Add netlify and Code of Conduct links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .Rproj.user
 .jekyll-cache
 .jekyll-metadata
+.vendor/
 Glossary.egg-info
 MANIFEST
 R/sysdata.rda

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,7 @@
+---
+permalink: /conduct/
+---
+
 # The Carpentries Code of Conduct
 
 As contributors and maintainers of this project, we pledge to follow the [Carpentries Code of Conduct][coc].

--- a/_layouts/glossary.html
+++ b/_layouts/glossary.html
@@ -41,6 +41,8 @@
         -
         <a href="{{'/license/' | relative_url}}">License</a>
         -
+        <a href="{{'/conduct/' | relative_url}}">Code of Conduct</a>
+        -
         <a href="{{ site.repository_url }}">GitHub</a>
         -
         <a href="https://www.netlify.com">This site is powered by Netlify</a>

--- a/_layouts/glossary.html
+++ b/_layouts/glossary.html
@@ -41,7 +41,9 @@
         -
         <a href="{{'/license/' | relative_url}}">License</a>
         -
-        <a href="https://github.com/carpentries/glosario/">GitHub</a>
+        <a href="{{ site.repository_url }}">GitHub</a>
+        -
+        <a href="https://www.netlify.com">This site is powered by Netlify</a>
     </p>
 </footer>
 </body>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -35,6 +35,8 @@
         -
         <a href="{{'/license/' | relative_url}}">License</a>
         -
+        <a href="{{'/conduct/' | relative_url}}">Code of Conduct</a>
+        -
         <a href="{{ site.repository_url }}">GitHub</a>
         -
         <a href="https://www.netlify.com">This site is powered by Netlify</a>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -36,6 +36,8 @@
         <a href="{{'/license/' | relative_url}}">License</a>
         -
         <a href="{{ site.repository_url }}">GitHub</a>
+        -
+        <a href="https://www.netlify.com">This site is powered by Netlify</a>
       </p>
     </footer>
   </body>


### PR DESCRIPTION
We use netlify to deploy glosario, but we need to switch to a Pro plan because we are reaching the limits of our deployment capabilities. Luckily, [Netlify has an Open Source Plan policy](https://www.netlify.com/legal/open-source-policy/), which effectively stipulates that we can have a prorated pro plan, as long as our project is 

1. open source (it is), 
2. has a Code of Conduct (it does) that is clearly visible (in this PR, which was sorely needed), 
3. it says that it's deployed by Netlify (in this PR), and 
4. must not be a commercial product (it is not)

