### PR TITLE
add definition to 'parametric_statistics' (Afrikaans)

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -10045,6 +10045,14 @@
 
 
 - slug: yaml
+  af:
+    term: "YAML"
+    def: >
+      'n Afkorting vir "YAML Ain't Markup Language". Dis 'n metode om geneste data 
+      deur indentasie voor te stel liewer as om hakkies of kommas of [JSON](#json) 
+      te gebruik. YAML word dikwels gebruik in konfigurasie lêers en word ook gebruik om 
+      [PARAMETERS](#parameters) te definieer vir verskeie variasies van [MARKDOWN](#markdown) 
+      dokumente.
   de:
     term: "YAML"
     def: >

--- a/glossary.yml
+++ b/glossary.yml
@@ -10102,6 +10102,11 @@
 - slug: parametric_statistics
   ref:
     - nonparametric_statistics
+  af: 
+  term: "parametriese (statistiek)"
+  def: > 
+    'n Klas van statistieke toetse wat almal aanneem dat die verdeling van die populasie waarvandaan die steekproef geneem was, bekend is. 
+    (ANOVA en Student se t-toetse is beide voorbeelde van parametriese toetse.)
   en:
     term: "parametric (statistics)"
     def: >


### PR DESCRIPTION
<!-- If you are adding terms, change the pull request title to mention the terms added and language, or if there are a lot of them, the number of terms and language.

Examples:

Add definition for 'byte' (English)
Add definitions for 'agrégation', 'commentaire' (French)
Translate 5 terms (Spanish)
-->

Fill in each of the sections (using NA for those that are not applicable).

## Author: 

- Alette Schoon

## Language: 

- Afrikaans

## Terms defined:

- parametric statistics
- 
- 
