### PR TITLE
Update glossary.yml constant typos

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -2971,10 +2971,7 @@
   en:
     term: "constant"
     def: >- 
-      A constant in programming is a name associated with a value that never changes during the execution of a program. You can only access the constant’s value but not change it over time. Oposed to a [variable](#variable_program) 
-
-      # A value that cannot be changed after it has been defined, as opposed 
-      # to a [variable](#variable_program).
+      A constant in programming is a name associated with a value that never changes during the execution of a program. You can only access the constant’s value but not change it over time, as opposed to a [variable](#variable_program) 
   fr:
     term: "constante"
     def: >


### PR DESCRIPTION
The "constant" definition had typos and weird formatting. I fixed the "constant" definition to read:

A constant in programming is a name associated with a value that never changes during the execution of a program. You can only access the constant’s value but not change it over time, as opposed to a [variable].

-->

Fill in each of the sections (using NA for those that are not applicable).

## Author: 

- NA

## Language: 

- English

## Terms defined:

- NA
- 
- 
