### PR TITLE
Added term Pointcloud in English

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -7657,6 +7657,11 @@
     def: >
       Om ten gunste van iets te stem.
 
+- slug: pointcloud
+  en:
+    term: "pointcloud"
+    def: >
+      A set of discrete data points in three-dimensional space.
 
 - slug: poisson_distribution
   en:


### PR DESCRIPTION
<!-- If you are adding terms, change the pull request title to mention the terms added and language, or if there are a lot of them, the number of terms and language.

Examples:

Add definition for 'byte' (English)
Add definitions for 'agrégation', 'commentaire' (French)
Translate 5 terms (Spanish)
-->

Fill in each of the sections (using NA for those that are not applicable).

## Author: Doug Daniels

- 

## Language: English

- 

## Terms defined: Pointcloud

- 
- 
- 
