### PR TITLE
add definition for 'high performance computing' (English)

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -5239,6 +5239,14 @@
     def: >
       በሌሎች ተግባራት ላይ የሚሰራ ተግባር ፡፡ ለምሳሌ ፣ ከፍተኛ-ትዕዛዝ ተግባር "ካርታ` በ [ዝርዝር](#list) ውስጥ በእያንዳንዱ እሴት ላይ አንድ ጊዜ የተሰጠ ተግባርን ያከናውናል። የከፍተኛ ትዕዛዝ ተግባራት [በተግባራዊ መርሃግብር](#functional_programming) ውስጥ በጣም ያገለግላሉ።
 
+- slug: high_performance_computing
+  en:
+    term: "high performance computing"
+    acronym: "HPC"
+    def: >
+        When computing power is drawn from multiple powerful processors that work together in parallel, rather than from a single desktop computer, laptop, or work station.
+        This significantly speeds up analysis and reduces computing time, which allows people to work with [big data](#big_data).
+
 - slug: hippocratic_license
   en:
     term: "Hippocratic License"


### PR DESCRIPTION
Lines 5242-5248 in glossary.yml

<!-- If you are adding terms, change the pull request title to mention the terms added and language, or if there are a lot of them, the number of terms and language.

Examples:

Add definition for 'byte' (English)
Add definitions for 'agrégation', 'commentaire' (French)
Translate 5 terms (Spanish)
-->

Fill in each of the sections (using NA for those that are not applicable).

## Author: 

- Lia Ossanna

## Language: 

- English

## Terms defined:

- high power computing
- 
- 
