### PR TITLE
Add matomo self-hosted tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ assets/css/to_delete.css
 .DS_Store
 _config.yml
 _data/
+count.py

--- a/_includes/matomo.html
+++ b/_includes/matomo.html
@@ -8,11 +8,11 @@
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
     (function() {
-        var u="https://carpentries.matomo.cloud/";
+        var u="https://matomo.carpentries.org/";
         _paq.push(['setTrackerUrl', u+'matomo.php']);
         _paq.push(['setSiteId', '12']);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.async=true; g.src='//cdn.matomo.cloud/carpentries.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
-    })();
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
     </script>
     <!-- End Matomo Code -->


### PR DESCRIPTION
Update the cloud hosted matomo tracker to our self-hosted version