### PR TITLE
Move 'artificial_intelligence' entry to alphabetical position

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -1213,6 +1213,24 @@
       Обчислюється для набору з n чисел шляхом знаходження їх суми та ділення результату на n.
       [Див. також середнє значення](#mean).
 
+- slug: artificial_intelligence
+  ref:
+    - nlp
+    - machine_learning
+  en:
+    term: "artificial intelligence (AI)"
+    def: >
+      Intelligence demonstrated by machines, as opposed to humans or other animals. AI can be
+      exhibited through perceiving, synthesizing and inference of information. Example tasks include
+      [natural language processing](#nlp), computer vision, and [machine learning]
+      (#machine_learning).
+  uk:
+    term: "штучний інтелект (ШІ)"
+    def: >
+      Інтелект, який демонструють машини, на відміну від людей або інших тварин. ШІ може проявлятися
+      через сприйняття, синтезування та виведення інформації. Серед завдань можна виділити [обробку природної мови](#nlp),
+      комп'ютерний зір та [машинне навчання](#machine_learning).
+
 - slug: ascii
   en:
     term: "ASCII"
@@ -11223,24 +11241,6 @@
     def: >
       A branch of statistical tests which do not assume a known distribution of the population which the samples were taken from (Kruskal-Wallis and Dunn test are examples of non-parametric tests).
 
-
-- slug: artificial_intelligence
-  ref:
-    - nlp
-    - machine_learning
-  en:
-    term: "artificial intelligence (AI)"
-    def: >
-      Intelligence demonstrated by machines, as opposed to humans or other animals. AI can be
-      exhibited through perceiving, synthesizing and inference of information. Example tasks include
-      [natural language processing](#nlp), computer vision, and [machine learning]
-      (#machine_learning).
-  uk:
-    term: "штучний інтелект (ШІ)"
-    def: >
-      Інтелект, який демонструють машини, на відміну від людей або інших тварин. ШІ може проявлятися
-      через сприйняття, синтезування та виведення інформації. Серед завдань можна виділити [обробку природної мови](#nlp),
-      комп'ютерний зір та [машинне навчання](#machine_learning).
 
 - slug: cnn
   ref:


### PR DESCRIPTION
- Moved the 'artificial_intelligence' entry to an earlier position in the file to maintain proper alphabetical order.
- No changes made to the content of any entries.
