### PR TITLE
Procedural generation: don't repeat term in definition

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -7779,7 +7779,7 @@
   en:
     term: "procedural generation"
     def: >
-      Procedural generation is a method of generating data algorithmically rather than manually. Typically
+      A method of generating data algorithmically rather than manually. Typically
       this is done to reduce file sizes, increase the overall amount of content, and/or incorporate
       randomness at the expense of processing power.
 


### PR DESCRIPTION
This would match the general style elsewhere of not repeating the term being define (demonstrated in the preceding and following entries).

## Author: 

- @warrickball

## Language: 

- en

## Terms defined:

- procedural generation
