### PR TITLE
Fix ref links and remove leading whitespace

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -10087,7 +10087,7 @@
      
 - slug: parametric_statistics
   ref:
-    - non-parametric (statistics)
+    - nonparametric_statistics
   en:
     term: "parametric (statistics)"
     def: >
@@ -10096,9 +10096,9 @@
 
 - slug: nonparametric_statistics
   ref:
-    - parametric (statistics)
+    - parametric_statistics
   en:
-    term: " non-parametric (statistics)"
+    term: "non-parametric (statistics)"
     def: >
       A branch of statistical tests which do not assume a known distribution of the population which the samples were taken from (Kruskal-Wallis and Dunn test are examples of non-parametric tests).
      


### PR DESCRIPTION
Fixes #580  Fix ref links in parametric_statistics and nonparametric_statistics, and remove leading whitespace in "non-parametric (statistics)" term that was preventing correct alphabetizing.


Fill in each of the sections (using NA for those that are not applicable).

## Author: 

- Rose Hartman

## Language: 

- English

## Terms defined:

- NA
