### PR TITLE
Replace spaces with underscores in slug and ref fields

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -3438,7 +3438,7 @@
     def: >
       Діапазон, в якому з заданою ймовірністю знаходиться реальне значення оцінки.
   
-- slug: configuration file
+- slug: configuration_file
   en:
     term: "configuration file"
     def: >
@@ -9655,7 +9655,7 @@
     def: >
       Om volledige kolomme of rye in 'n tabel volgens naam of plek te kies (selekteer).
 
-- slug: selecting on the dependent variable bias
+- slug: selecting_on_the_dependent_variable_bias
   en:
     term: "selecting on the dependent variable bias"
     def: >
@@ -9963,11 +9963,11 @@
       For example, the proportion of people who do not have a disease that test negative.
       Calculated as Specificity = TN/(TN+FP).
 
-- slug: spectral analysis
+- slug: spectral_analysis
   ref:
     - python
-    - data analysis
-    - bayesian statistics
+    - data_analysis
+    - bayesian_statistics
   en:
     term: "spectral analysis"
     def: >


### PR DESCRIPTION
Replaced spaces with underscores in the following slugs:

1) configuration file → configuration_file

2) selecting on the dependent variable bias → selecting_on_the_dependent_variable_bias

3) spectral analysis → spectral_analysis


Replaced spaces with underscores in the following ref fields:

1) data analysis → data_analysis

2) bayesian statistics → bayesian_statistics

I’ve checked that the two slugs — data analysis and bayesian statistics — referenced in the spectral analysis entry don’t exist in the project.

