### PR TITLE
Added Kiswahili translations for 5 words

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -2736,7 +2736,7 @@
     def: >
       አንድ ተጠቃሚ ትዕዛዞች ሊገባበት የሚችልበት የኮምፒውተር ተርሚናል ወይም እንደ ዛጎል ያለ ፕሮግራም እንዲህ ያለውን መሣሪያ የሚኮርጅ ነው።
       
-    sw:
+  sw:
     term: "koni ya kompyuta"
     def: >
       Kituo cha kompyuta ambapo mtumiaji anaweza kuingiza amri, au programu, kama vile shell
@@ -2769,11 +2769,11 @@
     def: >
       قيمة عددية ثابتة لا يمكن أن تتغير وهي عكس المتغير الذي يمكن أن يأخذ أكثر من قيمة.
 
- sw:
+  sw:
     term: "thabiti"
     def: >-
       Thamani ambayo haiwezi kubadilishwa baada ya kubainishwa, 
-      ukilinganisha na [kigeu](#programu_kigeugeu) ambayo hubadilika.
+      ukilinganisha na [kigeu](#variable_program) ambayo hubadilika.
       
 
 - slug: constructor
@@ -2810,7 +2810,7 @@
   sw:
     term: "kishawishi endelevu"
     def: >
-       [kishawishi](#kishawishi) kinachoashiria kwamba amri inayochapwa kwa sasa bado haijakamilika, 
+       [kishawishi](#prompt) kinachoashiria kwamba amri inayochapwa kwa sasa bado haijakamilika, 
        na itaendeshwa mara tu itakapokamilika.
 
 - slug: continuous_integration

--- a/glossary.yml
+++ b/glossary.yml
@@ -2720,8 +2720,7 @@
   sw:
     term: "faili ya usanidi"
     def: >
-      Faili inayobainisha vigezo na mipangilio ya awali ya programu. 
-      Faili ya usanidi hutumiwa kwa habari  zinazobadilika mara nyingi, 
+      Faili inayobainisha vigezo na mipangilio ya awali ya programu. Faili ya usanidi hutumiwa kwa habari  zinazobadilika mara nyingi, 
       kama vile mipangilio iambatanayo ya mazingira.
 
 

--- a/glossary.yml
+++ b/glossary.yml
@@ -2717,7 +2717,7 @@
     def: >
       የሶፍትዌሩን ፕሮግራም መስፈሪያዎች እና የመጀመሪያ አቀማመዶች የሚወስን ፋይል. ቅንብር ወይም config, ፋይሎች ብዙውን ጊዜ ለውጦች ለሚታዩበት መረጃ ጥቅም ላይ ይውላሉ, እንደ አካባቢ-የተለየ አቀማመጥ.
       
-   sw:
+  sw:
     term: "faili ya usanidi"
     def: >
       Faili inayobainisha vigezo na mipangilio ya awali ya programu. 

--- a/glossary.yml
+++ b/glossary.yml
@@ -2716,6 +2716,14 @@
     term: የቅንብር ፋይል
     def: >
       የሶፍትዌሩን ፕሮግራም መስፈሪያዎች እና የመጀመሪያ አቀማመዶች የሚወስን ፋይል. ቅንብር ወይም config, ፋይሎች ብዙውን ጊዜ ለውጦች ለሚታዩበት መረጃ ጥቅም ላይ ይውላሉ, እንደ አካባቢ-የተለየ አቀማመጥ.
+      
+   sw:
+    term: "faili ya usanidi"
+    def: >
+      Faili inayobainisha vigezo na mipangilio ya awali ya programu. 
+      Faili ya usanidi hutumiwa kwa habari  zinazobadilika mara nyingi, 
+      kama vile mipangilio iambatanayo ya mazingira.
+
 
 - slug: console
   en:
@@ -2728,6 +2736,13 @@
     term: ኮንሶል
     def: >
       አንድ ተጠቃሚ ትዕዛዞች ሊገባበት የሚችልበት የኮምፒውተር ተርሚናል ወይም እንደ ዛጎል ያለ ፕሮግራም እንዲህ ያለውን መሣሪያ የሚኮርጅ ነው።
+      
+    sw:
+    term: "koni ya kompyuta"
+    def: >
+      Kituo cha kompyuta ambapo mtumiaji anaweza kuingiza amri, au programu, kama vile shell
+      ambayo huiga kifaa kama hicho.
+      
 
 - slug: confusion_matrix
   en:
@@ -2755,6 +2770,12 @@
     def: >
       قيمة عددية ثابتة لا يمكن أن تتغير وهي عكس المتغير الذي يمكن أن يأخذ أكثر من قيمة.
 
+ sw:
+    term: "thabiti"
+    def: >-
+      Thamani ambayo haiwezi kubadilishwa baada ya kubainishwa, 
+      ukilinganisha na [kigeu](#programu_kigeugeu) ambayo hubadilika.
+      
 
 - slug: constructor
   en:
@@ -2786,6 +2807,12 @@
     term: ቀጣይነት ያለው እርምጃ
     def: >
       በአሁኑ ጊዜ እየተለፈፈ ያለው ትዕዛዝ አለመሆኑን የሚያመለክት [አፋጣኝ](#prompt) ገና ሙሉ እስከሆነ ድረስ አይሮጥም
+
+  sw:
+    term: "kishawishi endelevu"
+    def: >
+       [kishawishi](#kishawishi) kinachoashiria kwamba amri inayochapwa kwa sasa bado haijakamilika, 
+       na itaendeshwa mara tu itakapokamilika.
 
 - slug: continuous_integration
   en:
@@ -2954,6 +2981,13 @@
     term: ማዕከላዊ ማቀነባበሪያ ክፍል
     def: >
       የማንኛውም ዲጂታል ኮምፒውተር ዋና ሃርድዌር. ሲፒዩ ነው::  መመሪያዎችን የሚተረጉም እና የሚፈፅም አስፈላጊ የኤሌክትሮኒክ ስረሰር ከሶፍትዌሩ ወይም ከሌላ ሃርድዌር የተወሰደ።በተጨማሪም ማዕከላዊ ፕሮሲሰር ተብሎ ይጠራል፤ ዋና ፕሮሲሰር ወይም ማይክሮፕሮሰሰር ::
+
+  sw:
+    term: "Central Processing Unit"
+    def: >
+      Vifaa vikuu vya kompyuta yoyote ya dijitali inayojumuisha
+      sakiti muhimu za kielektroniki zinazotafsiri na kutekeleza maagizo
+      kutoka kwa programu au maunzi mengine.
 
 - slug: cran
   ref:


### PR DESCRIPTION
Added Kiswahili translations for 4 words ("console", "constant", "continuation prompt", “Central Processing Unit”)

<!-- If you are adding terms, change the pull request title to mention the terms added and language, or if there are a lot of them, the number of terms and language.

Examples:

Add definition for 'byte' (English)
Add definitions for 'agrégation', 'commentaire' (French)
Translate 5 terms (Spanish)
-->

Fill in each of the sections (using NA for those that are not applicable).

## Author: 

- NOngeso

## Language: 

- Kiswahili

## Terms defined:

- configuration file
- console
- constant
- continuation prompt
- Central Processing Unit

