### PR TITLE
Update Portuguese definition of 'argument' and add 'parameter'

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -983,8 +983,9 @@
   pt:
     term: "argumento"
     def: >
-      Um valor passado para uma função. Algumas pessoas autoras usam este termo como
-      sinônimo de parâmetro(#parameter) e outras não fazem isso; é tudo bastante confuso.
+      Uma expressão, possivelmente dentre muitas, passada para uma função. É o valor em si.
+      Não confundir com [parâmetro](#parameter), que é um termo relacionado, mas diferente.
+      Parâmetros são variáveis e argumentos são os valores dessas variáveis.
   ar:
     term: "وسيطة"
     def: >
@@ -7482,6 +7483,12 @@
       Die Parameter sind die Namen der Eingangswerte einer Funktion, welche beim Aufruf übergeben
       werden. Parameter und Argumente sind verwandt aber nicht identisch. Ein Parameter ist eine
       Variable und ein [Argument](#argument) ist dem der Variable zugewiesene Wert.
+  pt:
+    term: "parâmetro"
+    def: >
+      Uma variável especificada na definição de uma função, cujo valor é passado para a função quando
+      ela é invocada. O parâmetro é a variável, enquanto seu valor dentro da função é
+      um [argumento](#argument). Parâmetro e argumento são termos relacionados, mas diferentes.
 
 
 - slug: parent_class


### PR DESCRIPTION
Updated Portuguese definition of "argument" to match the content of the definition in other languages. That definition compares arguments to parameters; a Portuguese definition of "parameter" didn't exist, so I also added it.

## Author: 

- Ian V. Caldas

## Language: 

- Portuguese

## Terms defined:

- Argument
- Parameter 
