### PR TITLE
Add crosslink for specificity, sensitivity and accuracy

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -3395,7 +3395,7 @@
       represents the predicted classes. For a binary classification model the confusion matrix
       gives the True Positives (TP), False Negatives (FN), False Positives (FP) and True Negatives
       (TN) in the 1st, 2nd, 3rd and 4th quadrants, respectively. The table can be used to calculate
-      Accuracy, Sensitivity and Specificity amongst other measures of the model.
+      Accuracy, Sensitivity and [Specificity](#specificity) amongst other measures of the model.
 
 - slug: constant
   en:

--- a/glossary.yml
+++ b/glossary.yml
@@ -3395,7 +3395,7 @@
       represents the predicted classes. For a binary classification model the confusion matrix
       gives the True Positives (TP), False Negatives (FN), False Positives (FP) and True Negatives
       (TN) in the 1st, 2nd, 3rd and 4th quadrants, respectively. The table can be used to calculate
-      Accuracy, Sensitivity and [Specificity](#specificity) amongst other measures of the model.
+      Accuracy, [Sensitivity](#sensitivity) and [Specificity](#specificity) amongst other measures of the model.
 
 - slug: constant
   en:

--- a/glossary.yml
+++ b/glossary.yml
@@ -3395,7 +3395,7 @@
       represents the predicted classes. For a binary classification model the confusion matrix
       gives the True Positives (TP), False Negatives (FN), False Positives (FP) and True Negatives
       (TN) in the 1st, 2nd, 3rd and 4th quadrants, respectively. The table can be used to calculate
-      Accuracy, [Sensitivity](#sensitivity) and [Specificity](#specificity) amongst other measures of the model.
+      [Accuracy](#accuracy), [Sensitivity](#sensitivity) and [Specificity](#specificity) amongst other measures of the model.
 
 - slug: constant
   en:


### PR DESCRIPTION
## Author: 
@sfmig

## Language: 
- en

## Terms defined:
Not actually defined, simply cross-linked:
- specificity
- sensitivity
- accuracy

This PR comes from trying to address #595, which raised that the definition of "specificity" was incorrect. This seems to be corrected now, but I added the crosslinks between the related terms.