### PR TITLE
Changed 'Chinese' to 中文

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -285,7 +285,7 @@ languages:
     blurb: >-
       In translation
   - key: zh
-    name: Chinese
+    name: 中文
     title: 术语表
     blurb: >
       `glosario`是开源的数据科学术语表，也可作为[R](https://github.com/carpentries/glosario-r/)


### PR DESCRIPTION
Changed 'Chinese' to 中文, as suggested by lingmeng634: https://github.com/carpentries/glosario/issues/525. This is to better align with the glossary's other languages, whose names are presented in their native orthographies.

## Author: 

- Courtney Dalton

## Language: 

- 中文

## Terms defined: 

- N/A
