### PR TITLE
Fix missing first headings in some languages

### DIFF
--- a/_includes/glossary.html
+++ b/_includes/glossary.html
@@ -22,7 +22,7 @@ Display glossary in alphabetical order.
 Cross-references are displayed in __bold__ if that term is missing.
 {%- endcomment -%}
 <dl dir="auto">
-{% assign gloss_letter = "A" %}
+{% assign gloss_letter = "" %}
 {% assign headings = '' %}
 {%- for slug in actual -%}
   {% assign item = gloss | where: "slug", slug | first %}


### PR DESCRIPTION
This PR fixes https://github.com/carpentries/glosario/issues/741, where some languages were missing the first heading(s) for each start letter.
