### PR TITLE
Update Gemfile to lock ffi to version < 1.17

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 
 gem "webrick", "~> 1.7"
+
+# Fix for mismatched deps: https://github.com/ffi/ffi/issues/1103
+gem "ffi", "< 1.17.0"


### PR DESCRIPTION
Site fails to build and deploy due to a mismatch in an underlying dependency (`ffi`). The suggested fix until alignment is to lock the ffi version: https://github.com/ffi/ffi/issues/1103