### PR TITLE
Update GitHub Workflows

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 name: Build and Deploy Glossary Website
 
@@ -23,7 +23,7 @@ jobs:
     - name: Deploy to site
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'zkamvar/glosario' }}
       uses: JamesIves/github-pages-deploy-action@v4
-      with: 
+      with:
         branch: site
         folder: _gh-site
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Deploy to site
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'carpentries/glosario' }}
-      uses: JamesIves/github-pages-deploy-action@4
+      uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: site
         folder: _gh-site

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2.3.1
+      uses: actions/checkout@v3
       with:
           persist-credentials: false
 
@@ -22,7 +22,8 @@ jobs:
 
     - name: Deploy to site
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'carpentries/glosario' }}
-      uses: JamesIves/github-pages-deploy-action@4.1.5
+      uses: JamesIves/github-pages-deploy-action@4
       with:
         branch: site
         folder: _gh-site
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -23,7 +23,7 @@ jobs:
       run: ls -alh _gh-site && ls -alh _gh-site/_data
 
     - name: Deploy to site
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'carpentries/glosario' }}
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'zkamvar/glosario' }}
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: site

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Deploy to site
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'zkamvar/glosario' }}
       uses: JamesIves/github-pages-deploy-action@v4
-      with:
+      with: 
         branch: site
         folder: _gh-site
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -4,8 +4,6 @@ name: Build and Deploy Glossary Website
 
 jobs:
   build-and-deploy:
-    permissions:
-      contents: write
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -4,6 +4,8 @@ name: Build and Deploy Glossary Website
 
 jobs:
   build-and-deploy:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -21,7 +21,7 @@ jobs:
       run: ls -alh _gh-site && ls -alh _gh-site/_data
 
     - name: Deploy to site
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'zkamvar/glosario' }}
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'carpentries/glosario' }}
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: site

--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -4,14 +4,13 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.8]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
## Problem

As noted in https://github.com/carpentries/glosario/issues/576#issuecomment-1702659711

The github pages workflow has not been running since August. After some inspection, this was due to a change in behaviour where the runner token was not detected during the build sometime after August 1.

## Solution

**please squash merge** this PR

I have fixed the pressing issue by adding a `token: ${{ secrets.GITHUB_TOKEN }}` to the `gh-pages-deploy-action`, which is automatically scoped to the type of run so that `pull_requests` do not have any write permissions (see [the automatic token documentation](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)). 

Here are the other changes I've implemented:

1. added the `workflow_dispatch` button to the build and deploy workflow so we can rebuild on the fly without adding a fake commit
2. update many of the actions to `@v3` so that we no longer get warnings about deprecated node versions
3. switch the JamesIves action to `@v4` so that we can benefit from security updates in that branch
