### PR TITLE
Fix broken ref in openrefine entry

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -8276,7 +8276,7 @@
      
 - slug: openrefine
   ref:
-    - tidy data
+    - tidy_data
   en:
     term: "OpenRefine"
     def: >


### PR DESCRIPTION
Fixed a broken reference in the openrefine entry by changing "tidy data" to "tidy_data" in the ref field to fix the internal link.