### PR TITLE
Absolute error definition adapted from wolfram alpha

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -137,8 +137,8 @@
   en:
     term: "absolute error"
     def: >
-      The total value  of the difference between the observed and correct value.
-      The absolute error is typically less useful than [relative error](#relative_error).
+      The difference between the measured or inferred value of a quantity and its actual value, 
+      sometimes with the absolute value taken. 
   id:
     term: "kesalahan absolut"
     def: >


### PR DESCRIPTION
## Author: 
- @sfmig

## Language: 

- en

## Terms defined:

- Absolute error

I followed the suggestion from issue #267 and rephrased the definition to better match the one given by [Wolfram alpha](https://mathworld.wolfram.com/AbsoluteError.html#:~:text=The%20difference%20between%20the%20measured,sum%20of%20their%20absolute%20errors.)

I realise there are a few issues and discussions about this definition, feel free to edit and adapt this suggestion as needed!