### PR TITLE
Translate "training data" to Ukrainian

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -9853,6 +9853,13 @@
       algorithm to recognise similar data. It should always be separated from the
       [test data](#test_data) to ensure that the model is properly tested with data it has
       never seen before.
+  uk:
+    term: "тренувальні дані"
+    def: >
+      Частина набору даних, яка використовується для тренування алгоритму 
+      [машинного навчання](#machine_learning), щоб розпізнувати схожі дані. 
+      Тренувальні дані завжди мають бути відокремлені від [тестових даних](#test_data), 
+      щоб гарантувати, що модель протестована на даних, які не використовувалися раніше.
 
 - slug: transitive_dependency
   en:


### PR DESCRIPTION
<!-- If you are adding terms, change the pull request title to mention the terms added and language, or if there are a lot of them, the number of terms and language.

Examples:

Add definition for 'byte' (English)
Add definitions for 'agrégation', 'commentaire' (French)
Translate 5 terms (Spanish)
-->

Fill in each of the sections (using NA for those that are not applicable).

## Author: 

- Oleksii Nazarenko

## Language: 

- Ukrainian

## Terms defined:

- training data