### PR TITLE
Add ML and data science terms for issue #1032

### DIFF
--- a/glossary.yml
+++ b/glossary.yml
@@ -1,11475 +1,13375 @@
 - slug: 68_95_997_rule
   de:
-    term: "68-95-99.7 Regel"
-    def: >
-      Drückt die Tatsache aus, dass 68% der Werte innerhalb einer
-      [Standardabweichung](#standard_deviation) vom Mittelwert liegen,
-      95% innerhalb von zwei und 99,7% innerhalb von drei. Umgekehrt
-      liegen etwa 0,3% der Werte in den meisten Fällen mehr als drei
-      Standardabweichungen über oder unterhalb des Mittelwerts.
-  en:
-    term: "68-95-99.7 rule"
-    def: >
-      Expresses the fact that 68% of values lie within one [standard
-      deviation](#standard_deviation) of the [mean](#mean), 95% lie within two, and
-      99.7% lie within three. Conversely, about 0.3% of values lie more than three
-      standard deviations above or below the mean in most cases.
-  id:
-    term: "Aturan 68-95-99.7"
-    def: >
-      Menyatakan fakta bahwa 68% berkisar di satu [standar deviasi](#standard_deviation)
-      dari mean(#mean), 95% berkisar di dua, dan 99.7% berkisar di tiga.
-      Sebaliknya, sekitar 0.3% berkisar lebih dari tiga standar deviasi
-      di atas atau di bawah mean dari kasus kebanyakan.
-  it:
-    term: "regola 68-95-99,7"
-    def: >
-      Esprime il fatto che il 68% dei valori si trova entro una [deviazione
-      standard](#standard_deviation) dalla [media](#mean), il 95% entro due deviazioni
-      standard e il 99,7% entro tre. Al contrario, circa lo 0,3% dei valori si trova oltre
-      tre deviazioni standard sopra o sotto la media.
-  af:
-    term: "68-95-99.7 reël"
-    def: >
-      Beskryf die beginsel dat 68% van alle waardes binne een
-      [standaardafwyking](#standard_deviation) van die [gemiddelde](#mean) val, 95%
-      val binne twee en 99.7% val binne drie standaardafwykings. Omgekeerd, in die
-      meeste gevalle val 0.3% van die waardes meer as drie standaardafwykings bo of
-      onder die gemiddelde.
-  es:
-    term: "regla 68-95-99.7"
-    def: >
-      Expresa el hecho de que el 68% de los valores se encuentran dentro de una
-      [desviación estándar](#standard_deviation) de la [media](#mean), el
-      95% está dentro de dos y el 99,7% está dentro de tres. Por el contrario,
-      aproximadamente el 0,3% de los valores se encuentran más de tres desviaciones
-      estándar por encima o por debajo de la media en la mayoría de los casos.
-  pt:
-    term: "regra 68-95-99,7"
-    def: >
-      Expressa o fato de que 68% dos valores estão dentro de um [desvio padrão](#standard_deviation)
-      da [média](#mean), 95% estão dentro de dois e 99,7% estão dentro de três. Inversamente,
-      aproximadamente 0,3% dos valores estão mais do que três desvios padrões acima ou abaixo da média
-      na maioria dos casos.
-  fr:
-    term: "règle de 68-95-99.7"
-    def: >
-      Exprime le fait que 68% des valeurs sont localisées à l'intérieur d'un (1)
-      [écart-type](#standard_deviation) de la [moyenne](#mean), 95% à l'intérieur de
-      deux (2) écarts-types, et 99,7% à l'intérieur de trois (3) écarts-types.
-      Inversement et dans la plupart des cas, environ 0.3% des valeurs
-      se situent à plus de 3 écarts-types au-dessus ou au-dessous de la moyenne.
-  ar:
-    term: "القاعدة ٩٩,٧-٩٥-٦٨"
-    def: >
-        يُعبِر عن حقيقة أن ٦٨٪ من القيم تقع ضمن وحدة واحدة من
-        [الانحراف المعياري](#standard_deviation)
-        من
-        [الوسط](#mean)
-        ، بينما ٩٥٪ تقع ضمن وحدتين،
-        و٩٩,٧٪ تقع ضمن ثلاث وحدات
-        بالمقابل ، حوالي ٠,٣ ٪  من القيم تقع  في أكثر من ثلاثة وحدات
-        من الانحرافات المعيارية أعلى أو أقل من المتوسط في معظم الحالات.
+    term: 68-95-99.7 Regel
+    def: 'Drückt die Tatsache aus, dass 68% der Werte innerhalb einer [Standardabweichung](#standard_deviation)
+      vom Mittelwert liegen, 95% innerhalb von zwei und 99,7% innerhalb von drei.
+      Umgekehrt liegen etwa 0,3% der Werte in den meisten Fällen mehr als drei Standardabweichungen
+      über oder unterhalb des Mittelwerts.
 
+      '
+  en:
+    term: 68-95-99.7 rule
+    def: 'Expresses the fact that 68% of values lie within one [standard deviation](#standard_deviation)
+      of the [mean](#mean), 95% lie within two, and 99.7% lie within three. Conversely,
+      about 0.3% of values lie more than three standard deviations above or below
+      the mean in most cases.
+
+      '
+  id:
+    term: Aturan 68-95-99.7
+    def: 'Menyatakan fakta bahwa 68% berkisar di satu [standar deviasi](#standard_deviation)
+      dari mean(#mean), 95% berkisar di dua, dan 99.7% berkisar di tiga. Sebaliknya,
+      sekitar 0.3% berkisar lebih dari tiga standar deviasi di atas atau di bawah
+      mean dari kasus kebanyakan.
+
+      '
+  it:
+    term: regola 68-95-99,7
+    def: 'Esprime il fatto che il 68% dei valori si trova entro una [deviazione standard](#standard_deviation)
+      dalla [media](#mean), il 95% entro due deviazioni standard e il 99,7% entro
+      tre. Al contrario, circa lo 0,3% dei valori si trova oltre tre deviazioni standard
+      sopra o sotto la media.
+
+      '
+  af:
+    term: 68-95-99.7 reël
+    def: 'Beskryf die beginsel dat 68% van alle waardes binne een [standaardafwyking](#standard_deviation)
+      van die [gemiddelde](#mean) val, 95% val binne twee en 99.7% val binne drie
+      standaardafwykings. Omgekeerd, in die meeste gevalle val 0.3% van die waardes
+      meer as drie standaardafwykings bo of onder die gemiddelde.
+
+      '
+  es:
+    term: regla 68-95-99.7
+    def: 'Expresa el hecho de que el 68% de los valores se encuentran dentro de una
+      [desviación estándar](#standard_deviation) de la [media](#mean), el 95% está
+      dentro de dos y el 99,7% está dentro de tres. Por el contrario, aproximadamente
+      el 0,3% de los valores se encuentran más de tres desviaciones estándar por encima
+      o por debajo de la media en la mayoría de los casos.
+
+      '
+  pt:
+    term: regra 68-95-99,7
+    def: 'Expressa o fato de que 68% dos valores estão dentro de um [desvio padrão](#standard_deviation)
+      da [média](#mean), 95% estão dentro de dois e 99,7% estão dentro de três. Inversamente,
+      aproximadamente 0,3% dos valores estão mais do que três desvios padrões acima
+      ou abaixo da média na maioria dos casos.
+
+      '
+  fr:
+    term: règle de 68-95-99.7
+    def: 'Exprime le fait que 68% des valeurs sont localisées à l''intérieur d''un
+      (1) [écart-type](#standard_deviation) de la [moyenne](#mean), 95% à l''intérieur
+      de deux (2) écarts-types, et 99,7% à l''intérieur de trois (3) écarts-types.
+      Inversement et dans la plupart des cas, environ 0.3% des valeurs se situent
+      à plus de 3 écarts-types au-dessus ou au-dessous de la moyenne.
+
+      '
+  ar:
+    term: القاعدة ٩٩,٧-٩٥-٦٨
+    def: 'يُعبِر عن حقيقة أن ٦٨٪ من القيم تقع ضمن وحدة واحدة من [الانحراف المعياري](#standard_deviation)
+      من [الوسط](#mean) ، بينما ٩٥٪ تقع ضمن وحدتين، و٩٩,٧٪ تقع ضمن ثلاث وحدات بالمقابل
+      ، حوالي ٠,٣ ٪  من القيم تقع  في أكثر من ثلاثة وحدات من الانحرافات المعيارية
+      أعلى أو أقل من المتوسط في معظم الحالات.
+
+      '
   am:
     term: 68-95-99.7 ደንብ
-    def: >
-      68% የሥነ-ምግባር እሴቶች በአንድ [መሥፈርት) ውስጥ እንደሚመደቡ ይገልፃሉ:: የ[ማለት](#mean)[standard deviation](#standard_deviation) 95% በሁለት ውስጥ ያርፋል፣ እና 99.7% በሶስት ውስጥ ያርፋል. በተቃራኒው ደግሞ 0.3% ገደማ የሚሆኑት እሴቶች ከሦስት በላይ ናቸው አብዛኛውን ጊዜ ከዚያ በላይ ወይም ከዚያ በታች ያሉደረጃዎች።
+    def: '68% የሥነ-ምግባር እሴቶች በአንድ [መሥፈርት) ውስጥ እንደሚመደቡ ይገልፃሉ:: የ[ማለት](#mean)[standard
+      deviation](#standard_deviation) 95% በሁለት ውስጥ ያርፋል፣ እና 99.7% በሶስት ውስጥ ያርፋል. በተቃራኒው
+      ደግሞ 0.3% ገደማ የሚሆኑት እሴቶች ከሦስት በላይ ናቸው አብዛኛውን ጊዜ ከዚያ በላይ ወይም ከዚያ በታች ያሉደረጃዎች።
 
+      '
 - slug: abandonware
   bn:
-    term: "বিসর্জনকৃত সফটওয়্যার"
-    def: >
-      যে সফটওয়্যার আর সক্রিয়ভাবে রক্ষনাবেক্ষন করা হচ্ছেনা।
+    term: বিসর্জনকৃত সফটওয়্যার
+    def: 'যে সফটওয়্যার আর সক্রিয়ভাবে রক্ষনাবেক্ষন করা হচ্ছেনা।
+
+      '
   de:
-    term: "Abandonware"
-    def: >
-      Software die nicht länger weiterentwickelt wird.
+    term: Abandonware
+    def: 'Software die nicht länger weiterentwickelt wird.
+
+      '
   en:
-    term: "abandonware"
-    def: >
-      Software that is no longer being maintained.
+    term: abandonware
+    def: 'Software that is no longer being maintained.
+
+      '
   id:
-    term: "abandonware"
-    def: >
-      Perangkat lunak yang sudah tidak dikelola.
+    term: abandonware
+    def: 'Perangkat lunak yang sudah tidak dikelola.
+
+      '
   pt:
-    term: "abandonware"
-    def: >
-      Software que não é mais mantido.
+    term: abandonware
+    def: 'Software que não é mais mantido.
+
+      '
   af:
-    term: "afgooiware"
-    def: >
-      Sagteware wat nie meer onderhou word nie.
+    term: afgooiware
+    def: 'Sagteware wat nie meer onderhou word nie.
+
+      '
   es:
-    term: "abandonware"
-    def: >
-      Software cuyo mantenimiento ha sido abandonado.
+    term: abandonware
+    def: 'Software cuyo mantenimiento ha sido abandonado.
+
+      '
   fr:
-    term: "abandonware"
-    def: >
-      Un logiciel qui n'est plus maintenu.
+    term: abandonware
+    def: 'Un logiciel qui n''est plus maintenu.
+
+      '
   ar:
-    term: "البرمجيات المهجورة أو المتروكة"
-    def: >
-      هي البرامج التى لايتوفر لها دعم من أي برمجيات أُخرى
-      ولم تعد على قيد الصيانة.
+    term: البرمجيات المهجورة أو المتروكة
+    def: 'هي البرامج التى لايتوفر لها دعم من أي برمجيات أُخرى ولم تعد على قيد الصيانة.
+
+      '
   am:
     term: የተተወው ዌር
-    def: >
-      ከአሁን በኋላ እየተስተካከለ ያለው ዌር።
-  tn:
-    term: "Matlotla"
-    def: >
-      Serweboleta (software) se se sa tlholeng se tlhokomelwa kgotsa se tlhabololwa.
-  it:
-    term: "abandonware"
-    def: >
-      "Un software abbandonato, non più mantenuto"
+    def: 'ከአሁን በኋላ እየተስተካከለ ያለው ዌር።
 
+      '
+  tn:
+    term: Matlotla
+    def: 'Serweboleta (software) se se sa tlholeng se tlhokomelwa kgotsa se tlhabololwa.
+
+      '
+  it:
+    term: abandonware
+    def: '"Un software abbandonato, non più mantenuto"
+
+      '
 - slug: absolute_error
   de:
-    term: "Absoluter Fehler"
-    def: >
-      Der absolute Wert der Differenz zwischen dem beobachteten und
-      dem korrekten Wert. Der absolute Fehler ist normalerweise
-      weniger nützlich als der [relative Fehler](#relative_error).
+    term: Absoluter Fehler
+    def: 'Der absolute Wert der Differenz zwischen dem beobachteten und dem korrekten
+      Wert. Der absolute Fehler ist normalerweise weniger nützlich als der [relative
+      Fehler](#relative_error).
+
+      '
   en:
-    term: "absolute error"
-    def: >
-      The difference between the measured or inferred value of a quantity and its actual value, 
-      sometimes with the absolute value taken. 
+    term: absolute error
+    def: "The difference between the measured or inferred value of a quantity and\
+      \ its actual value,  sometimes with the absolute value taken. \n"
   id:
-    term: "kesalahan absolut"
-    def: >
-      Nilai absolut dari perbedaan nilai yang diobservasi dan nilai yang benar.
-      Kesalahan absolut seringkali tidak terlalu berguna daripada
-      [kesalahan relatif](#relative_error).
+    term: kesalahan absolut
+    def: 'Nilai absolut dari perbedaan nilai yang diobservasi dan nilai yang benar.
+      Kesalahan absolut seringkali tidak terlalu berguna daripada [kesalahan relatif](#relative_error).
+
+      '
   it:
-    term: "errore assoluto"
-    def: >
-      La differenza in valore assoluto tra il valore osservato e il valore corretto.
-      L'errore assoluto è in genere meno utile dell'[errore relativo](#relative_error).
+    term: errore assoluto
+    def: 'La differenza in valore assoluto tra il valore osservato e il valore corretto.
+      L''errore assoluto è in genere meno utile dell''[errore relativo](#relative_error).
+
+      '
   es:
-    term: "error absoluto"
-    def: >
-      El valor absoluto de la diferencia entre el valor observado y el valor correcto.
+    term: error absoluto
+    def: 'El valor absoluto de la diferencia entre el valor observado y el valor correcto.
       El error absoluto suele ser menos útil que el [error relativo](#relative_error).
+
+      '
   af:
-    term: "absolute fout"
-    def: >
-      Die absolute fout is die absolute waarde van die verskil tussen die waargenome-
-      en die korrekte waarde. Die absolute fout is gewoonlik van minder waarde as die
-      [relatiewe](#relative_error) fout.
+    term: absolute fout
+    def: 'Die absolute fout is die absolute waarde van die verskil tussen die waargenome-
+      en die korrekte waarde. Die absolute fout is gewoonlik van minder waarde as
+      die [relatiewe](#relative_error) fout.
+
+      '
   pt:
-    term: "erro absoluto"
-    def: >
-      O valor absoluto da diferença entre um valor observado e o valor correto. O erro
-      absoluto é normalmente menos útil do que o [erro relativo](#relative_error).
+    term: erro absoluto
+    def: 'O valor absoluto da diferença entre um valor observado e o valor correto.
+      O erro absoluto é normalmente menos útil do que o [erro relativo](#relative_error).
+
+      '
   fr:
-    term: "erreur absolue"
-    def: >
-      La valeur absolue de la différence entre la valeur observée et la valeur
-      correcte. L'erreur absolue est généralement moins pertinente que l'[erreur relative](#relative_error).
+    term: erreur absolue
+    def: 'La valeur absolue de la différence entre la valeur observée et la valeur
+      correcte. L''erreur absolue est généralement moins pertinente que l''[erreur
+      relative](#relative_error).
+
+      '
   ar:
-    term: "الخطأ المُطلق"
-    def: >
-      هو عبارة عن القيمة المطلقة للفرق بين القيمة المرصودة والقيمة الواقعية الصحيحة،
-      مع العِلم أن
-      الخطأ المُطلق عادة مايكون أقل فائدة من
-      [الخطأ النسبي](#relative_error).
+    term: الخطأ المُطلق
+    def: 'هو عبارة عن القيمة المطلقة للفرق بين القيمة المرصودة والقيمة الواقعية الصحيحة،
+      مع العِلم أن الخطأ المُطلق عادة مايكون أقل فائدة من [الخطأ النسبي](#relative_error).
+
+      '
   am:
     term: ፍጹም ስህተት
-    def: >
-      በተመለከተው እና በትክክለኛው እሴት መካከል ያለው ልዩነት ፍጹም እሴት። ፍፁም ስህተት አብዛኛውን ጊዜ ከ [አንፃራዊ ስህተት](#relative_error) ያነሰ ጠቀሜታ አለው ፡፡
-  sw:
-    term: "ukubwa wa nambari ya ukosefu "
-    def: >
-      Ukubwa wa hesabu ya kutoa jibu umepata kutoka jibu sahihi.
-      Dhani ingine kama hii, ni [uwiano wa ukosefu](#relative_error).
+    def: 'በተመለከተው እና በትክክለኛው እሴት መካከል ያለው ልዩነት ፍጹም እሴት። ፍፁም ስህተት አብዛኛውን ጊዜ ከ [አንፃራዊ
+      ስህተት](#relative_error) ያነሰ ጠቀሜታ አለው ፡፡
 
+      '
+  sw:
+    term: 'ukubwa wa nambari ya ukosefu '
+    def: 'Ukubwa wa hesabu ya kutoa jibu umepata kutoka jibu sahihi. Dhani ingine
+      kama hii, ni [uwiano wa ukosefu](#relative_error).
+
+      '
 - slug: absolute_path
   ref:
-    - relative_path
+  - relative_path
   en:
-    term: "absolute path"
-    def: >
-      A path that points to the same location in a [filesystem](#filesystem)
-      regardless of where it is evaluated. An absolute path is the equivalent of
-      latitude and longitude in geography.
+    term: absolute path
+    def: 'A path that points to the same location in a [filesystem](#filesystem) regardless
+      of where it is evaluated. An absolute path is the equivalent of latitude and
+      longitude in geography.
+
+      '
   id:
-    term: "path absolut"
-    def: >
-      Sebuah path yang menunjukkan lokasi dalam [filesystem](#filesystem) terlepas
-      dari lokasi program dijalanakn. Path absolut sama dengan garis lintang dan
-      garis bujur dalam geografi.
+    term: path absolut
+    def: 'Sebuah path yang menunjukkan lokasi dalam [filesystem](#filesystem) terlepas
+      dari lokasi program dijalanakn. Path absolut sama dengan garis lintang dan garis
+      bujur dalam geografi.
+
+      '
   de:
-    term: "absoluter Pfad"
-    def: >
-      Der absolute Pfad zeigt auf die gleiche Position im [filesystem](#filesystem),
+    term: absoluter Pfad
+    def: 'Der absolute Pfad zeigt auf die gleiche Position im [filesystem](#filesystem),
       unabhängig davon, wo er ausgewertet wird. Der absolute Pfad entspricht in der
       Geographie der Angabe von Längen- und Breitengrad.
+
+      '
   af:
-    term: "absolute roete"
-    def: >
-      'n Roete wat dieselfde posisie in die [lêerstelsel](#filesystem) aandui ongeag
-      die posisie vanwaar dit geëvalueer word. Die absolute roete is die ekwivalent
+    term: absolute roete
+    def: '''n Roete wat dieselfde posisie in die [lêerstelsel](#filesystem) aandui
+      ongeag die posisie vanwaar dit geëvalueer word. Die absolute roete is die ekwivalent
       van lengtegraad en breedtegraad in geografie.
+
+      '
   fr:
-    term: "chemin d'accès absolu"
-    def: >
-      Un chemin d'accès absolu indique la même position dans le système de fichier
-      quel que soit l'emplacement où il est evalué. Un chemin d'accès absolu est
-      l'équivalent de la latitude et longitude en géographie.
+    term: chemin d'accès absolu
+    def: 'Un chemin d''accès absolu indique la même position dans le système de fichier
+      quel que soit l''emplacement où il est evalué. Un chemin d''accès absolu est
+      l''équivalent de la latitude et longitude en géographie.
+
+      '
   es:
-    term: "ruta absoluta"
-    def: >
-      Una ruta que dirige a la misma ubicación en el sistema de archivos
-      independientemente del contexto donde sea evaluada. Una ruta absoluta es el
-      equivalente a la latitud y longitud en geografía.
+    term: ruta absoluta
+    def: 'Una ruta que dirige a la misma ubicación en el sistema de archivos independientemente
+      del contexto donde sea evaluada. Una ruta absoluta es el equivalente a la latitud
+      y longitud en geografía.
+
+      '
   pt:
-    term: "caminho absoluto"
-    def: >
-      Um caminho que leva ao mesmo local no sistema de arquivos independente do
-      contexto em que é avaliado. Um caminho absoluto pode ser comparado com a
-      latitude e longitude em geografia.
+    term: caminho absoluto
+    def: 'Um caminho que leva ao mesmo local no sistema de arquivos independente do
+      contexto em que é avaliado. Um caminho absoluto pode ser comparado com a latitude
+      e longitude em geografia.
+
+      '
   ar:
-    term: "المسار المُطلق"
-    def: >
-      المسار الذي يُشير إلى ذات الموقع في
-      [نظام الملفات](#filesystem)،
-      بغض النظر عن مكان تقييمها،
-      وللتبسيط يمكن أن يُقال أن
-      المسار المُطلق يُعادل خطوط الطول والعرض في الجغرافيا.
-
-        المسار الذي يُشير إلى ذات الموقع في
-        [نظام الملفات](#filesystem)،
-        بغض النظر عن مكان تقييمها،
-        وللتبسيط يمكن أن يُقال أن
-        المسار المُطلق يُعادل خطوط الطول والعرض في الجغرافيا.
+    term: المسار المُطلق
+    def: "المسار الذي يُشير إلى ذات الموقع في [نظام الملفات](#filesystem)، بغض النظر\
+      \ عن مكان تقييمها، وللتبسيط يمكن أن يُقال أن المسار المُطلق يُعادل خطوط الطول\
+      \ والعرض في الجغرافيا.\n\n  المسار الذي يُشير إلى ذات الموقع في\n  [نظام الملفات](#filesystem)،\n\
+      \  بغض النظر عن مكان تقييمها،\n  وللتبسيط يمكن أن يُقال أن\n  المسار المُطلق\
+      \ يُعادل خطوط الطول والعرض في الجغرافيا.\n"
   uk:
-    term: "абсолютний шлях"
-    def: >
-      Шлях, який вказує на одне й теж саме місце у [файловій системі](#filesystem) 
-      незалежно від поточного розташування. Абсолютний шлях є 
-      аналогом широти та довготи в географії.
-  el:
-    term: "απόλυτο μονοπάτι"
-    def: >
-      Ένα μονοπάτι (path) που δείχνει στην ίδια τοποθεσία στο [σύστημα αρχείων](#filesystem)
-      ανεξάρτητα από το πού αξιολογείται. Ένα απόλυτο μονοπάτι ισοδυναμεί με
-      το γεωγραφικό πλάτος και το γεωγραφικό μήκος στην γεωγραφία.
+    term: абсолютний шлях
+    def: 'Шлях, який вказує на одне й теж саме місце у [файловій системі](#filesystem)  незалежно
+      від поточного розташування. Абсолютний шлях є  аналогом широти та довготи в
+      географії.
 
+      '
+  el:
+    term: απόλυτο μονοπάτι
+    def: 'Ένα μονοπάτι (path) που δείχνει στην ίδια τοποθεσία στο [σύστημα αρχείων](#filesystem)
+      ανεξάρτητα από το πού αξιολογείται. Ένα απόλυτο μονοπάτι ισοδυναμεί με το γεωγραφικό
+      πλάτος και το γεωγραφικό μήκος στην γεωγραφία.
+
+      '
   am:
     term: ፍጹም መንገድ
     def: በ [የፋይል ስርዓት ውስጥ ወደ ተመሳሳይ ሥፍራ የሚጠቁም መንገድ የሚገመገምበት ቦታ ምንም ይሁን ምን ፡፡ ፍፁም ጎዳና
       እኩል ነው ጂኦግራፊ ውስጥ ኬክሮስ እና ኬንትሮስ
   it:
-    term: "percorso assoluto del file"
-    def: >
-      Un percorso a un file che punta allo stesso luogo nel [filesystem](#filesystem)
-      indipendentemente da dove venga valutato. Un percorso assoluto del file è
-      l'equivalente di latitudine e longitudine in geografia.
+    term: percorso assoluto del file
+    def: 'Un percorso a un file che punta allo stesso luogo nel [filesystem](#filesystem)
+      indipendentemente da dove venga valutato. Un percorso assoluto del file è l''equivalente
+      di latitudine e longitudine in geografia.
 
+      '
 - slug: absolute_row_number
   de:
-    term: "Absolute Zeilennummer"
-    def: >
-      Der sequentielle Index einer Zeile in einer Tabelle, unabhängig
-      davon, welche Abschnitte der Tabelle angezeigt werden.
-  en:
-    term: "absolute row number"
-    def: >
-      The sequential index of a row in a table, regardless of what section of the
-      table is being displayed.
-  id:
-    term: "nomor baris absolut"
-    def: >
-      Indeks berurutan dari sebuah baris dalam tabel, terlepas dari bagian apa
-      dari tabel yang ditampilkan.
-  af:
-    term: "absolute rynommer"
-    def: >
-      Die opeenvolgende indeks van 'n ry in 'n tabel, ongeag die gedeelte van die
-      tabel wat vertoon word.
-  es:
-    term: "número de fila absoluto"
-    def: >
-      El índice secuencial que indentifica una fila en un tablero, sin importar qué
-      secciones se estén mostrando.
-  pt:
-    term: "número de linha absoluto"
-    def: >
-      O índice sequencial de uma linha em uma tabela, independente de qual seção da
-      tabela está sendo exibida.
-  he:
-    term: "מספר שורה מוחלט"
-    def: >
-      המספר הסידורי של שורה בטבלה, ללא קשר לאילו חלקים של הטבלה מוצגים
-  ar:
-    term: "رقم الصف المُطلق"
-    def: >
-      هو الفهرس المتسلسل لصف في جدول، بغض النظر عن أي قسم من اقسام الجدول يتم عرضها.
+    term: Absolute Zeilennummer
+    def: 'Der sequentielle Index einer Zeile in einer Tabelle, unabhängig davon, welche
+      Abschnitte der Tabelle angezeigt werden.
 
+      '
+  en:
+    term: absolute row number
+    def: 'The sequential index of a row in a table, regardless of what section of
+      the table is being displayed.
+
+      '
+  id:
+    term: nomor baris absolut
+    def: 'Indeks berurutan dari sebuah baris dalam tabel, terlepas dari bagian apa
+      dari tabel yang ditampilkan.
+
+      '
+  af:
+    term: absolute rynommer
+    def: 'Die opeenvolgende indeks van ''n ry in ''n tabel, ongeag die gedeelte van
+      die tabel wat vertoon word.
+
+      '
+  es:
+    term: número de fila absoluto
+    def: 'El índice secuencial que indentifica una fila en un tablero, sin importar
+      qué secciones se estén mostrando.
+
+      '
+  pt:
+    term: número de linha absoluto
+    def: 'O índice sequencial de uma linha em uma tabela, independente de qual seção
+      da tabela está sendo exibida.
+
+      '
+  he:
+    term: מספר שורה מוחלט
+    def: 'המספר הסידורי של שורה בטבלה, ללא קשר לאילו חלקים של הטבלה מוצגים
+
+      '
+  ar:
+    term: رقم الصف المُطلق
+    def: 'هو الفهرس المتسلسل لصف في جدول، بغض النظر عن أي قسم من اقسام الجدول يتم
+      عرضها.
+
+      '
   am:
     term: ፍጹም ረድፍ ቁጥር
     def: የትኞቹም ክፍሎች ቢኖሩ በሠንጠረዥ ውስጥ የአንድ ረድፍ ቅደም ተከተል ማውጫ ጠረጴዛ እየታየ ነው ፡፡
   it:
-    term: "numero di riga assoluto"
-    def: >
-      Indice sequenziale di una riga in una tabella, indipendetemente da quale sezione
-      della tabella sia visualizzata.
+    term: numero di riga assoluto
+    def: 'Indice sequenziale di una riga in una tabella, indipendetemente da quale
+      sezione della tabella sia visualizzata.
 
+      '
   fr:
-    term: "numéro de ligne absolu"
-    def: >
-      L'index séquentiel d'une ligne dans une table, quelles que soient les sections de la table affichées.
+    term: numéro de ligne absolu
+    def: 'L''index séquentiel d''une ligne dans une table, quelles que soient les
+      sections de la table affichées.
 
+      '
   el:
-    term: "απόλυτος αριθμός σειράς"
-    def: >
-      Το διαδοχικό ευρετήριο (index) μιας γραμμής σε έναν πίνακα, ανεξάρτητα από το ποια τμήματα
-      του πίνακα εμφανίζονται.
+    term: απόλυτος αριθμός σειράς
+    def: 'Το διαδοχικό ευρετήριο (index) μιας γραμμής σε έναν πίνακα, ανεξάρτητα από
+      το ποια τμήματα του πίνακα εμφανίζονται.
 
+      '
 - slug: abstract_method
   de:
-    term: "Abstrakte Methode"
-    def: >
-      In der [objektorientierten Programmierung](#oop) eine
-      [Methode](#method), die zwar definiert, aber nicht implementiert
-      ist. Programmierer definieren eine abstrakte Methode in einer
-      [übergeordneten Klasse](#parent_class), um Operationen zu
-      spezifizieren, die die [untergeordneten Klassen](#child_class)
-      bereitstellen müssen.
+    term: Abstrakte Methode
+    def: 'In der [objektorientierten Programmierung](#oop) eine [Methode](#method),
+      die zwar definiert, aber nicht implementiert ist. Programmierer definieren eine
+      abstrakte Methode in einer [übergeordneten Klasse](#parent_class), um Operationen
+      zu spezifizieren, die die [untergeordneten Klassen](#child_class) bereitstellen
+      müssen.
+
+      '
   en:
-    term: "abstract method"
-    def: >
-      It is used in [object-oriented programming](#oop) and is a [method](#method) that is defined but
-      not implemented. Programmers will define an abstract method in a [parent
-      class](#parent_class) to specify operations that [child classes](#child_class)
+    term: abstract method
+    def: 'It is used in [object-oriented programming](#oop) and is a [method](#method)
+      that is defined but not implemented. Programmers will define an abstract method
+      in a [parent class](#parent_class) to specify operations that [child classes](#child_class)
       must provide.
+
+      '
   es:
-    term: "método abstracto"
-    def: >
-      En [programación orientada a objectos](#oop), es un [método](#method) definido pero no implementado.
-      Programadores definen un método abstracto en una [superclase](#parent_class) para especificar operaciones
-      que las [subclases](#child_class) deberán proveer.
+    term: método abstracto
+    def: 'En [programación orientada a objectos](#oop), es un [método](#method) definido
+      pero no implementado. Programadores definen un método abstracto en una [superclase](#parent_class)
+      para especificar operaciones que las [subclases](#child_class) deberán proveer.
+
+      '
   id:
-    term: "metode abstrak"
-    def: >
-      Dalam [pemrograman berorientasi objek](#oop), sebuah [metode](#method)
-      yang didefinisikan tapi tidak diimplementasikan. Pemrogram akan mendefinisikan
-      metode abstrak dalam [parent class](#parent_class) untuk menspesifikasikan operasi
+    term: metode abstrak
+    def: 'Dalam [pemrograman berorientasi objek](#oop), sebuah [metode](#method) yang
+      didefinisikan tapi tidak diimplementasikan. Pemrogram akan mendefinisikan metode
+      abstrak dalam [parent class](#parent_class) untuk menspesifikasikan operasi
       yang harus dimiliki oleh [child classes](#child_class).
+
+      '
   af:
-    term: "abstrakte metode"
-    def: >
-      'n [Metode](#method), in [objekgeoriënteerde programmering](#oop), wat
-      gedefiniëer maar nie geïmplementeer is nie. Programmeerders sal 'n abstrakte
-      metode in 'n [voorsaatklas](#parent_class) definiëer wat in
-      [nasaatklasse](#child_class) geïmplementeer moet word.
+    term: abstrakte metode
+    def: '''n [Metode](#method), in [objekgeoriënteerde programmering](#oop), wat
+      gedefiniëer maar nie geïmplementeer is nie. Programmeerders sal ''n abstrakte
+      metode in ''n [voorsaatklas](#parent_class) definiëer wat in [nasaatklasse](#child_class)
+      geïmplementeer moet word.
+
+      '
   pt:
-    term: "método abstrato"
-    def: >
-      In [programação orientada a objetos](#oop), um [método](#method) que é definido
-      mas não implementado. Pessoas programadoras definem um método abstrato em uma [classe base](#parent_class)
-      para especificar operações que as [classes derivadas](#child_class) devem prover.
+    term: método abstrato
+    def: 'In [programação orientada a objetos](#oop), um [método](#method) que é definido
+      mas não implementado. Pessoas programadoras definem um método abstrato em uma
+      [classe base](#parent_class) para especificar operações que as [classes derivadas](#child_class)
+      devem prover.
+
+      '
   ar:
-    term: "الطريقة المجردة"
-    def: >
-      الطريقة المجردة هو تعبير يُتخدم
-      في
-      [البرمجة الشيئية](#oop)
-      ،
-      هذه
-       [الطريقة](#method)
-      يتم تعريفها ولكن لم لايتم تنفيذها،
-      بمعنى آخر، المبرمجون يُعرِفون عادة طريقة مجردة في
-      [الفئه الرئيسية](#parent_class)
-      لتحديد العمليات التي يجب أن تقدمها
-      [الفئات الفرعية](#child_class).
+    term: الطريقة المجردة
+    def: "الطريقة المجردة هو تعبير يُتخدم في [البرمجة الشيئية](#oop) ، هذه\n [الطريقة](#method)\n\
+      يتم تعريفها ولكن لم لايتم تنفيذها، بمعنى آخر، المبرمجون يُعرِفون عادة طريقة\
+      \ مجردة في [الفئه الرئيسية](#parent_class) لتحديد العمليات التي يجب أن تقدمها\
+      \ [الفئات الفرعية](#child_class).\n"
   am:
     term: abstract method
-    def: >
-      "በ [ነገር-ተኮር መርሃግብር](#oop) ውስጥ አንድ [ዘዴ](#method) ተገልፇል ነገር ግን አልተተገበረም ፡፡
+    def: '"በ [ነገር-ተኮር መርሃግብር](#oop) ውስጥ አንድ [ዘዴ](#method) ተገልፇል ነገር ግን አልተተገበረም ፡፡
       መርሃግብሮች [ወላጅ] ውስጥ ረቂቅ ዘዴን ይገልፃሉ ክፍል](#parent_class) [የህፃናት ክፍሎች](#child_class)
       ማቅረብ አለበት ፡፡ "
-  fr:
-    term: "méthode abstraite"
-    def: >
-      En programmation orientée objet, une méthode définie mais non implémentée. Les programmeurs définissent une méthode abstraite dans une classe parente pour spécifier les opérations que les classes enfants doivent fournir.
-  it:
-    term: "metodo astratto"
-    def: >
-      In [programmazione orientata agli oggetti](#oop), un [metodo](#method) che è
-      definito ma non implementato. Il programmatore definisce un metodo astratto in
-      una [classe padre](#parent_class) per specificare delle operazioni che la
-      [classe figlia](#child_class) deve implementare.
-  el:
-    term: "αφηρημένη μέθοδος"
-    def: >
-      Στον [αντικειμενοστραφή προγραμματισμό](#oop), μια [μέθοδος](#method) που ορίζεται αλλά
-       δεν εφαρμόζεται. Οι προγραμματιστές θα ορίσουν μια αφηρημένη μέθοδο σε μια [γονεϊκή
-       κλάση](#parent_class) για να καθορίσουν διαδικασίες που οι [θυγατρικές κλάσεις](#child_class)
-       πρέπει να παρέχουν.
 
+      '
+  fr:
+    term: méthode abstraite
+    def: 'En programmation orientée objet, une méthode définie mais non implémentée.
+      Les programmeurs définissent une méthode abstraite dans une classe parente pour
+      spécifier les opérations que les classes enfants doivent fournir.
+
+      '
+  it:
+    term: metodo astratto
+    def: 'In [programmazione orientata agli oggetti](#oop), un [metodo](#method) che
+      è definito ma non implementato. Il programmatore definisce un metodo astratto
+      in una [classe padre](#parent_class) per specificare delle operazioni che la
+      [classe figlia](#child_class) deve implementare.
+
+      '
+  el:
+    term: αφηρημένη μέθοδος
+    def: "Στον [αντικειμενοστραφή προγραμματισμό](#oop), μια [μέθοδος](#method) που\
+      \ ορίζεται αλλά\n δεν εφαρμόζεται. Οι προγραμματιστές θα ορίσουν μια αφηρημένη\
+      \ μέθοδο σε μια [γονεϊκή\n κλάση](#parent_class) για να καθορίσουν διαδικασίες\
+      \ που οι [θυγατρικές κλάσεις](#child_class)\n πρέπει να παρέχουν.\n"
 - slug: abstract_syntax_tree
   en:
-    term: "abstract syntax tree"
-    acronym: "AST"
-    def: >
-      A deeply nested data structure, or [tree](#tree), that represents the structure
+    term: abstract syntax tree
+    acronym: AST
+    def: 'A deeply nested data structure, or [tree](#tree), that represents the structure
       of a program. For example, the AST might have a [node](#node) representing a
       [`while` loop](#while_loop) with one [child](#child_tree) representing the loop
       condition and another representing the [loop body](#loop_body).
+
+      '
   id:
-    term: "abstract syntax tree"
-    acronym: "AST"
-    def: >
-      Sebuah struktur data bersarang, atau [tree](#tree), yang merepresentasikan struktur
-      dari sebuah program. Sebagai contoh, AST bisa jadi memiliki sebuah (node)[#node]
-      merepresentasikan sebuah [`while` loop](#while_loop) degan sebuah [child](#child_tree)
-      merepresentasikan kondisi loop dan yang lain merepresentasikan [loop body](#loop_body).
+    term: abstract syntax tree
+    acronym: AST
+    def: 'Sebuah struktur data bersarang, atau [tree](#tree), yang merepresentasikan
+      struktur dari sebuah program. Sebagai contoh, AST bisa jadi memiliki sebuah
+      (node)[#node] merepresentasikan sebuah [`while` loop](#while_loop) degan sebuah
+      [child](#child_tree) merepresentasikan kondisi loop dan yang lain merepresentasikan
+      [loop body](#loop_body).
+
+      '
   af:
-    term: "abstrakte sintaksisontledingsboom"
-    def: >
-      'n Diepgeneste datastruktuur, of [boom](#tree), wat die struktuur van 'n program
-      verteenwoordig. Byvoorbeeld, as die abstrakte sintaksontledingsboom 'n
-      [nodus](#node) het wat 'n [`doen` terwyl-lus](#while_loop) verteenwoordig wat
-      met een [naasaatontledingsboom](#child_tree) die lustoestand verteenwoordig en
-      'n ander nasaatontledingsboom wat die [lusraam](#loop_body) verteenwoordig.
+    term: abstrakte sintaksisontledingsboom
+    def: '''n Diepgeneste datastruktuur, of [boom](#tree), wat die struktuur van ''n
+      program verteenwoordig. Byvoorbeeld, as die abstrakte sintaksontledingsboom
+      ''n [nodus](#node) het wat ''n [`doen` terwyl-lus](#while_loop) verteenwoordig
+      wat met een [naasaatontledingsboom](#child_tree) die lustoestand verteenwoordig
+      en ''n ander nasaatontledingsboom wat die [lusraam](#loop_body) verteenwoordig.
+
+      '
   am:
     term: ረቂቅ አገባብ ዛፍ
-    def: >
-      አወቃቀሩን የሚወክል በጥልቀት የተቀመጠ የውሂብ መዋቅር ወይም [ዛፍ](#tree)ፕሮግራም ለምሳሌ ፣ AST ሀ ን የሚወክል [መስቀለኛ መንገድ](#node) ሊኖረው ይችላል ["while` loop](#while_loop) ከአንድ [ልጅ](#child_tree) ጋር ሁኔታ እና ሌላ የ [loop አካል](#loop_body)።
+    def: 'አወቃቀሩን የሚወክል በጥልቀት የተቀመጠ የውሂብ መዋቅር ወይም [ዛፍ](#tree)ፕሮግራም ለምሳሌ ፣ AST ሀ ን የሚወክል
+      [መስቀለኛ መንገድ](#node) ሊኖረው ይችላል ["while` loop](#while_loop) ከአንድ [ልጅ](#child_tree)
+      ጋር ሁኔታ እና ሌላ የ [loop አካል](#loop_body)።
 
+      '
 - slug: accuracy
   en:
-    term: "accuracy"
-    def: >
-      Accuracy measures how close results are to the true or known value.
-      A statistical measure of a classification model which gives the proportion
-      of correct predictions among a total number of cases. It is calculated as
-      Accuracy = (TP+TN)/(TP+TN+FP+FN).
+    term: accuracy
+    def: 'Accuracy measures how close results are to the true or known value. A statistical
+      measure of a classification model which gives the proportion of correct predictions
+      among a total number of cases. It is calculated as Accuracy = (TP+TN)/(TP+TN+FP+FN).
 
-      - TP = True Positive
-      - FP = False Positive
-      - FN = False Negative
-      - TN = True Negative
+      - TP = True Positive - FP = False Positive - FN = False Negative - TN = True
+      Negative
 
-      Accuracy and precision are both ways to measure results. Accuracy measures how close results are
-      to the true or known value. Precision, on the other hand, measures how close results are to one another.
+      Accuracy and precision are both ways to measure results. Accuracy measures how
+      close results are to the true or known value. Precision, on the other hand,
+      measures how close results are to one another.
+
+      '
   es:
-    term: "precisión"
-    def: >
-      Medida estadística de un modelo de clasificación que da la proporción
-      de predicciones correctas entre el número total de casos.
-      Se calcula como Precisión = (TP+TN)/(TP+TN+FP+FN)
-  sw:
-    term: "usahihi"
-    def: >
-      Kipimo cha takwimu cha muundo wa uainishaji ambao hutoa uwiano
-      ya utabiri sahihi kati ya jumla ya idadi ya kesi. Imehesabiwa kama
-      Usahihi = (TP+TN)/(TP+TN+FP+FN)
-  de:
-    term: "Genauigkeit"
-    def: >
-      Ein statistisches Maß zur Beschreibung eines Klassifizierungsmodells,
-      das den Anteil der korrekten Vorhersagen unter allen Vorhersagen angibt. Es wird als Genauigkeit = (TP+TN)/(TP+TN+FP+FN) berechnet.
-  af:
-    term: "akkuraatheid"
-    def: >
-      Dit is 'n statistiese maatstaf van 'n klassifikasiemodel wat die proporsie van korrekte voorspellings gee onder die totale aantal gevalle.
-      Dit word bereken as Akkuraatheid = (TP+TN)/(TP+TN+FP+FN).
-  fr:
-    term: "Précision"
-    def: >
-      L'exactitude et la précision sont deux façons de mesurer les résultats. 
-      L'exactitude mesure à quel point les résultats sont proches de la valeur vraie ou connue. 
-      La précision, quant à elle, mesure la proximité des résultats les uns par rapport aux autres. 
-  uk:
-    term: "точність"
-    def: >
-      Статистична міра класифікаційної моделі, яка показує частку правильних прогнозів серед загальної кількості випадків. 
-      Обчислюється за формулою: Точність = (ІП + ІН) / (ІП + ІН + ХП + ХН).
-      - ІП = істинно позитивні 
-      - ІН = істинно негативні
-      - ХН = хибно негативні
-      - ХП = хибно позитивні
+    term: precisión
+    def: 'Medida estadística de un modelo de clasificación que da la proporción de
+      predicciones correctas entre el número total de casos. Se calcula como Precisión
+      = (TP+TN)/(TP+TN+FP+FN)
 
+      '
+  sw:
+    term: usahihi
+    def: 'Kipimo cha takwimu cha muundo wa uainishaji ambao hutoa uwiano ya utabiri
+      sahihi kati ya jumla ya idadi ya kesi. Imehesabiwa kama Usahihi = (TP+TN)/(TP+TN+FP+FN)
+
+      '
+  de:
+    term: Genauigkeit
+    def: 'Ein statistisches Maß zur Beschreibung eines Klassifizierungsmodells, das
+      den Anteil der korrekten Vorhersagen unter allen Vorhersagen angibt. Es wird
+      als Genauigkeit = (TP+TN)/(TP+TN+FP+FN) berechnet.
+
+      '
+  af:
+    term: akkuraatheid
+    def: 'Dit is ''n statistiese maatstaf van ''n klassifikasiemodel wat die proporsie
+      van korrekte voorspellings gee onder die totale aantal gevalle. Dit word bereken
+      as Akkuraatheid = (TP+TN)/(TP+TN+FP+FN).
+
+      '
+  fr:
+    term: Précision
+    def: "L'exactitude et la précision sont deux façons de mesurer les résultats.\
+      \  L'exactitude mesure à quel point les résultats sont proches de la valeur\
+      \ vraie ou connue.  La précision, quant à elle, mesure la proximité des résultats\
+      \ les uns par rapport aux autres. \n"
+  uk:
+    term: точність
+    def: 'Статистична міра класифікаційної моделі, яка показує частку правильних прогнозів
+      серед загальної кількості випадків.  Обчислюється за формулою: Точність = (ІП
+      + ІН) / (ІП + ІН + ХП + ХН). - ІП = істинно позитивні  - ІН = істинно негативні
+      - ХН = хибно негативні - ХП = хибно позитивні
+
+      '
+- slug: activation_function
+  ref:
+  - neural_network
+  - deep_learning
+  en:
+    term: activation function
+    def: 'A mathematical function applied to the output of a neuron in a [neural network](#neural_network)
+      that introduces non-linearity, allowing the network to learn complex patterns.
+      Common examples include ReLU, sigmoid, and tanh.
+
+      '
 - slug: actual_result
   de:
-    term: "Tatsächliches Ergebnis"
-    def: >
-      Der Wert, der durch Ausführen von Code in einem Test erzeugt
-      wird. Wenn dieser Wert mit dem [erwarteten
-      Ergebnis](#expected_result) übereinstimmt, ist der Test
-      bestanden; wenn die beiden Werte unterschiedlich sind, [schlägt
-      der Test fehl](#fail_test).
+    term: Tatsächliches Ergebnis
+    def: 'Der Wert, der durch Ausführen von Code in einem Test erzeugt wird. Wenn
+      dieser Wert mit dem [erwarteten Ergebnis](#expected_result) übereinstimmt, ist
+      der Test bestanden; wenn die beiden Werte unterschiedlich sind, [schlägt der
+      Test fehl](#fail_test).
+
+      '
   en:
-    term: "actual result (of test)"
-    def: >
-      The outcome or value of performing a statistical test. If this matches the [expected
-      result](#expected_result), the test [passes](#pass_test); if the two are
-      different, the test [fails](#fail_test).
+    term: actual result (of test)
+    def: 'The outcome or value of performing a statistical test. If this matches the
+      [expected result](#expected_result), the test [passes](#pass_test); if the two
+      are different, the test [fails](#fail_test).
+
+      '
   sw:
-    term: "matokeo halisi"
-    def: >
-      Huonyesha matokeo ya kujaribu msimbo kwenye tarakilishi. Ikiwa hili linafanana na [matokeo halisi]
-      (#expected_result), hilo jaribio [hupita](#pass_test); Ikiwa upatalo na matokeo halisi
-      sio sawa, huo msimbo huwa [jaribio lililoshindikana](#fail_test)
+    term: matokeo halisi
+    def: 'Huonyesha matokeo ya kujaribu msimbo kwenye tarakilishi. Ikiwa hili linafanana
+      na [matokeo halisi] (#expected_result), hilo jaribio [hupita](#pass_test); Ikiwa
+      upatalo na matokeo halisi sio sawa, huo msimbo huwa [jaribio lililoshindikana](#fail_test)
 
+      '
   af:
-    term: "absolute resultaat (van 'n toets)"
-    def: >
-      Die waarde wat deur 'n toets gegenereer is. Indien dié waarde gelyk is aan die
-      [verwagte resultaat](#actual_result), is die toets suksesvol; as die twee
-      waardes verskil het die toets gefaal.
-  ar:
-    term: "النتيجة الفعلية للإختِبار"
-    def: >
-      القيمة الناتجة عن تشغيل إختبار للتعليمات البرمجية، إذا كانت هذه النتيجة تُطابِق
-      [النتيجة المتوقعة](#expected_result)
-      فإن الإختبار
-      [تم نجاحه](#pass_test)
-      و اذا كان النتيجتين مختلفتين فان الاختبار قد
-      [فشل](#fail_test).
-  tn:
-    term: "Dipholo tsa tlhomamiso (tsa teko)"
-    def: >
-      Ke palo e e bonwang ka go fetisa "khoutu" mo tekong. Fa palo e, e tsamaelana le dipholo tse
-      [di solofetsweng](#expected_result), go raya gore teko e falotse; fa palo e le dipholo tse di solofetsweng
-      di sa tsamaelane, go raya gore teko [e tlholegile](#fail_test).
-  id:
-    term: "hasil aktual (dari sebuah pengujian)"
-    def: >
-      Nilai yang dihasilkan dari kode yang dijalankan di dalam sebuah pengujian.
-      Jika hasil pengujian sesuai dengan [hasil yang diharapkan](#expected_result),
-      maka pengujian dianggap [lulus](#pass_test);
-      namun jika hasil keduanya berbeda, maka pengujian dianggap [gagal](#fail_test).
-  es:
-    term: "resultado real (de una prueba)"
-    def: >
-      El valor generado ejecutando el código en una prueba. Si coincide con el
-      [resultado esperado] (#expected_result), la prueba [pasa] (#pass_test);
-      si son diferentes, la prueba [falla] (#fail_test).
-  fr:
-    term: "résultat réel (du test)"
-    def: >
-      La valeur générée par l'exécution du code lors d'un test. Si elle correspond au résultat attendu, le test réussit ; s'ils sont différents, le test échoue.
+    term: absolute resultaat (van 'n toets)
+    def: 'Die waarde wat deur ''n toets gegenereer is. Indien dié waarde gelyk is
+      aan die [verwagte resultaat](#actual_result), is die toets suksesvol; as die
+      twee waardes verskil het die toets gefaal.
 
+      '
+  ar:
+    term: النتيجة الفعلية للإختِبار
+    def: 'القيمة الناتجة عن تشغيل إختبار للتعليمات البرمجية، إذا كانت هذه النتيجة
+      تُطابِق [النتيجة المتوقعة](#expected_result) فإن الإختبار [تم نجاحه](#pass_test)
+      و اذا كان النتيجتين مختلفتين فان الاختبار قد [فشل](#fail_test).
+
+      '
+  tn:
+    term: Dipholo tsa tlhomamiso (tsa teko)
+    def: 'Ke palo e e bonwang ka go fetisa "khoutu" mo tekong. Fa palo e, e tsamaelana
+      le dipholo tse [di solofetsweng](#expected_result), go raya gore teko e falotse;
+      fa palo e le dipholo tse di solofetsweng di sa tsamaelane, go raya gore teko
+      [e tlholegile](#fail_test).
+
+      '
+  id:
+    term: hasil aktual (dari sebuah pengujian)
+    def: 'Nilai yang dihasilkan dari kode yang dijalankan di dalam sebuah pengujian.
+      Jika hasil pengujian sesuai dengan [hasil yang diharapkan](#expected_result),
+      maka pengujian dianggap [lulus](#pass_test); namun jika hasil keduanya berbeda,
+      maka pengujian dianggap [gagal](#fail_test).
+
+      '
+  es:
+    term: resultado real (de una prueba)
+    def: 'El valor generado ejecutando el código en una prueba. Si coincide con el
+      [resultado esperado] (#expected_result), la prueba [pasa] (#pass_test); si son
+      diferentes, la prueba [falla] (#fail_test).
+
+      '
+  fr:
+    term: résultat réel (du test)
+    def: 'La valeur générée par l''exécution du code lors d''un test. Si elle correspond
+      au résultat attendu, le test réussit ; s''ils sont différents, le test échoue.
+
+      '
 - slug: affordance
   en:
-    term: "affordance"
-    def: >
-      Fields you can interact with such as a handle or button.
+    term: affordance
+    def: 'Fields you can interact with such as a handle or button.
+
+      '
   id:
-    term: "keterjangkauan"
-    def: >
-      suatu properti yang menyatakan bagaimana suatu hal dapat digunakan, seperti pegangan atau tombol.
+    term: keterjangkauan
+    def: 'suatu properti yang menyatakan bagaimana suatu hal dapat digunakan, seperti
+      pegangan atau tombol.
+
+      '
   af:
-    term: "bekostigbaarheid"
-    def: >
-      'n Eienskap van iets wat aandui hoe dit gebruik kan word, bevoorbeeld 'n
-      lêerhanteerder of 'n knoppie.
+    term: bekostigbaarheid
+    def: '''n Eienskap van iets wat aandui hoe dit gebruik kan word, bevoorbeeld ''n
+      lêerhanteerder of ''n knoppie.
+
+      '
   am:
     term: አቅም
-    def: >
-      የአንድ ነገር ንብረት እንደ መያዣ ወይም አዝራር እንዴት መጠቀም እንደሚቻል የሚጠቁም
-  fr:
-    term: "affordance"
-    def: >
-      La caractéristique d'un objet qui suggère à son utilisateur son mode d'usage ou autre pratique.
-  sw:
-    term: "uwezesho"
-    def: >
-      Sifa ya kitu ambacho kinapendekeza jinsi kinavyoweza kutumika, kama vile mpini au  kitufe.
+    def: 'የአንድ ነገር ንብረት እንደ መያዣ ወይም አዝራር እንዴት መጠቀም እንደሚቻል የሚጠቁም
 
+      '
+  fr:
+    term: affordance
+    def: 'La caractéristique d''un objet qui suggère à son utilisateur son mode d''usage
+      ou autre pratique.
+
+      '
+  sw:
+    term: uwezesho
+    def: 'Sifa ya kitu ambacho kinapendekeza jinsi kinavyoweza kutumika, kama vile
+      mpini au  kitufe.
+
+      '
 - slug: aggregation
   en:
-    term: "aggregation"
-    def: >
-      To combine many values into one, e.g., by summing a set of numbers or
-      linking a set of strings.
-  tn:
-    term: "Ditlhopha tsa boleng"
-    def: >
-      Karolo ya boranyane bo kopane go aga ditlhophana tsa boleng jo bo rileng/ seemo se se rileng sa kitso. Sekai, e ka nna setlhopha sa mafoko a boleng jo bo tshwanang.
-  es:
-    term: "agregación"
-    def: >
-      Combinar muchos valores en uno, por ejemplo, sumando una serie de números o
-      concatenando un conjunto de cadenas de caracteres.
-  fr:
-    term: "agrégation"
-    def: >
-      Synthétise plusieurs valeurs en une seule, example, en sommant plusieurs nombres
-      ou en concaténant un ensemble de caractères.
-  af:
-    term: "samevoeging"
-    def: >
-      Om 'n groep waardes in een te kombineer bv. om 'n versameling getalle op te som
-      of om 'n versameling alfabetiese stringe aaneen te skakel.
-  pt:
-    term: "agregação"
-    def: >
-      Combinar vários valores em um, por exemplo, somando um conjunto numérico ou
-      concatenando um conjunto de caracteres.
-  de:
-    term: "Aggreation"
-    def: >
-      Mehrere Werte zu einem zusammenfassen, z.B. durch Aufsummieren einer Reihe von Zahlen
-      oder Verkettung einer Reihe von Zeichenketten.
-  ar:
-    term: "تجميع"
-    def: >
-      دمج مجموعة من القيم في قيمة واحدة، مثال، حمع مجموعة من الأرقام أو تجميع مجموعة من السلاسل.
-  sw:
-    term: "mchanganyiko"
-    def: >
-      Kugawana vitu mingi pamoja, kwa mfano, kujumlisha nambari au
-      kunganisha matini.
+    term: aggregation
+    def: 'To combine many values into one, e.g., by summing a set of numbers or linking
+      a set of strings.
 
+      '
+  tn:
+    term: Ditlhopha tsa boleng
+    def: 'Karolo ya boranyane bo kopane go aga ditlhophana tsa boleng jo bo rileng/
+      seemo se se rileng sa kitso. Sekai, e ka nna setlhopha sa mafoko a boleng jo
+      bo tshwanang.
+
+      '
+  es:
+    term: agregación
+    def: 'Combinar muchos valores en uno, por ejemplo, sumando una serie de números
+      o concatenando un conjunto de cadenas de caracteres.
+
+      '
+  fr:
+    term: agrégation
+    def: 'Synthétise plusieurs valeurs en une seule, example, en sommant plusieurs
+      nombres ou en concaténant un ensemble de caractères.
+
+      '
+  af:
+    term: samevoeging
+    def: 'Om ''n groep waardes in een te kombineer bv. om ''n versameling getalle
+      op te som of om ''n versameling alfabetiese stringe aaneen te skakel.
+
+      '
+  pt:
+    term: agregação
+    def: 'Combinar vários valores em um, por exemplo, somando um conjunto numérico
+      ou concatenando um conjunto de caracteres.
+
+      '
+  de:
+    term: Aggreation
+    def: 'Mehrere Werte zu einem zusammenfassen, z.B. durch Aufsummieren einer Reihe
+      von Zahlen oder Verkettung einer Reihe von Zeichenketten.
+
+      '
+  ar:
+    term: تجميع
+    def: 'دمج مجموعة من القيم في قيمة واحدة، مثال، حمع مجموعة من الأرقام أو تجميع
+      مجموعة من السلاسل.
+
+      '
+  sw:
+    term: mchanganyiko
+    def: 'Kugawana vitu mingi pamoja, kwa mfano, kujumlisha nambari au kunganisha
+      matini.
+
+      '
 - slug: aggregation_function
   en:
-    term: "aggregation function"
-    def: >
-      A function that combines many values into one, such as `sum` or `max`.
-  id:
-    term: "fungsi Agregasi"
-    def: >
-      Sebuah fungsi untuk memadatkan beberapa nilai menjadi sebuah nilai, misalnya `sum` atau `max`.
-  es:
-    term: "función de agregación"
-    def: >
-      Una función que combina varios valores en uno, como `sum` o `max`.
-  fr:
-    term: "fonction d'agrégation"
-    def: >
-      Une fonction qui permet de synthétiser plusieurs valeurs en une seule, comme par
-      exemple 'sum' ou 'max'.
-  pt:
-    term: "função de agregação"
-    def: >
-      Uma função que combina muitos valores em um só, como `sum` ou `max`.
-  af:
-    term: "aggregaatfunksie"
-    def: >
-      'n Funksie wat 'n groep waardes saamvoeg, bv. `sum` (summering) en `max`
-      (maksimale waarde)
-  ar:
-    term: "دالة التجميع"
-    def: >
-      دالة تدمج العديد من القيم في قيمة واحدة ، مثل
-      جمع
-      أو
-      أقصى.
-  de:
-    term: "Aggregatfunktion"
-    def: >
-      Eine Funktion, welche mehrere Werte in einem Ergebnis zusammenfasst,
-      beispielsweise in einer Summe oder dem Maximalwert.
-  tn:
-    term: "Bokao/Tiriso ya ditlhopha"
-    def: >
-      Ke boranyane jwa boleng jo khompiutara/sebalamakgolo e bo balang ka go dirisa dipalo go tsentswe le kitso ya tlhomamo.
+    term: aggregation function
+    def: 'A function that combines many values into one, such as `sum` or `max`.
 
+      '
+  id:
+    term: fungsi Agregasi
+    def: 'Sebuah fungsi untuk memadatkan beberapa nilai menjadi sebuah nilai, misalnya
+      `sum` atau `max`.
+
+      '
+  es:
+    term: función de agregación
+    def: 'Una función que combina varios valores en uno, como `sum` o `max`.
+
+      '
+  fr:
+    term: fonction d'agrégation
+    def: 'Une fonction qui permet de synthétiser plusieurs valeurs en une seule, comme
+      par exemple ''sum'' ou ''max''.
+
+      '
+  pt:
+    term: função de agregação
+    def: 'Uma função que combina muitos valores em um só, como `sum` ou `max`.
+
+      '
+  af:
+    term: aggregaatfunksie
+    def: '''n Funksie wat ''n groep waardes saamvoeg, bv. `sum` (summering) en `max`
+      (maksimale waarde)
+
+      '
+  ar:
+    term: دالة التجميع
+    def: 'دالة تدمج العديد من القيم في قيمة واحدة ، مثل جمع أو أقصى.
+
+      '
+  de:
+    term: Aggregatfunktion
+    def: 'Eine Funktion, welche mehrere Werte in einem Ergebnis zusammenfasst, beispielsweise
+      in einer Summe oder dem Maximalwert.
+
+      '
+  tn:
+    term: Bokao/Tiriso ya ditlhopha
+    def: 'Ke boranyane jwa boleng jo khompiutara/sebalamakgolo e bo balang ka go dirisa
+      dipalo go tsentswe le kitso ya tlhomamo.
+
+      '
 - slug: agile
   en:
-    term: "agile development"
-    def: >
-      A software development methodology that emphasizes lots of small steps and
-      continuous feedback instead of up-front planning and long-term scheduling.
-      [Exploratory programming](#exploratory_programming) is often agile.
-  es:
-    term: "desarrollo ágil"
-    def: >
-      Una metodología de desarrollo de software que enfatiza muchos pasos pequeños y
-      feedback continuo en vez de planificación por adelantado y a largo plazo.
-      [Programación exploratoria](#exploratory_programming) suele ser ágil.
-  af:
-    term: "lenige ontwikkeling"
-    def: >
-      'n Sagteware-ontwikkelingsmetode wat die klem lê op vele klein stappies en
-      deurlopende terugvoering in plaas van vooraf beplanning en langtermyn
-      skeduluering. [Verkennende programmering](#exploratory_programming) is dikwel lenig.
-  pt:
-    term: "desenvolvimento ágil"
-    def: >
-      Um método de desenvolvimento de software que enfatiza vários passos pequenos e
-      feedback contínuo ao invés de planejamento de longo prazo. [Programação exploratória](#exploratory_programming)
-      costuma ser ágil.
-  de:
-    term: "Agile Softwareentwicklung"
-    def: >
-      Eine Methodik der Softwareentwicklung in der die Arbeit in viele
-      kleine Schritte aufgeteilt wird und mit ständigem Feedback innerhalb
-      selbstorganisierter Teams ein Program entwickelt wird. Im Gegensatz dazu
-      stehen klassische Ansätze die häufig aufwändiger Planung bedürfen.
-      [Explorative Programmierung](#exploratory_programming) ist oft agil.
-  fr:
-    term: "développement agile"
-    def: >
-      Une méthodologie de développement logiciel qui privilégie de nombreuses petites étapes et une rétroaction continue plutôt que la planification initiale et la programmation à long terme. La programmation exploratoire est souvent associée à l'approche agile.
-  tn:
-    term: "Tiro ya Potlako"
-    def: >
-      thulaganyo ya go kwala khoutu ya dirweboleta (software) e e remeletseng
-      mo dikgatong-potlana tse di mmalwa le mo dikakgelong tse di tlhomameng, go na le mo mananeong
-      a sennella-ruri le togamaano ko tshimologong.
-  sw:
-    term: "maendeleo pesi"
-    def: >
-      Mbinu ya ukuzaji programu ambayo inasisitiza hatua nyingi ndogo na maoni
-      endelevu badala ya mipango ya mbeleni na ratiba ya muda mrefu.
-      [Exploratory programming](#exploratory_programming) mara nyingi huwa chapa.
-  uk:
-    term: "гнучка розробка"
-    def: >
-      Методологія розробки програмного забезпечення, яка робить акцент на поступових 
-      ітераціях і постійному зворотному зв'язку замість складання довгострокових планів. 
-      [Дослідницьке програмування](#exploratory_programming) часто використовує гнучкий підхід.
+    term: agile development
+    def: 'A software development methodology that emphasizes lots of small steps and
+      continuous feedback instead of up-front planning and long-term scheduling. [Exploratory
+      programming](#exploratory_programming) is often agile.
 
+      '
+  es:
+    term: desarrollo ágil
+    def: 'Una metodología de desarrollo de software que enfatiza muchos pasos pequeños
+      y feedback continuo en vez de planificación por adelantado y a largo plazo.
+      [Programación exploratoria](#exploratory_programming) suele ser ágil.
+
+      '
+  af:
+    term: lenige ontwikkeling
+    def: '''n Sagteware-ontwikkelingsmetode wat die klem lê op vele klein stappies
+      en deurlopende terugvoering in plaas van vooraf beplanning en langtermyn skeduluering.
+      [Verkennende programmering](#exploratory_programming) is dikwel lenig.
+
+      '
+  pt:
+    term: desenvolvimento ágil
+    def: 'Um método de desenvolvimento de software que enfatiza vários passos pequenos
+      e feedback contínuo ao invés de planejamento de longo prazo. [Programação exploratória](#exploratory_programming)
+      costuma ser ágil.
+
+      '
+  de:
+    term: Agile Softwareentwicklung
+    def: 'Eine Methodik der Softwareentwicklung in der die Arbeit in viele kleine
+      Schritte aufgeteilt wird und mit ständigem Feedback innerhalb selbstorganisierter
+      Teams ein Program entwickelt wird. Im Gegensatz dazu stehen klassische Ansätze
+      die häufig aufwändiger Planung bedürfen. [Explorative Programmierung](#exploratory_programming)
+      ist oft agil.
+
+      '
+  fr:
+    term: développement agile
+    def: 'Une méthodologie de développement logiciel qui privilégie de nombreuses
+      petites étapes et une rétroaction continue plutôt que la planification initiale
+      et la programmation à long terme. La programmation exploratoire est souvent
+      associée à l''approche agile.
+
+      '
+  tn:
+    term: Tiro ya Potlako
+    def: 'thulaganyo ya go kwala khoutu ya dirweboleta (software) e e remeletseng
+      mo dikgatong-potlana tse di mmalwa le mo dikakgelong tse di tlhomameng, go na
+      le mo mananeong a sennella-ruri le togamaano ko tshimologong.
+
+      '
+  sw:
+    term: maendeleo pesi
+    def: 'Mbinu ya ukuzaji programu ambayo inasisitiza hatua nyingi ndogo na maoni
+      endelevu badala ya mipango ya mbeleni na ratiba ya muda mrefu. [Exploratory
+      programming](#exploratory_programming) mara nyingi huwa chapa.
+
+      '
+  uk:
+    term: гнучка розробка
+    def: 'Методологія розробки програмного забезпечення, яка робить акцент на поступових  ітераціях
+      і постійному зворотному зв''язку замість складання довгострокових планів.  [Дослідницьке
+      програмування](#exploratory_programming) часто використовує гнучкий підхід.
+
+      '
 - slug: algorithm
   en:
-    term: "algorithm"
-    def: >
-      An algorithm is a set of steps, intructions, or rules followed to accomplish a specific
-      task. In computer science, an algorithm is a set of instructions in a computer program that solves a
-      computational problem.
-  id:
-    term: "algoritma"
-    def: >
-      Rangkaian langkah, perintah, atau aturan yang harus diikuti untuk menyelesaikan suatu tugas spesifik.
-      Di dalam ilmu komputer, algoritma adalah rangkaian perintah di dalam sebuah program komputer yang
-      bertujuan untuk menyelesaikan permasalahan komputasi.
-  zu:
-    term: "I-algorithm"
-    def: >
-      An algorithm is a set of steps, intructions, or rules to be followed to accomplish a specific
-      task. In computer science, an algorithm is a set of instructions in a computer program that solves a
-      computational problem.
-  af:
-    term: "algoritme"
-    def: >
-      'n Algoritme is 'n stel instruksies wat gevolg moet word om 'n spesifieke taak uit te voer.
-  es:
-    term: "algoritmo"
-    def: >
-      Un algoritmo es un conjunto de pasos, instrucciones o reglas que se han de seguir para llevar a cabo una tarea específica.
-      En informática, un algoritmo es un conjunto de instrucciones en un programa informático que resuelve un problema computacional.
-  fr:
-    term: "algorithme"
-    def: >
-      Un algorithme est un ensemble d'étapes ou de règles à suivre pour réaliser une certaine tâche.
-      En informatique, un algorithme est un ensemble d'instructions présentes dans un programme qui permet de résoudre un problème informatique.
-  de:
-    term: "Algorithmus"
-    def: >
-      Ein Algorithmus beschreibt eine Handlungsvorschrift, ein Verfahren oder einen Regelsatz zum Lösen eines Problems.
-      In der Informatik ist ein Algorithmus eine eindeutige, ausführbare Folge von Anweisungen endlicher Länge zur Lösung eines Problems,
-      welche immer das gleiche Ergebnis liefern.
-  ar:
-    term: "خوارزمية"
-    def: >
-      الخوارزمية عبارة عن مجموعة من الخطوات والمقدمات أوالقواعد التي يجب اتباعها لتحقيق مهمة معين.
-      في علوم الحاسب، الخوارزمية هي مجموعة من التعليمات في برنامج كمبيوتر تحل مشكلة حاسوبية.
-  el:
-    term: "αλγόριθμος"
-    def: >
-      Αλγόριθμος είναι ένα σύνολο από βήματα ή κανόνες για τη διεκπεραίωση μιας συγκεκριμένης εργασίας.
-      Στην πληροφορική, αλγόριθμος είναι ένα σύνολο από εντολές σε κάποιο πρόγραμμα οι οποίες επιλύουν κάποιο
-      υπολογιστικό πρόβλημα.
-  it:
-    term: "algoritmo"
-    def: >
-      Un algoritmo è una sequenza finita di operazioni da eseguire al fine di realizzare un certo compito.
-      In informatica, un algoritmo è una sequenza finita di istruzioni presenti in un programma che permette di risolvere un problema computazionale.
-  pt:
-    term: "algoritmo"
-    def: >
-      Um algoritmo é um conjunto de etapas, instruções ou regras a serem seguidas para realizar uma tarefa específica.
-      Na ciência da computação, um algoritmo é um conjunto de instruções em um programa de computador que resolve um problema computacional.
-  uk:
-    term: "алгоритм"
-    def: >
-      Алгоритм — це впорядкований набір кроків, інструкцій або правил, яких слід дотримуватися для виконання конкретного завдання.
-      В інформатиці алгоритм - це набір інструкцій у комп’ютерній програмі, який розв’язує обчислювальну задачу.
-  sw:
-    term: "algorithimu"
-    def: >
-       Ni utaratibu wa hatua za kutatua tatizo. Ni kanuni zinazofuatwa na kompyuta ama tarakilishi ili kupata jibu la tatizo.
+    term: algorithm
+    def: 'An algorithm is a set of steps, intructions, or rules followed to accomplish
+      a specific task. In computer science, an algorithm is a set of instructions
+      in a computer program that solves a computational problem.
 
+      '
+  id:
+    term: algoritma
+    def: 'Rangkaian langkah, perintah, atau aturan yang harus diikuti untuk menyelesaikan
+      suatu tugas spesifik. Di dalam ilmu komputer, algoritma adalah rangkaian perintah
+      di dalam sebuah program komputer yang bertujuan untuk menyelesaikan permasalahan
+      komputasi.
+
+      '
+  zu:
+    term: I-algorithm
+    def: 'An algorithm is a set of steps, intructions, or rules to be followed to
+      accomplish a specific task. In computer science, an algorithm is a set of instructions
+      in a computer program that solves a computational problem.
+
+      '
+  af:
+    term: algoritme
+    def: '''n Algoritme is ''n stel instruksies wat gevolg moet word om ''n spesifieke
+      taak uit te voer.
+
+      '
+  es:
+    term: algoritmo
+    def: 'Un algoritmo es un conjunto de pasos, instrucciones o reglas que se han
+      de seguir para llevar a cabo una tarea específica. En informática, un algoritmo
+      es un conjunto de instrucciones en un programa informático que resuelve un problema
+      computacional.
+
+      '
+  fr:
+    term: algorithme
+    def: 'Un algorithme est un ensemble d''étapes ou de règles à suivre pour réaliser
+      une certaine tâche. En informatique, un algorithme est un ensemble d''instructions
+      présentes dans un programme qui permet de résoudre un problème informatique.
+
+      '
+  de:
+    term: Algorithmus
+    def: 'Ein Algorithmus beschreibt eine Handlungsvorschrift, ein Verfahren oder
+      einen Regelsatz zum Lösen eines Problems. In der Informatik ist ein Algorithmus
+      eine eindeutige, ausführbare Folge von Anweisungen endlicher Länge zur Lösung
+      eines Problems, welche immer das gleiche Ergebnis liefern.
+
+      '
+  ar:
+    term: خوارزمية
+    def: 'الخوارزمية عبارة عن مجموعة من الخطوات والمقدمات أوالقواعد التي يجب اتباعها
+      لتحقيق مهمة معين. في علوم الحاسب، الخوارزمية هي مجموعة من التعليمات في برنامج
+      كمبيوتر تحل مشكلة حاسوبية.
+
+      '
+  el:
+    term: αλγόριθμος
+    def: 'Αλγόριθμος είναι ένα σύνολο από βήματα ή κανόνες για τη διεκπεραίωση μιας
+      συγκεκριμένης εργασίας. Στην πληροφορική, αλγόριθμος είναι ένα σύνολο από εντολές
+      σε κάποιο πρόγραμμα οι οποίες επιλύουν κάποιο υπολογιστικό πρόβλημα.
+
+      '
+  it:
+    term: algoritmo
+    def: 'Un algoritmo è una sequenza finita di operazioni da eseguire al fine di
+      realizzare un certo compito. In informatica, un algoritmo è una sequenza finita
+      di istruzioni presenti in un programma che permette di risolvere un problema
+      computazionale.
+
+      '
+  pt:
+    term: algoritmo
+    def: 'Um algoritmo é um conjunto de etapas, instruções ou regras a serem seguidas
+      para realizar uma tarefa específica. Na ciência da computação, um algoritmo
+      é um conjunto de instruções em um programa de computador que resolve um problema
+      computacional.
+
+      '
+  uk:
+    term: алгоритм
+    def: 'Алгоритм — це впорядкований набір кроків, інструкцій або правил, яких слід
+      дотримуватися для виконання конкретного завдання. В інформатиці алгоритм - це
+      набір інструкцій у комп’ютерній програмі, який розв’язує обчислювальну задачу.
+
+      '
+  sw:
+    term: algorithimu
+    def: 'Ni utaratibu wa hatua za kutatua tatizo. Ni kanuni zinazofuatwa na kompyuta
+      ama tarakilishi ili kupata jibu la tatizo.
+
+      '
 - slug: algorithmic_bias
   ref:
-    - algorithm
+  - algorithm
   en:
-    term: "algorithmic bias"
-    def: >
-      Repeatable results that show bias, or skewed treatment, found in an [algorithm](#algorithm).
-      For example, social media algorithms may prioritize or stigmatize content from certain groups of users.
+    term: algorithmic bias
+    def: 'Repeatable results that show bias, or skewed treatment, found in an [algorithm](#algorithm).
+      For example, social media algorithms may prioritize or stigmatize content from
+      certain groups of users.
+
+      '
   af:
-    term: "algoritmiese vooroordeel"
-    def: >
-      Herhaalbare resultate in 'n [algoritme](#algorithm) wat vooroordeel or geskeefde behandeling toon. Byvoorbeeld, sosiale media algoritmes
-      wat bevooroordeelde of gestigmateerde inhoud van seker groepe prioritiseer.
+    term: algoritmiese vooroordeel
+    def: 'Herhaalbare resultate in ''n [algoritme](#algorithm) wat vooroordeel or
+      geskeefde behandeling toon. Byvoorbeeld, sosiale media algoritmes wat bevooroordeelde
+      of gestigmateerde inhoud van seker groepe prioritiseer.
+
+      '
   am:
     term: ስልተ ቀመር
-    def: >
-      "አንድ ስልተ-ቀመር አንድን የተወሰነን ነገር ለማከናወን ሊከተሏቸው የሚገቡ እርምጃዎች ፣ ጥሰቶች ወይም ህጎች ስብስብነው
+    def: '"አንድ ስልተ-ቀመር አንድን የተወሰነን ነገር ለማከናወን ሊከተሏቸው የሚገቡ እርምጃዎች ፣ ጥሰቶች ወይም ህጎች ስብስብነው
       \ አልጎሪዝም  በኮምፒተር ሳይንስ ውስጥ  የሂሳብ ችግሮችን ለመፍታት የተቀመጡ የኮምፒተር ፕሮግራም መመሪያዎች ስብስብ ነው"
+
+      '
   ar:
-    term: "الخوارزمية المتحيزة"
-    def: >
-      النتائج المتكررة التي تظهر التحيز أو المعالجة المنحرفة الموجودة في
-      .[الخوارزمية](#algorithm)
-      .على سبيل المثال، قد تعطي خوارزميات وسائل التواصل الاجتماعي الأولوية أو الوسم للمحتوى الخاص بمجموعات معينة من المستخدمين
+    term: الخوارزمية المتحيزة
+    def: 'النتائج المتكررة التي تظهر التحيز أو المعالجة المنحرفة الموجودة في .[الخوارزمية](#algorithm)
+      .على سبيل المثال، قد تعطي خوارزميات وسائل التواصل الاجتماعي الأولوية أو الوسم
+      للمحتوى الخاص بمجموعات معينة من المستخدمين
+
+      '
   es:
-    term: "sesgo algorítmico"
-    def: >
-      Resultados repetibles que muestran un sesgo, o un tratamiento sesgado, encontrado en un [algoritmo](#algorithm).
-      Por ejemplo, algoritmos de redes sociales pueden priorizar o estigmatizar contenido de ciertos grupos de usuarios.
+    term: sesgo algorítmico
+    def: 'Resultados repetibles que muestran un sesgo, o un tratamiento sesgado, encontrado
+      en un [algoritmo](#algorithm). Por ejemplo, algoritmos de redes sociales pueden
+      priorizar o estigmatizar contenido de ciertos grupos de usuarios.
 
+      '
   sw:
-    term: "upendeleo wa algorithm"
-    def: >
-      Matokeo yanayojirudia yanayoonyesha upendeleo, au matibabu yasiyo sawa, yanayopatikana katika [algorithms](#algorithm).
-      Kwa mfano, algorithms za mitandao ya kijamii zinaweza kuipa kipaumbele au kuashiria maudhui kutoka kwa vikundi fulani vya watumiaji.
+    term: upendeleo wa algorithm
+    def: 'Matokeo yanayojirudia yanayoonyesha upendeleo, au matibabu yasiyo sawa,
+      yanayopatikana katika [algorithms](#algorithm). Kwa mfano, algorithms za mitandao
+      ya kijamii zinaweza kuipa kipaumbele au kuashiria maudhui kutoka kwa vikundi
+      fulani vya watumiaji.
 
+      '
+- slug: aliased
+  en:
+    term: aliased
+    def: 'When two or more references point to the same data in memory. Modifying
+      data through one alias affects all other aliases to that data.
 
+      '
 - slug: aliasing
   en:
-    term: "aliasing"
-    def: >
-      To have two or more references to the same thing, such as a data structure in
-      memory or a file on disk.
-  af:
-    term: "aliasering"
-    def: >
-      Om twee of meer verwysing na dieselfde ding te hê, soos byvoorbeeld meer as een
-      verwysing na 'n datastruktuur in geheue of na 'n lêer op 'n skyf.
-  de:
-    term: "Aliasing"
-    def: >
-      Aliasing bezeichnet die Überlappung mehrerer Deskriptoren, also z.B.
-      Speicheradressen (Zeiger) oder Referenzen, die den selben Ort für ein
-      Objekt, beispielsweise eine Datenstruktur, beschreiben.
-  tn:
-    term: "Melawana_tiriso"
-    def: >
-      Melawana e e salwang morago ke khompiutara/sebalamakgolo go rarabolola dikgwetlho tse di amang tiriso ya tse di mo boranyaneng.
-  fr:
-    term: "aliasing"
-    def: >
-      Le fait d'avoir deux ou plusieurs références au même objet, comme par exemple une structure de données en mémoire ou un fichier sur disque.
-  sw:
-    term: "Kutambulisha"
-    def: >
-      Kuwa na marejeleo mawili au zaidi ya kitu kimoja, kama vile muundo wa data kwenye kumbukumbu au faili kwenye diski.
-  es:
-    term: "aliasing"
-    def: >
-      Solapamiento. Tener dos o más referencias al mismo objeto, por ejemplo como estructura de datos
-      en memoria o como archivo guardado en disco.
+    term: aliasing
+    def: 'To have two or more references to the same thing, such as a data structure
+      in memory or a file on disk.
 
+      '
+  af:
+    term: aliasering
+    def: 'Om twee of meer verwysing na dieselfde ding te hê, soos byvoorbeeld meer
+      as een verwysing na ''n datastruktuur in geheue of na ''n lêer op ''n skyf.
+
+      '
+  de:
+    term: Aliasing
+    def: 'Aliasing bezeichnet die Überlappung mehrerer Deskriptoren, also z.B. Speicheradressen
+      (Zeiger) oder Referenzen, die den selben Ort für ein Objekt, beispielsweise
+      eine Datenstruktur, beschreiben.
+
+      '
+  tn:
+    term: Melawana_tiriso
+    def: 'Melawana e e salwang morago ke khompiutara/sebalamakgolo go rarabolola dikgwetlho
+      tse di amang tiriso ya tse di mo boranyaneng.
+
+      '
+  fr:
+    term: aliasing
+    def: 'Le fait d''avoir deux ou plusieurs références au même objet, comme par exemple
+      une structure de données en mémoire ou un fichier sur disque.
+
+      '
+  sw:
+    term: Kutambulisha
+    def: 'Kuwa na marejeleo mawili au zaidi ya kitu kimoja, kama vile muundo wa data
+      kwenye kumbukumbu au faili kwenye diski.
+
+      '
+  es:
+    term: aliasing
+    def: 'Solapamiento. Tener dos o más referencias al mismo objeto, por ejemplo como
+      estructura de datos en memoria o como archivo guardado en disco.
+
+      '
 - slug: anaconda
   ref:
-    - pip
-    - conda
+  - pip
+  - conda
   en:
-    term: "Anaconda"
-    def: >
-      Anaconda is a [software distribution](#software_distribution) of R and Python. It is also a [repository](#repository) of open-source Python and R programs for data science, packaged using the [conda](#conda) [package manager](#package_manager). Anaconda also creates Anaconda Navigator, a suite of desktop tools including an [IDE](#ide) and the [Jupyter Notebook](#jupyter_notebook) application.
-  uk:
-    term: "Anaconda"
-    def: >
-      Anaconda - це [дистрибутив програмного забезпечення](#software_distribution)
-      для мов програмування R та Python.
-      Це також [репозиторій](#repository) програм з відкритим кодом в Python та R для аналізу даних,
-      побудований на базі [менеджеру пакетів](#package_manager) [conda](#conda).
-      Після встановлення, Anaconda створює Anaconda Navigator, набір інструментів для робочого столу,
-      включаючи [IDE] (#ide) та застосунок [Jupyter Notebook](#jupyter_notebook).
-  af:
-    term: "Anaconda"
-    def: >
-      Anaconda is ’n [sagtewareverspreiding](#software_distribution) van R en Python. Dit is ook ’n [bewaarplek](#repository) van oopbron-programme in Python en R vir datawetenskap,
-      saamgestel met behulp van die [conda](#conda) [pakketbestuurder](#package_manager). Anaconda sluit ook Anaconda Navigator in, ’n stel lessenaartoepassingsinsluitend ’n [IDE](#ide)
-      en die [Jupyter Notebook](#jupyter_notebook) toepassing.
+    term: Anaconda
+    def: 'Anaconda is a [software distribution](#software_distribution) of R and Python.
+      It is also a [repository](#repository) of open-source Python and R programs
+      for data science, packaged using the [conda](#conda) [package manager](#package_manager).
+      Anaconda also creates Anaconda Navigator, a suite of desktop tools including
+      an [IDE](#ide) and the [Jupyter Notebook](#jupyter_notebook) application.
 
+      '
+  uk:
+    term: Anaconda
+    def: 'Anaconda - це [дистрибутив програмного забезпечення](#software_distribution)
+      для мов програмування R та Python. Це також [репозиторій](#repository) програм
+      з відкритим кодом в Python та R для аналізу даних, побудований на базі [менеджеру
+      пакетів](#package_manager) [conda](#conda). Після встановлення, Anaconda створює
+      Anaconda Navigator, набір інструментів для робочого столу, включаючи [IDE] (#ide)
+      та застосунок [Jupyter Notebook](#jupyter_notebook).
+
+      '
+  af:
+    term: Anaconda
+    def: 'Anaconda is ’n [sagtewareverspreiding](#software_distribution) van R en
+      Python. Dit is ook ’n [bewaarplek](#repository) van oopbron-programme in Python
+      en R vir datawetenskap, saamgestel met behulp van die [conda](#conda) [pakketbestuurder](#package_manager).
+      Anaconda sluit ook Anaconda Navigator in, ’n stel lessenaartoepassingsinsluitend
+      ’n [IDE](#ide) en die [Jupyter Notebook](#jupyter_notebook) toepassing.
+
+      '
 - slug: anchor
   en:
-    term: "anchor"
-    def: >
-      In a [regular expression](#regular_expression), a symbol that fixes a position
-      without matching characters. `^` matches the start of the line, while `$`
-      matches the end of the line and `\b` matches a break between word and non-word characters.
+    term: anchor
+    def: 'In a [regular expression](#regular_expression), a symbol that fixes a position
+      without matching characters. `^` matches the start of the line, while `$` matches
+      the end of the line and `\b` matches a break between word and non-word characters.
+
+      '
   af:
-    term: "anker"
-    def: >
-      In 'n [gewone (reguliere) uitdrukking](#regular_expression), is 'n anker 'n
-      simbool wat 'n posisie aandui, bv. `^` dui die begin van 'n lyn aan en `$` dui
-      die einde van 'n lyn aan. 'n Uidrukking soos bv. `^Die` anker die soektog na die
-      woord `Die` aan die begin van die lyn.
+    term: anker
+    def: 'In ''n [gewone (reguliere) uitdrukking](#regular_expression), is ''n anker
+      ''n simbool wat ''n posisie aandui, bv. `^` dui die begin van ''n lyn aan en
+      `$` dui die einde van ''n lyn aan. ''n Uidrukking soos bv. `^Die` anker die
+      soektog na die woord `Die` aan die begin van die lyn.
+
+      '
   fr:
-    term: "ancre"
-    def: >
-      C'est un symbole utilisé dans les expressions régulières (#regular_expression)
-      afin de déterminer une position sans pour autant identifier des charactères. `^`
-      détermine le début d'une ligne, tandis que `$` détermine sa fin. `\b` identifie
+    term: ancre
+    def: 'C''est un symbole utilisé dans les expressions régulières (#regular_expression)
+      afin de déterminer une position sans pour autant identifier des charactères.
+      `^` détermine le début d''une ligne, tandis que `$` détermine sa fin. `\b` identifie
       un espace entre un mot et un non-mot.
+
+      '
   pt:
-    term: "âncora"
-    def: >
-      Em uma [expressão regular](#regular_expression), é um símbolo que fixa uma posição sem caracteres
-      correspondentes. `^` identifica o começo de uma linha, enquanto `$` indica o fim de uma linha e
-      `\b` identifica uma quebra entre caracteres que formam e que não formam uma palavra.
+    term: âncora
+    def: 'Em uma [expressão regular](#regular_expression), é um símbolo que fixa uma
+      posição sem caracteres correspondentes. `^` identifica o começo de uma linha,
+      enquanto `$` indica o fim de uma linha e `\b` identifica uma quebra entre caracteres
+      que formam e que não formam uma palavra.
+
+      '
   es:
-    term: "ancla"
-    def: >
-      En una [expresión regular](#regular_expression), el símbolo que fija una posición
-      sin coincidir con caracteres. `^` coincide con un inicio de línea, `$`
-      con el final y `\b` con un límite de palabra.
+    term: ancla
+    def: 'En una [expresión regular](#regular_expression), el símbolo que fija una
+      posición sin coincidir con caracteres. `^` coincide con un inicio de línea,
+      `$` con el final y `\b` con un límite de palabra.
 
-
+      '
 - slug: anonymous_function
   en:
-    term: "anonymous function"
-    def: >
-      A function that has not been assigned a name. Anonymous functions are usually
+    term: anonymous function
+    def: 'A function that has not been assigned a name. Anonymous functions are usually
       quite short, and are usually defined where they are used, e.g., as callbacks.
-      In [Python](#python), these are called lambda functions and are created through use of the
-      lambda reserved word.
+      In [Python](#python), these are called lambda functions and are created through
+      use of the lambda reserved word.
+
+      '
   af:
-    term: "anonieme funksie"
-    def: >
-      'n Funksie waaraan daar nie 'n naam toegeken is nie. Anonieme funksies is
-      gewoonlik baie kort en word gewoonlik gedefinieer waar hulle gebruik word bv. in
-      die geval van 'n [terugskakelfunksie](#callback).
+    term: anonieme funksie
+    def: '''n Funksie waaraan daar nie ''n naam toegeken is nie. Anonieme funksies
+      is gewoonlik baie kort en word gewoonlik gedefinieer waar hulle gebruik word
+      bv. in die geval van ''n [terugskakelfunksie](#callback).
+
+      '
   fr:
-    term: "fonction anonyme"
-    def: >
-      Une fonction qui ne s'est pas vue assignée de nom. Les fonctions anonymes sont
-      en général courtes et définies là où elles sont utilisées, exemple: callbacks.
+    term: fonction anonyme
+    def: 'Une fonction qui ne s''est pas vue assignée de nom. Les fonctions anonymes
+      sont en général courtes et définies là où elles sont utilisées, exemple: callbacks.
       En [Python](#python), elles sont appelées fonctions lambda et sont créées en
       utilisant le mot-clé `lambda`.
+
+      '
   ar:
-    term: "دالة مجهولة"
-    def: >
-      هي دالة  لم يتم تعيين اسم لها، عادةً ما تكون الدوال المجهولة قصيرة جدًا
-      وعادة ما يتم تحديدها في الموضع الذي يتم استخدامها ،مثل عمليات رد الإتصال
-      (callback).
-      لكن
-      في
-      لغة
-      [Python](#python)
-      تسمى هذه وظائف lambda ويتم إنشاؤها من خلال استخدام كلمة lambda المتداوله.
+    term: دالة مجهولة
+    def: 'هي دالة  لم يتم تعيين اسم لها، عادةً ما تكون الدوال المجهولة قصيرة جدًا
+      وعادة ما يتم تحديدها في الموضع الذي يتم استخدامها ،مثل عمليات رد الإتصال (callback).
+      لكن في لغة [Python](#python) تسمى هذه وظائف lambda ويتم إنشاؤها من خلال استخدام
+      كلمة lambda المتداوله.
+
+      '
   es:
-    term: "función anónima"
-    def: >
-      Es una función que no tiene asignado un nombre. Las funciones anónimas son usualmente cortas,
-      y se definen en el mismo lugar donde son utilizadas, por ejemplo: en callbacks.
-      En [Python](#python), estas funciones se conocen como funciones lambda
-      y son creadas con el uso de la palabra reservada lambda.
+    term: función anónima
+    def: 'Es una función que no tiene asignado un nombre. Las funciones anónimas son
+      usualmente cortas, y se definen en el mismo lugar donde son utilizadas, por
+      ejemplo: en callbacks. En [Python](#python), estas funciones se conocen como
+      funciones lambda y son creadas con el uso de la palabra reservada lambda.
+
+      '
   de:
-    term: "Anonyme Funktion"
-    def: >
-      Eine Funktion ohne Namen. In der Regel sind anonyme Funktionen sehr kurz
-      und werden nur dort definiert wo sie verwendet werden, z.B. als
-      [Rückruffunktion](#callback). In [Python](#python) wird diese Art der Funktionen
-      als Lambda-Funktionen bezeichnet und mit dem reservierten Ausdruck
-      `lambda` definiert.
+    term: Anonyme Funktion
+    def: 'Eine Funktion ohne Namen. In der Regel sind anonyme Funktionen sehr kurz
+      und werden nur dort definiert wo sie verwendet werden, z.B. als [Rückruffunktion](#callback).
+      In [Python](#python) wird diese Art der Funktionen als Lambda-Funktionen bezeichnet
+      und mit dem reservierten Ausdruck `lambda` definiert.
+
+      '
   am:
     term: ስም-አልባ ተግባር
-    def: >
-      "ስም ያልተመደበ ተግባር። ስም-አልባ ተግባራት ብዙውን ጊዜ  በጣም አጭር  እና አብዛኛውን ጊዜ ጥቅም ላይ በሚውሉበትን
+    def: '"ስም ያልተመደበ ተግባር። ስም-አልባ ተግባራት ብዙውን ጊዜ  በጣም አጭር  እና አብዛኛውን ጊዜ ጥቅም ላይ በሚውሉበትን
       ቦታ የሚገልፁ ናቸዉ  ፣ ለምሳሌ ፣ እንደ የመልሶ መደወያዎች። በ [Python](#python) ውስጥ እነዚህ ላምበዳ ተግባራት
       ተብለው የሚጠሩ  እና በ lambda የተጠበቀ ቃል የተፈጠሩ ናቸው "
 
+      '
 - slug: anti_join
   ref:
-    - anti_join
-    - cross_join
-    - full_join
-    - inner_join
-    - left_join
-    - right_join
-    - self_join
+  - anti_join
+  - cross_join
+  - full_join
+  - inner_join
+  - left_join
+  - right_join
+  - self_join
   en:
-    term: "anti join"
-    def: >
-      A [join](#join) that keeps rows from table A whose keys do *not* match keys in
-      table B.
+    term: anti join
+    def: 'A [join](#join) that keeps rows from table A whose keys do *not* match keys
+      in table B.
+
+      '
   af:
-    term: "anti-koppeling"
-    def: >
-      'n [Koppeling](#join) wat rye in tabel A bevat wie se sleutels *nie* die
+    term: anti-koppeling
+    def: '''n [Koppeling](#join) wat rye in tabel A bevat wie se sleutels *nie* die
       sleutels van tabel B bevat nie.
+
+      '
   es:
-    term: "anti join"
-    def: >
-      Una [unión](#join) que conserva las filas de la tabla A cuyas claves *no*
+    term: anti join
+    def: 'Una [unión](#join) que conserva las filas de la tabla A cuyas claves *no*
       coinciden con las de la tabla B.
+
+      '
   am:
     term: ፀረ መቀላቀል
     def: "በረድፎች ሠንጠረዥ ሀን ከሠንጠረዥ ለ እንዳይቀላቀሉ የሚያግዱ (#join) ቁልፎች  *ቁልፎች* \n"
   fr:
-    term: "anti join"
-    def: >
-      Une jointure qui conserve les lignes de la table A dont les clés ne correspondent pas aux clés de la table B.
+    term: anti join
+    def: 'Une jointure qui conserve les lignes de la table A dont les clés ne correspondent
+      pas aux clés de la table B.
 
+      '
 - slug: api
   en:
-    term: "Application Programming Interface"
-    acronym: "API"
-    def: >
-      A set of functions and procedures provided by one software library or web
-      service through which another application can communicate with it. An API is not
-      the code, the database, or the server: it's the access point.
+    term: Application Programming Interface
+    acronym: API
+    def: 'A set of functions and procedures provided by one software library or web
+      service through which another application can communicate with it. An API is
+      not the code, the database, or the server: it''s the access point.
+
+      '
   af:
-    term: "Toepassing Programmeerderkoppelvlak"
-    def: >
-      n Versameling funksies en prosedures wat deur 'n sagtewareprogrammateek of
-      webdiens voorsien word vir gebruik deur ander toepassings om met die
-      programmateek of webdiens te kommunikeer. Die API is nie die kode, die databasis
-      of die bediener nie, dit is die koppelvlak.
+    term: Toepassing Programmeerderkoppelvlak
+    def: 'n Versameling funksies en prosedures wat deur ''n sagtewareprogrammateek
+      of webdiens voorsien word vir gebruik deur ander toepassings om met die programmateek
+      of webdiens te kommunikeer. Die API is nie die kode, die databasis of die bediener
+      nie, dit is die koppelvlak.
+
+      '
   es:
-    term: "Interfaz de Programación de Aplicaciones"
-    def: >
-      Un conjunto de funciones y procedimientos proporcionados por una libreria de software o servicio web
-      atraves del cual otra aplicación se puede comunicar. Una API no es el código,
-      la base de datos o el servidor; es el punto de acceso.
+    term: Interfaz de Programación de Aplicaciones
+    def: 'Un conjunto de funciones y procedimientos proporcionados por una libreria
+      de software o servicio web atraves del cual otra aplicación se puede comunicar.
+      Una API no es el código, la base de datos o el servidor; es el punto de acceso.
+
+      '
   ar:
-    term: "واجهة التطبيق البرمجية"
-    def: >
-      مجموعة من الوظائف والإجراءات التي توفرها مكتبات البرامج أو خدمة الويب والتي يمكن من خلالها  لتطبيق آخر التواصل معها.
-      واجهة التطبيق البرمجية ليست الكود أو قاعدة البيانات أو الخادم: إنها نقطة الوصول.
+    term: واجهة التطبيق البرمجية
+    def: 'مجموعة من الوظائف والإجراءات التي توفرها مكتبات البرامج أو خدمة الويب والتي
+      يمكن من خلالها  لتطبيق آخر التواصل معها. واجهة التطبيق البرمجية ليست الكود أو
+      قاعدة البيانات أو الخادم: إنها نقطة الوصول.
+
+      '
   fr:
-    term: "Interface de Programmation d'application"
-    def: >
-      Un ensemble de fonctions et de procédures fournies par une bibliothèque de logiciels ou un service web
-      par lequel une autre application peut communiquer. Une API n'est ni le code, ni la base de données
-      ni le serveur, mais le point d'accès.
+    term: Interface de Programmation d'application
+    def: 'Un ensemble de fonctions et de procédures fournies par une bibliothèque
+      de logiciels ou un service web par lequel une autre application peut communiquer.
+      Une API n''est ni le code, ni la base de données ni le serveur, mais le point
+      d''accès.
+
+      '
   de:
-    term: "Schnittstelle zur Programmierung von Anwendungen"
-    def: >
-      Eine Sammlung von Funktionen und Prozeduren die von einer Softwarebibliothek bereitgestellt werden, sodass eine andere Software  damit interagieren kann. Eine API ist nicht der Code, die Datenbasis oder ein Server sie ist lediglich der Anküpfungspunkt.
+    term: Schnittstelle zur Programmierung von Anwendungen
+    def: 'Eine Sammlung von Funktionen und Prozeduren die von einer Softwarebibliothek
+      bereitgestellt werden, sodass eine andere Software  damit interagieren kann.
+      Eine API ist nicht der Code, die Datenbasis oder ein Server sie ist lediglich
+      der Anküpfungspunkt.
+
+      '
   am:
     term: የትግበራ ፕሮግራም በይነገጽ
-    def: >
-      በአንድ የሶፍትዌር ቤተ-መጽሐፍት ወይም ድር የሚሰጡ የተግባሮች እና የአሠራር ሂደቶች ስብስብ ሌላ መተግበሪያ ከእሱ ጋር መገናኘት የሚችልበት አገልግሎት። ኤፒ አይ ኮድ አይደለም  ፣ የመረጃ ቋቱ ወይም አገልጋዩ የመዳረሻ ነጥብ ነው ፡፡
-  tn:
-    term: "Mekgwatiriso ya Segokaganyi (API)"
-    def: >
-      Setlhotshwana sa ditiriso le ditsamaiso mo motlobong wa serweboleta (software library), kgotsa mo Tirelong ya Webo (web service),
-      se se gokaganyang motlobo kana tirelo ya teng le Tiriso (app) e sele. Ga se khoutu, polokelotshedimosetso kana sefara: ke seletlelelakgolagano.
-  sw:
-    term: "Kiolesura cha Kuandaa Programu [API]"
-    def: >
-      Seti ya vipengele na taratibu zinazotolewa na maktaba moja ya programu au
-      huduma ya tovuti ambayo programu nyingine inaweza kuwasiliana nayo.
-      API sio msimbo, hifadhidata, au seva: ni mahali pa ufikiaji.
-  uk:
-    term: "інтерфейс програмування застосунків (API)"
-    def: >
-      Набір функцій і процедур, наданих однією програмною бібліотекою або веб-службою,
-      через які інший застосунок може з нею взаємодіяти. API – це не код, база даних чи
-      сервер: це точка доступу.
+    def: 'በአንድ የሶፍትዌር ቤተ-መጽሐፍት ወይም ድር የሚሰጡ የተግባሮች እና የአሠራር ሂደቶች ስብስብ ሌላ መተግበሪያ ከእሱ
+      ጋር መገናኘት የሚችልበት አገልግሎት። ኤፒ አይ ኮድ አይደለም  ፣ የመረጃ ቋቱ ወይም አገልጋዩ የመዳረሻ ነጥብ ነው ፡፡
 
+      '
+  tn:
+    term: Mekgwatiriso ya Segokaganyi (API)
+    def: 'Setlhotshwana sa ditiriso le ditsamaiso mo motlobong wa serweboleta (software
+      library), kgotsa mo Tirelong ya Webo (web service), se se gokaganyang motlobo
+      kana tirelo ya teng le Tiriso (app) e sele. Ga se khoutu, polokelotshedimosetso
+      kana sefara: ke seletlelelakgolagano.
+
+      '
+  sw:
+    term: Kiolesura cha Kuandaa Programu [API]
+    def: 'Seti ya vipengele na taratibu zinazotolewa na maktaba moja ya programu au
+      huduma ya tovuti ambayo programu nyingine inaweza kuwasiliana nayo. API sio
+      msimbo, hifadhidata, au seva: ni mahali pa ufikiaji.
+
+      '
+  uk:
+    term: інтерфейс програмування застосунків (API)
+    def: 'Набір функцій і процедур, наданих однією програмною бібліотекою або веб-службою,
+      через які інший застосунок може з нею взаємодіяти. API – це не код, база даних
+      чи сервер: це точка доступу.
+
+      '
 - slug: append_mode
   en:
-    term: "append mode"
-    def: >
-      To add data to the end of an existing file instead of overwriting the previous
+    term: append mode
+    def: 'To add data to the end of an existing file instead of overwriting the previous
       contents of that file. Overwriting is the default, so most programming languages
       require programs to be explicit about wanting to append instead.
+
+      '
   af:
-    term: "byvoeg modus"
-    def: >
-      Om data aan die einde van 'n lêer te voeg in plaas daarvan om die inhoud van
-      dielêer te oorskryf. Oorskryf is die verstek, wat beteken dat
-      meesteprogrammeertale verwag dat programme eksplisiet moet aandui dat daar
-      bygevoeg inplaas van oorskryf moet word.
+    term: byvoeg modus
+    def: 'Om data aan die einde van ''n lêer te voeg in plaas daarvan om die inhoud
+      van dielêer te oorskryf. Oorskryf is die verstek, wat beteken dat meesteprogrammeertale
+      verwag dat programme eksplisiet moet aandui dat daar bygevoeg inplaas van oorskryf
+      moet word.
+
+      '
   am:
     term: አባሪ ሁነታ
-    def: >
-      በቀደመው ፋይል ይዘቶች ላይ ከመፃፍ ይልቅ አሁን ባለው ፋይል መጨረሻ ላይ ውሂብ ለማከል ። እንደገና መፃፍ የነበረዉ ነው ፣ ስለሆነም አብዛኛዎቹ የፕሮግራም ቋንቋዎች በምትኩ ለመተካት ፕሮግራሞች ግልጽ እንዲሆኑ ይጠይቃሉ።
-  fr:
-    term: "append mode"
-    def: >
-      Le fait d'ajouter des données à la fin d'un fichier existant au lieu d'écraser le contenu précédent de ce fichier. L'écrasement est la valeur par défaut, donc la plupart des langages de programmation exigent que les programmes soient explicites sur le fait de vouloir ajouter des données à la place.
-  sw:
-    term: "Hali ya Kuambatanisha"
-    def: >
-      Kuongeza data mwishoni mwa faili iliyopo badala ya kubatilisha yaliyomo awali ya faili hiyo.
-      Kuandika upya ni chaguo-msingi, kwa hivyo lugha nyingi za programu ahitaji programu kuwa wazi kuhusu kutaka kuambatanisha badala yake.
+    def: 'በቀደመው ፋይል ይዘቶች ላይ ከመፃፍ ይልቅ አሁን ባለው ፋይል መጨረሻ ላይ ውሂብ ለማከል ። እንደገና መፃፍ የነበረዉ
+      ነው ፣ ስለሆነም አብዛኛዎቹ የፕሮግራም ቋንቋዎች በምትኩ ለመተካት ፕሮግራሞች ግልጽ እንዲሆኑ ይጠይቃሉ።
 
+      '
+  fr:
+    term: append mode
+    def: 'Le fait d''ajouter des données à la fin d''un fichier existant au lieu d''écraser
+      le contenu précédent de ce fichier. L''écrasement est la valeur par défaut,
+      donc la plupart des langages de programmation exigent que les programmes soient
+      explicites sur le fait de vouloir ajouter des données à la place.
+
+      '
+  sw:
+    term: Hali ya Kuambatanisha
+    def: 'Kuongeza data mwishoni mwa faili iliyopo badala ya kubatilisha yaliyomo
+      awali ya faili hiyo. Kuandika upya ni chaguo-msingi, kwa hivyo lugha nyingi
+      za programu ahitaji programu kuwa wazi kuhusu kutaka kuambatanisha badala yake.
+
+      '
 - slug: argument
   en:
-    term: "argument"
-    def: >
-      The term should not be confused with, and is not a synonym for,
-      [parameter](#parameter). An argument is one of possibly several expressions
-      that are passed to a function. It is the actual value that is passed.
-      Parameters and arguments are distinct, but related concepts. Parameters are
-      variables and arguments are the values assigned to those variables.
+    term: argument
+    def: 'The term should not be confused with, and is not a synonym for, [parameter](#parameter).
+      An argument is one of possibly several expressions that are passed to a function.
+      It is the actual value that is passed. Parameters and arguments are distinct,
+      but related concepts. Parameters are variables and arguments are the values
+      assigned to those variables.
+
+      '
   es:
-    term: "argumento"
-    def: >
-      El término no debe ser confundido con, ni es sinónimo de, [parámetro](#parameter).
-      Un argumento es una de posiblemente varias expresiones que son pasadas a una función.
-      Es el valor real que se pasa.
-      Parámetros y argumentos son conceptos distintos pero relacionados.
-      Los parámetros son variables y los argumentos son los valores asignados a esas variables.
+    term: argumento
+    def: 'El término no debe ser confundido con, ni es sinónimo de, [parámetro](#parameter).
+      Un argumento es una de posiblemente varias expresiones que son pasadas a una
+      función. Es el valor real que se pasa. Parámetros y argumentos son conceptos
+      distintos pero relacionados. Los parámetros son variables y los argumentos son
+      los valores asignados a esas variables.
+
+      '
   fr:
-    term: "argument"
-    def: >
-      Un argument est une expression donnée passée à une fonction.
-      Ce terme ne doit pas être confondu avec [paramètre](#parameter), et n'en est pas un
-      synonyme. Alors qu'un paramètre est une variable, un argument est une valeur associée
+    term: argument
+    def: 'Un argument est une expression donnée passée à une fonction. Ce terme ne
+      doit pas être confondu avec [paramètre](#parameter), et n''en est pas un synonyme.
+      Alors qu''un paramètre est une variable, un argument est une valeur associée
       à cette variable.
+
+      '
   pt:
-    term: "argumento"
-    def: >
-      O termo não deve ser confundido com, e não é sinônimo de, [parâmetro](#parameter). Um argumento é uma das
-      possíveis expressões que são passadas para uma função. É o valor real que é transmitido.
-      Parâmetros e argumentos são conceitos distintos, mas relacionados. Parâmetros são variáveis e argumentos
-      são os valores atribuídos a essas variáveis.
+    term: argumento
+    def: 'O termo não deve ser confundido com, e não é sinônimo de, [parâmetro](#parameter).
+      Um argumento é uma das possíveis expressões que são passadas para uma função.
+      É o valor real que é transmitido. Parâmetros e argumentos são conceitos distintos,
+      mas relacionados. Parâmetros são variáveis e argumentos são os valores atribuídos
+      a essas variáveis.
+
+      '
   ar:
-    term: "وسيطة"
-    def: >
-      قيمة يتم تمريرها إلى دالة أو وسيطة ، البعض يُطلِق عليها مصطلح
-      [مُعطى](#parameter)
+    term: وسيطة
+    def: 'قيمة يتم تمريرها إلى دالة أو وسيطة ، البعض يُطلِق عليها مصطلح [مُعطى](#parameter)
       والبعض الآخر يُطلِق عليها مصطلح وسيطة.
+
+      '
   af:
-    term: "argument"
-    def: >
-      Die term moet nie verwar word met [parameter](#parameter) nie en is ook nie 'n
-      sinoniem daarvoor nie. 'n Argument is die spesifieke waarde wat aan 'n funksie
-      verskaf word in 'n lys van waardes wat deur kommas geskei word
-      Die term moet nie verwar word met [parameter](#parameter) nie en is ook nie 'n
-      sinoniem daarvoor nie. 'n Argument is die spesifieke waarde wat aan 'n funksie
-      verskaf word in 'n lys van waardes wat deur kommas geskei word. Parameters is
-      die veranderlikes en argumente is die waardes wat aan die veranderlikes toegeken is.
+    term: argument
+    def: 'Die term moet nie verwar word met [parameter](#parameter) nie en is ook
+      nie ''n sinoniem daarvoor nie. ''n Argument is die spesifieke waarde wat aan
+      ''n funksie verskaf word in ''n lys van waardes wat deur kommas geskei word
+      Die term moet nie verwar word met [parameter](#parameter) nie en is ook nie
+      ''n sinoniem daarvoor nie. ''n Argument is die spesifieke waarde wat aan ''n
+      funksie verskaf word in ''n lys van waardes wat deur kommas geskei word. Parameters
+      is die veranderlikes en argumente is die waardes wat aan die veranderlikes toegeken
+      is.
+
+      '
   de:
-    term: "Argument"
-    def: >
-      Nicht zu verwechseln mit dem [Parameter](#parameter).  Parameter und Argumente sind
-      verwandt aber nicht identisch. Ein Argument ist der tatsächliche Wert eines Parameters
-      der beim Funktionsaufruf übergeben wird.
+    term: Argument
+    def: 'Nicht zu verwechseln mit dem [Parameter](#parameter).  Parameter und Argumente
+      sind verwandt aber nicht identisch. Ein Argument ist der tatsächliche Wert eines
+      Parameters der beim Funktionsaufruf übergeben wird.
+
+      '
   am:
     term: ክርክር
-    def: >
-      ቃሉ ግራ መጋባት የለበትም ፣ ተመሳሳይ ቃልም  አይደለም ፣ [ግቤት](#parameter)። ክርክር ምናልባት ከበርካታ አገላለጾች አንዱ እና ወደ ተግባር የሚተላለፉ ነው ፡፡ እሱም  የተላለፈው ትክክለኛ እሴት ነው። መለኪያዎች እና ክርክሮች የተለዩ ናቸው ፣ ግን ተዛማጅ ፅንሰ ሀሳቦች ናቸው። መለኪያዎች ተለዋዋጮች ናቸው  ክርክሮች ደግሞ ለእነዚያ ተለዋዋጮች የተሰጡ እሴቶች ናቸው።
+    def: 'ቃሉ ግራ መጋባት የለበትም ፣ ተመሳሳይ ቃልም  አይደለም ፣ [ግቤት](#parameter)። ክርክር ምናልባት ከበርካታ
+      አገላለጾች አንዱ እና ወደ ተግባር የሚተላለፉ ነው ፡፡ እሱም  የተላለፈው ትክክለኛ እሴት ነው። መለኪያዎች እና ክርክሮች
+      የተለዩ ናቸው ፣ ግን ተዛማጅ ፅንሰ ሀሳቦች ናቸው። መለኪያዎች ተለዋዋጮች ናቸው  ክርክሮች ደግሞ ለእነዚያ ተለዋዋጮች የተሰጡ
+      እሴቶች ናቸው።
+
+      '
   sw:
-    term: "Hoja"
-    def: >
-      Neno hilo halipaswi kuchanganywa na, na si kisawe cha,[parameter](#parameter).
+    term: Hoja
+    def: 'Neno hilo halipaswi kuchanganywa na, na si kisawe cha,[parameter](#parameter).
       Hoja ni mojawapo ya misemo kadhaa ambayo hupitishwa kwa chaguo la kukokotoa.
       Ni thamani halisi inayopitishwa. Vigezo na hoja ni tofauti, lakini dhana zinazohusiana.
       Vigezo ni vigeuzo na hoja ni thamani zilizopewa vigeu hivyo.
-  uk:
-    term: "аргумент"
-    def: >
-      Термін не слід плутати з [параметром](#parameter), це не синонім. Аргумент — це 
-      фактичне значення, яке передається функції під час її виклику.
-      Параметри та аргументи — це різні, але пов’язані поняття. Параметри — це змінні,
-      а аргументи — це значення, які призначаються цим змінним.
 
+      '
+  uk:
+    term: аргумент
+    def: 'Термін не слід плутати з [параметром](#parameter), це не синонім. Аргумент
+      — це  фактичне значення, яке передається функції під час її виклику. Параметри
+      та аргументи — це різні, але пов’язані поняття. Параметри — це змінні, а аргументи
+      — це значення, які призначаються цим змінним.
+
+      '
 - slug: arithmetic_mean
   en:
-    term: "arithmetic mean"
-    def: >
-      See [mean](#mean). Calculated from a set of n numbers by summing those
-      numbers, and dividing the result by n.
-      See [mean](#mean).
+    term: arithmetic mean
+    def: 'See [mean](#mean). Calculated from a set of n numbers by summing those numbers,
+      and dividing the result by n. See [mean](#mean).
+
+      '
   it:
-    term: "media aritmetica"
-    def: >
-      Vedi [media](#mean).
+    term: media aritmetica
+    def: 'Vedi [media](#mean).
+
+      '
   pt:
-    term: "média aritmética"
-    def: >
-      Veja [média](#mean).
+    term: média aritmética
+    def: 'Veja [média](#mean).
+
+      '
   es:
-    term: "media aritmética"
-    def: >
-      Ver [media](#mean). Calculado por un grupo de n números realizando la suma
+    term: media aritmética
+    def: 'Ver [media](#mean). Calculado por un grupo de n números realizando la suma
       de esos números y dividiendo el resultado entre n.
+
+      '
   af:
-    term: "rekenkundige gemiddelde"
-    def: >
-      Sien [gemiddelde](#mean).
+    term: rekenkundige gemiddelde
+    def: 'Sien [gemiddelde](#mean).
+
+      '
   am:
     term: የሂሳብ ሚዛን
-    def: >
-      ይመልከቱ [ማለት](#mean)
-  fr:
-    term: "moyenne arithmétique"
-    def: >
-      Calculé à partir d'un ensemble de n nombres en additionnant ces nombres et en divisant le résultat par n.
-  sw:
-    term: "wastani wa hesabu"
-    def: >
-      Rejelea [mean](#mean).
-      Imehesabiwa kutoka kwa seti ya nambari za n kwa kujumlisha nambari hizo,
-      na kugawanya matokeo na
-  uk:
-    term: "середнє арифметичне"
-    def: >
-      Обчислюється для набору з n чисел шляхом знаходження їх суми та ділення результату на n.
-      [Див. також середнє значення](#mean).
+    def: 'ይመልከቱ [ማለት](#mean)
 
+      '
+  fr:
+    term: moyenne arithmétique
+    def: 'Calculé à partir d''un ensemble de n nombres en additionnant ces nombres
+      et en divisant le résultat par n.
+
+      '
+  sw:
+    term: wastani wa hesabu
+    def: 'Rejelea [mean](#mean). Imehesabiwa kutoka kwa seti ya nambari za n kwa kujumlisha
+      nambari hizo, na kugawanya matokeo na
+
+      '
+  uk:
+    term: середнє арифметичне
+    def: 'Обчислюється для набору з n чисел шляхом знаходження їх суми та ділення
+      результату на n. [Див. також середнє значення](#mean).
+
+      '
+- slug: array
+  ref:
+  - vector
+  en:
+    term: array
+    def: 'A collection of values stored in a regular grid or multi-dimensional structure,
+      where each element can be accessed by its position or index. Arrays can be one-dimensional
+      (like a [vector](#vector)), two-dimensional, or higher-dimensional.
+
+      '
 - slug: artificial_intelligence
   ref:
-    - nlp
-    - machine_learning
+  - nlp
+  - machine_learning
   en:
-    term: "artificial intelligence (AI)"
-    def: >
-      Intelligence demonstrated by machines, as opposed to humans or other animals. AI can be
-      exhibited through perceiving, synthesizing and inference of information. Example tasks include
-      [natural language processing](#nlp), computer vision, and [machine learning]
-      (#machine_learning).
-  uk:
-    term: "штучний інтелект (ШІ)"
-    def: >
-      Інтелект, який демонструють машини, на відміну від людей або інших тварин. ШІ може проявлятися
-      через сприйняття, синтезування та виведення інформації. Серед завдань можна виділити [обробку природної мови](#nlp),
-      комп'ютерний зір та [машинне навчання](#machine_learning).
-  af:
-    term: "kunsmatige intelligensie (KI)"
-    def: >
-      Intelligensie wat deur masjiene getoon word, in teenstelling met mense of ander diere.
-      KI kan manifesteer deur waarneming, sintese en afleiding van inligting.
-      Voorbeelde van sulke take sluit in [natuurlike taalverwerking](#nlp),
-      rekenaarvisie, en [masjienleer](#machine_learning).
+    term: artificial intelligence (AI)
+    def: 'Intelligence demonstrated by machines, as opposed to humans or other animals.
+      AI can be exhibited through perceiving, synthesizing and inference of information.
+      Example tasks include [natural language processing](#nlp), computer vision,
+      and [machine learning] (#machine_learning).
 
+      '
+  uk:
+    term: штучний інтелект (ШІ)
+    def: 'Інтелект, який демонструють машини, на відміну від людей або інших тварин.
+      ШІ може проявлятися через сприйняття, синтезування та виведення інформації.
+      Серед завдань можна виділити [обробку природної мови](#nlp), комп''ютерний зір
+      та [машинне навчання](#machine_learning).
+
+      '
+  af:
+    term: kunsmatige intelligensie (KI)
+    def: 'Intelligensie wat deur masjiene getoon word, in teenstelling met mense of
+      ander diere. KI kan manifesteer deur waarneming, sintese en afleiding van inligting.
+      Voorbeelde van sulke take sluit in [natuurlike taalverwerking](#nlp), rekenaarvisie,
+      en [masjienleer](#machine_learning).
+
+      '
 - slug: ascii
   en:
-    term: "ASCII"
-    def: >
-      A standard way to represent the characters commonly used in the Western European
-      languages as 7- or 8-[bit](#bit) integers, now superseded by [Unicode](#unicode).
+    term: ASCII
+    def: 'A standard way to represent the characters commonly used in the Western
+      European languages as 7- or 8-[bit](#bit) integers, now superseded by [Unicode](#unicode).
+
+      '
   af:
-    term: "ASCII"
-    def: >
-      'n Standaard manier om karakters wat algemeen in Wes-Europese tale gebruik word,
-      voor te stel as 7- of 8-bis heelgetalle. ASCII word vervang deur [Unicode](#unicode).
+    term: ASCII
+    def: '''n Standaard manier om karakters wat algemeen in Wes-Europese tale gebruik
+      word, voor te stel as 7- of 8-bis heelgetalle. ASCII word vervang deur [Unicode](#unicode).
+
+      '
   ar:
-    term: "آسكي"
-    def: >
-      طريقة قياسية لتمثيل الأحرف المستخدمة بشكل شائع في لغات أوروبا الغربية كأعداد صحيحة من ٧ أو ٨ بت،
-      يحل محلها الآن   [الترميز الموحد] (#unicode).
+    term: آسكي
+    def: 'طريقة قياسية لتمثيل الأحرف المستخدمة بشكل شائع في لغات أوروبا الغربية كأعداد
+      صحيحة من ٧ أو ٨ بت، يحل محلها الآن   [الترميز الموحد] (#unicode).
+
+      '
   es:
-    term: "ASCII"
-    def: >
-      Manera estándar de representar los caracteres comúnmente usados en lenguajes de Europa Occidental
-      como enteros de 7- u 8-[bits](#bit), ahora reemplazado por [Unicode](#unicode).
+    term: ASCII
+    def: 'Manera estándar de representar los caracteres comúnmente usados en lenguajes
+      de Europa Occidental como enteros de 7- u 8-[bits](#bit), ahora reemplazado
+      por [Unicode](#unicode).
+
+      '
   de:
-    term: "ASCII"
-    def: >
-      Eine standardisierte Methode um Zeichen und Ziffern, vornehmlich der Westeuropäischen
+    term: ASCII
+    def: 'Eine standardisierte Methode um Zeichen und Ziffern, vornehmlich der Westeuropäischen
       Sprachen, in 7 oder 8 [Bits](#bit) darzustellen. Heute weitgehend durch [Unicode](#unicode)
       abgelöst.
+
+      '
   am:
     term: አስኪ
-    def: >
-      በምዕራብ አውሮፓ ቋንቋዎች ውስጥ ጥቅም ላይ የዋሉ ገጸ-ባህሪያትን ለመወከል የሚጠቅም መደበኛ መንገድ እንደ 7 ወይም 8 ቢት ቁጥሮች ፣ አሁን በ [ዩኒኮድ](#unicode) የሚተዳደሩ
-  fr:
-    term: "ASCII"
-    def: >
-      Une norme informatique de codage qui représente les caractères couramment utilisés dans les langues d'Europe occidentale à 7 ou 8
-      [bits](#bit), aujourd'hui largement remplacé par [Unicode](#unicode).
-  sw:
-    term: "ASCII"
-    def: >
-      Njia ya kawaida ya kuwakilisha herufi zinazotumiwa sana katika lugha za Ulaya Magharibi kama nambari kamili 7- au 8-[bit](#bit),
-      ambayo sasa imechukuliwa na [Unicode](#unicode).
-  uk:
-    term: "ASCII"
-    def: >
-      Стандартний спосіб представлення символів, які зазвичай використовуються
-      в західноєвропейських мовах, у вигляді 7- або 8-бітних цілих чисел. 
-      Зараз замінений на [Unicode](#unicode).
+    def: 'በምዕራብ አውሮፓ ቋንቋዎች ውስጥ ጥቅም ላይ የዋሉ ገጸ-ባህሪያትን ለመወከል የሚጠቅም መደበኛ መንገድ እንደ 7 ወይም
+      8 ቢት ቁጥሮች ፣ አሁን በ [ዩኒኮድ](#unicode) የሚተዳደሩ
 
+      '
+  fr:
+    term: ASCII
+    def: 'Une norme informatique de codage qui représente les caractères couramment
+      utilisés dans les langues d''Europe occidentale à 7 ou 8 [bits](#bit), aujourd''hui
+      largement remplacé par [Unicode](#unicode).
+
+      '
+  sw:
+    term: ASCII
+    def: 'Njia ya kawaida ya kuwakilisha herufi zinazotumiwa sana katika lugha za
+      Ulaya Magharibi kama nambari kamili 7- au 8-[bit](#bit), ambayo sasa imechukuliwa
+      na [Unicode](#unicode).
+
+      '
+  uk:
+    term: ASCII
+    def: 'Стандартний спосіб представлення символів, які зазвичай використовуються
+      в західноєвропейських мовах, у вигляді 7- або 8-бітних цілих чисел.  Зараз замінений
+      на [Unicode](#unicode).
+
+      '
 - slug: assertion
   en:
-    term: "assertion"
-    def: >
-      A [Boolean](#boolean) expression that must be [true](#true) at a certain point in a
-      program. Assertions may be built into the language (e.g., [Python](#python)'s
-      `assert` statement) or provided as functions (e.g., [R](#r_language)'s `stopifnot`). They are
-      often used in testing, but are also put in [production code](#production_code)
-      to check that it is behaving correctly. In many languages, assertions should not be
-      used to perform data validation as they may be silently dropped by compilers and interpreters
-      under optimization conditions. Using assertions for data validation can therefore
-      introduce security risks. Unlike many languages, R does not have an `assert` statement
-      which can be disabled, and so use of a [package](#package) such as `assertr` for data
-      validation does not create security holes.
+    term: assertion
+    def: 'A [Boolean](#boolean) expression that must be [true](#true) at a certain
+      point in a program. Assertions may be built into the language (e.g., [Python](#python)''s
+      `assert` statement) or provided as functions (e.g., [R](#r_language)''s `stopifnot`).
+      They are often used in testing, but are also put in [production code](#production_code)
+      to check that it is behaving correctly. In many languages, assertions should
+      not be used to perform data validation as they may be silently dropped by compilers
+      and interpreters under optimization conditions. Using assertions for data validation
+      can therefore introduce security risks. Unlike many languages, R does not have
+      an `assert` statement which can be disabled, and so use of a [package](#package)
+      such as `assertr` for data validation does not create security holes.
+
+      '
   af:
-    term: "bewering"
-    def: >
-      'n [Boole](#boolean)-uitdrukking wat waar moet wees op 'n spesifiek plek
-      in 'n program. 'n Bewering kan ingebou wees in 'n programmeertaal (bv.
-      [Python](#python) het 'n ingeboude beweerstelling - assert) of dit kan
-      voorsien word as 'n funksie (bv. [R](#r_language) gebruik `stopifnot`).
-      Bewerings word dikwels gebruik gedurende die toetsfase van sagtewareontwikkeling
-      maar dit word ook gebruk in [produksieskode](#production_code) om te
-      bevestig dat die kode reg werk. In sommige tale moet die gebruik van
-      bewerings as 'n datageldigheidstoets vermy word aangesien sommige
-      kompileerders en interpreteerders die bewering stilweg weggooi onder
-      optimeringsvoorwaardes. Die gebruik van bewerings vir bevestiging van
-      datageldigheid kan dus sekuriteitsrisikos veroorsaak. R het nie 'n
-      beweringstelling wat gedeaktiveer kan word nie en dus sal die gebruik
-      van 'n [pakket](#package) soos 'assertr' vir datageldigheid nie
-      sekuriteitsgapings skep nie.
+    term: bewering
+    def: '''n [Boole](#boolean)-uitdrukking wat waar moet wees op ''n spesifiek plek
+      in ''n program. ''n Bewering kan ingebou wees in ''n programmeertaal (bv. [Python](#python)
+      het ''n ingeboude beweerstelling - assert) of dit kan voorsien word as ''n funksie
+      (bv. [R](#r_language) gebruik `stopifnot`). Bewerings word dikwels gebruik gedurende
+      die toetsfase van sagtewareontwikkeling maar dit word ook gebruk in [produksieskode](#production_code)
+      om te bevestig dat die kode reg werk. In sommige tale moet die gebruik van bewerings
+      as ''n datageldigheidstoets vermy word aangesien sommige kompileerders en interpreteerders
+      die bewering stilweg weggooi onder optimeringsvoorwaardes. Die gebruik van bewerings
+      vir bevestiging van datageldigheid kan dus sekuriteitsrisikos veroorsaak. R
+      het nie ''n beweringstelling wat gedeaktiveer kan word nie en dus sal die gebruik
+      van ''n [pakket](#package) soos ''assertr'' vir datageldigheid nie sekuriteitsgapings
+      skep nie.
+
+      '
   de:
-    term: "Assertion"
-    def: >
-      Eine [Boolscher Ausdruck](#boolean) welcher zu einem bestimmten Punkt während
+    term: Assertion
+    def: 'Eine [Boolscher Ausdruck](#boolean) welcher zu einem bestimmten Punkt während
       der Programlaufzeit [wahr](#true) sein muss um fortzuschreiten. In verschiedenen
-      Sprachen (z.B. `assert` in [Python](#python)) sind diese Sicherstellungen fest integriert,
-      oder werden als Funktionen bereitgestellt (z.B. `stopifnot` in [R](#r_language)).
-      Sie werden häufig zum testen von code verwendet, können aber auch in [fertigen Quellcode](#production_code)
-      einfließen um eine korrekte Ausführung zu gewährleisten. In vielen Sprachen sollten
-      Assertionen jedoch nicht zur Datenvalidierung verwendet werden, da der Compiler je
-      nach Optimierungsgrad diese entfernen kann. Assertionen können ein Sicherheitsrisiko
-      darstellen. In R können Assertionen nicht deaktiviert werden, daher werden
-      externe [Pakete](#package) wie beispielsweise `assertr` zur Datenvalidierung verwendet
-      ohne ein Sicherheitsrisiko darzustellen.
+      Sprachen (z.B. `assert` in [Python](#python)) sind diese Sicherstellungen fest
+      integriert, oder werden als Funktionen bereitgestellt (z.B. `stopifnot` in [R](#r_language)).
+      Sie werden häufig zum testen von code verwendet, können aber auch in [fertigen
+      Quellcode](#production_code) einfließen um eine korrekte Ausführung zu gewährleisten.
+      In vielen Sprachen sollten Assertionen jedoch nicht zur Datenvalidierung verwendet
+      werden, da der Compiler je nach Optimierungsgrad diese entfernen kann. Assertionen
+      können ein Sicherheitsrisiko darstellen. In R können Assertionen nicht deaktiviert
+      werden, daher werden externe [Pakete](#package) wie beispielsweise `assertr`
+      zur Datenvalidierung verwendet ohne ein Sicherheitsrisiko darzustellen.
+
+      '
   am:
     term: ማረጋገጫ
-    def: >
-      በአንድ [የተወሰነ] ቦታ ፕሮግራም ዉስጥ  ግዴታ  [እውነተኛ](#boolean) መሆን ያለበት የ [ቦሊያን](#true) አገላለጽ ነዉ.  ምልከታዎች በቋንቋው ውስጥ ሊገነቡ ይችላሉ (ለምሳሌ ፣ [ፓይቶን](#python) ዎቹ እንደ "ማረጋገጫ" መግለጫ ወይም እንደ ተግባራት ይቀርባሉ ል (ለምሳሌ ፣ [R](#r_language) 'stopifnot')።  ብዙውን ጊዜ ለሙከራ ጥቅም ላይ ይውላሉ ፣ ግን ደግሞ በትክክል እየሰራ መሆኑን ለማጣራት   [በምርት ኮድ](#production_code) ውስጥ ይቀመጣሉ፡፡  በብዙ ቋንቋዎች ማረጋገጫዎች መሆን የለባቸውም በአቀነባባሪዎች እና በአስተርጓሚዎች በዝምታ ሊጣሉ ስለሚችሉ የውሂብ ማረጋገጫ ለማከናወን ያገለግል ነበር በማመቻቸት ሁኔታዎች ውስጥ. ለመረጃ ማረጋገጫ ማረጋገጫዎችን መጠቀም ይችላል የደህንነት አደጋዎችን ያስተዋውቁ ፡፡ ከብዙ ቋንቋዎች በተለየ መልኩ አር "ማረጋገጫ" መግለጫ የለውም ሊቦዝን ይችላል ፣ እና ስለዚህ እንደ "assertr`" የመሰለ [ጥቅል](#package) መጠቀም ማረጋገጫ የደህንነት ቀዳዳዎችን አይፈጥርም ፡፡
+    def: 'በአንድ [የተወሰነ] ቦታ ፕሮግራም ዉስጥ  ግዴታ  [እውነተኛ](#boolean) መሆን ያለበት የ [ቦሊያን](#true)
+      አገላለጽ ነዉ.  ምልከታዎች በቋንቋው ውስጥ ሊገነቡ ይችላሉ (ለምሳሌ ፣ [ፓይቶን](#python) ዎቹ እንደ "ማረጋገጫ"
+      መግለጫ ወይም እንደ ተግባራት ይቀርባሉ ል (ለምሳሌ ፣ [R](#r_language) ''stopifnot'')።  ብዙውን ጊዜ
+      ለሙከራ ጥቅም ላይ ይውላሉ ፣ ግን ደግሞ በትክክል እየሰራ መሆኑን ለማጣራት   [በምርት ኮድ](#production_code)
+      ውስጥ ይቀመጣሉ፡፡  በብዙ ቋንቋዎች ማረጋገጫዎች መሆን የለባቸውም በአቀነባባሪዎች እና በአስተርጓሚዎች በዝምታ ሊጣሉ ስለሚችሉ
+      የውሂብ ማረጋገጫ ለማከናወን ያገለግል ነበር በማመቻቸት ሁኔታዎች ውስጥ. ለመረጃ ማረጋገጫ ማረጋገጫዎችን መጠቀም ይችላል
+      የደህንነት አደጋዎችን ያስተዋውቁ ፡፡ ከብዙ ቋንቋዎች በተለየ መልኩ አር "ማረጋገጫ" መግለጫ የለውም ሊቦዝን ይችላል ፣
+      እና ስለዚህ እንደ "assertr`" የመሰለ [ጥቅል](#package) መጠቀም ማረጋገጫ የደህንነት ቀዳዳዎችን አይፈጥርም
+      ፡፡
 
+      '
   sw:
-    term: "Madai"
-    def: >
-      Semi ya [Boolean](#boolean) ambayo lazima iwe [true](#true) katika hatua fulani katika programu.
-      Madai yanaweza kujengwa katika lugha (k.m., kauli ya `assert` ya [Python](#python)) au
-      kutolewa kama vitendakazi (k.m., `stopifnot` ya [R](#r_language)).
-      Mara nyingi hutumiwa katika majaribio, lakini pia huwekwa katika [production code](#production_code) ili kuangalia ikiwa inatenda ipasavyo.
-      Katika lugha nyingi, madai hayafai kutumiwa kutekeleza uthibitishaji wa data kwa vile yanaweza kuondolewa kimyakimya na wakusanyaji na
-      wakalimani chini ya hali ya uboreshaji. Kutumia madai kwa uthibitishaji wa data kwa hivyo kunaweza kuanzisha hatari za usalama.
-      Tofauti na lugha nyingi, R haina taarifa ya `assert` ambayo inaweza kuzimwa,
-      na kwa hivyo matumizi ya [package](#package) kama vile `assertr` kwa uthibitishaji wa data haileti mashimo ya usalama.
-  uk:
-    term: "припущення"
-    def: >
-      [Булевий вираз](#boolean), який повинен бути [істинним](#true) під час його обчислення у програмі.
-      Припущення можуть бути вбудованими в мову програмування (наприклад, оператор `assert` у [Python](#python))
-      або надаватися як функції (наприклад, `stopifnot` в [R](#r_language)).
-      Припущення часто використовуються розробниками під час тестування, але також можуть бути постійно
-      залишені у коді для перевірки подальшої правильності його виконання.
-      У багатьох мовах програмування припущення не слід використовувати для перевірки даних,
-      оскільки компілятори та інтерпретатори можуть їх пропускати під час оптимізації.
-      Використання припущень для перевірки даних може, таким чином, створити ризики безпеки.
-      Але на відміну від багатьох мов, R не має оператора `assert`, який можна вимкнути, тому
-      використання такого [пакета](#package) як `assertr` для перевірки даних є безпечним.
+    term: Madai
+    def: 'Semi ya [Boolean](#boolean) ambayo lazima iwe [true](#true) katika hatua
+      fulani katika programu. Madai yanaweza kujengwa katika lugha (k.m., kauli ya
+      `assert` ya [Python](#python)) au kutolewa kama vitendakazi (k.m., `stopifnot`
+      ya [R](#r_language)). Mara nyingi hutumiwa katika majaribio, lakini pia huwekwa
+      katika [production code](#production_code) ili kuangalia ikiwa inatenda ipasavyo.
+      Katika lugha nyingi, madai hayafai kutumiwa kutekeleza uthibitishaji wa data
+      kwa vile yanaweza kuondolewa kimyakimya na wakusanyaji na wakalimani chini ya
+      hali ya uboreshaji. Kutumia madai kwa uthibitishaji wa data kwa hivyo kunaweza
+      kuanzisha hatari za usalama. Tofauti na lugha nyingi, R haina taarifa ya `assert`
+      ambayo inaweza kuzimwa, na kwa hivyo matumizi ya [package](#package) kama vile
+      `assertr` kwa uthibitishaji wa data haileti mashimo ya usalama.
 
+      '
+  uk:
+    term: припущення
+    def: '[Булевий вираз](#boolean), який повинен бути [істинним](#true) під час його
+      обчислення у програмі. Припущення можуть бути вбудованими в мову програмування
+      (наприклад, оператор `assert` у [Python](#python)) або надаватися як функції
+      (наприклад, `stopifnot` в [R](#r_language)). Припущення часто використовуються
+      розробниками під час тестування, але також можуть бути постійно залишені у коді
+      для перевірки подальшої правильності його виконання. У багатьох мовах програмування
+      припущення не слід використовувати для перевірки даних, оскільки компілятори
+      та інтерпретатори можуть їх пропускати під час оптимізації. Використання припущень
+      для перевірки даних може, таким чином, створити ризики безпеки. Але на відміну
+      від багатьох мов, R не має оператора `assert`, який можна вимкнути, тому використання
+      такого [пакета](#package) як `assertr` для перевірки даних є безпечним.
+
+      '
 - slug: associative_array
   en:
-    term: "associative array"
-    def: >
-      See [dictionary](#dictionary).
+    term: associative array
+    def: 'See [dictionary](#dictionary).
+
+      '
   af:
-    term: "assosiatiewe skikking"
-    def: >
-      Sien [woordeboek](#dictionary).
+    term: assosiatiewe skikking
+    def: 'Sien [woordeboek](#dictionary).
+
+      '
   de:
-    term: "Assoziatives Array"
-    def: >
-      Siehe [Wörterbuch](#dictionary).
+    term: Assoziatives Array
+    def: 'Siehe [Wörterbuch](#dictionary).
+
+      '
   am:
     term: ተጓዳኝ ድርድር
-    def: >
-      [መዝገበ-ቃላትን](#dictionary) ይመልከቱ (#dictionary)።
-  sw:
-    term: "safu ya ushirika"
-    def: >
-      Rejelea [dictionary](#dictionary).
+    def: '[መዝገበ-ቃላትን](#dictionary) ይመልከቱ (#dictionary)።
 
+      '
+  sw:
+    term: safu ya ushirika
+    def: 'Rejelea [dictionary](#dictionary).
+
+      '
 - slug: asynchronous
   ref:
-    - synchronous
+  - synchronous
   en:
-    term: "asynchronous"
-    def: >
-      Not happening at the same time. In programming, an asynchronous operation is one
-      that runs independently of another, or that starts at one time and ends at another.
+    term: asynchronous
+    def: 'Not happening at the same time. In programming, an asynchronous operation
+      is one that runs independently of another, or that starts at one time and ends
+      at another.
+
+      '
   af:
-    term: "asinchronies"
-    def: >
-      Asinchronies is die teenoorgestelde van sinchronies wat beteken dat twee of meer
-      aktiwiteite tergelykertyd plaasvind. In programering is 'n asinchorniese bewerking 'n
-      bewerking wat onafhanklik van 'n ander een plaasvind.
+    term: asinchronies
+    def: 'Asinchronies is die teenoorgestelde van sinchronies wat beteken dat twee
+      of meer aktiwiteite tergelykertyd plaasvind. In programering is ''n asinchorniese
+      bewerking ''n bewerking wat onafhanklik van ''n ander een plaasvind.
+
+      '
   ar:
-    term: "غير متزامن"
-    def: >
-      لا يحدث في نفس الوقت.
-      في البرمجة، العملية غير المتزامنة هي العملية التي يتم تنفيذها بشكل مستقل عن الأخرى
-      أو تلك التي تبدأ في وقت معين وتنتهي في وقت آخر.
+    term: غير متزامن
+    def: 'لا يحدث في نفس الوقت. في البرمجة، العملية غير المتزامنة هي العملية التي
+      يتم تنفيذها بشكل مستقل عن الأخرى أو تلك التي تبدأ في وقت معين وتنتهي في وقت
+      آخر.
+
+      '
   el:
-    term: "ασύγχρονος"
-    def: >
-      Δεν συμβαίνει ταυτόχρονα με κάτι άλλο. Στον προγραμματισμό, μια ασύγχρονη διεργασία
-      είναι αυτή που εκτελείται ανεξάρτητα από άλλες διεργασίες.
+    term: ασύγχρονος
+    def: 'Δεν συμβαίνει ταυτόχρονα με κάτι άλλο. Στον προγραμματισμό, μια ασύγχρονη
+      διεργασία είναι αυτή που εκτελείται ανεξάρτητα από άλλες διεργασίες.
+
+      '
   es:
-    term: "asincrónico"
-    def: >
-      No sucediendo al mismo tiempo. En programación, una operación asincrónica es una que corre
-      independientemente de otra, o que comienza en un tiempo y termina en otro.
+    term: asincrónico
+    def: 'No sucediendo al mismo tiempo. En programación, una operación asincrónica
+      es una que corre independientemente de otra, o que comienza en un tiempo y termina
+      en otro.
+
+      '
   de:
-    term: "asynchron"
-    def: >
-      Nicht gleichzeitige Ausführung. In der Programmierung ist eine asynchrone Operation
-      unabhängig von anderen Operationen, oder wird zu einem bestimmten Zeitpunkt gestartet
-      oder beendet.
+    term: asynchron
+    def: 'Nicht gleichzeitige Ausführung. In der Programmierung ist eine asynchrone
+      Operation unabhängig von anderen Operationen, oder wird zu einem bestimmten
+      Zeitpunkt gestartet oder beendet.
+
+      '
   am:
     term: ያልተመሳሰለ
-    def: >
-      በተመሳሳይ ጊዜ አለመከሰት ፡፡ በፕሮግራም ውስጥ ያልተመሳሰለ አሠራር አንዱ  ከሌላው በተናጠል የሚሮጥ ፣ ወይም በተመሳሳይ  ጊዜ ተጀምሮ በሌላ ጊዜ ያበቃል ፡፡
+    def: 'በተመሳሳይ ጊዜ አለመከሰት ፡፡ በፕሮግራም ውስጥ ያልተመሳሰለ አሠራር አንዱ  ከሌላው በተናጠል የሚሮጥ ፣ ወይም በተመሳሳይ  ጊዜ
+      ተጀምሮ በሌላ ጊዜ ያበቃል ፡፡
+
+      '
   fr:
     term: asynchrone
-    def: >
-      Qui ne se produit pas en même temps. En programmation, une opération asynchrone
-      est une opération qui s'exécute indépendamment d'une autre, ou qui commence
+    def: 'Qui ne se produit pas en même temps. En programmation, une opération asynchrone
+      est une opération qui s''exécute indépendamment d''une autre, ou qui commence
       à un moment et se termine à un autre.
+
+      '
   sw:
-    term: "isiyolingana"
-    def: >
-      Haifanyiki kwa wakati mmoja. Katika programu, operesheni ya asynchronous ni ile inayoendesha kwa kujitegemea ya nyingine,
-      au ambayo huanza wakati mmoja na kuishia kwa mwingine.
+    term: isiyolingana
+    def: 'Haifanyiki kwa wakati mmoja. Katika programu, operesheni ya asynchronous
+      ni ile inayoendesha kwa kujitegemea ya nyingine, au ambayo huanza wakati mmoja
+      na kuishia kwa mwingine.
+
+      '
   uk:
-    term: "асинхронний (неодночасний)"
-    def: >
-      Характеристика чогось, що відбувається не одночасно. У програмуванні асинхронна операція - це операція, 
-      яка виконується незалежно від інших, запускається або завершується у визначений час без очікування 
-      завершення інших операцій.
-      
+    term: асинхронний (неодночасний)
+    def: 'Характеристика чогось, що відбувається не одночасно. У програмуванні асинхронна
+      операція - це операція,  яка виконується незалежно від інших, запускається або
+      завершується у визначений час без очікування  завершення інших операцій.
+
+      '
 - slug: attribute
   en:
-    term: "attribute"
-    def: >
-      A name-value pair associated with an object, used to store metadata about the
-      object such as an array's dimensions.
+    term: attribute
+    def: 'A name-value pair associated with an object, used to store metadata about
+      the object such as an array''s dimensions.
+
+      '
   fr:
-    term: "attribut"
-    def: >
-      Un couple nom-valeur associé à un objet et utilisé pour stocker des métadonnées
-      concernant ce dernier, par exemple les dimensions d'un tableau.
+    term: attribut
+    def: 'Un couple nom-valeur associé à un objet et utilisé pour stocker des métadonnées
+      concernant ce dernier, par exemple les dimensions d''un tableau.
+
+      '
   af:
-    term: "eienskap"
-    def: >
-      'n Naam-waarde paar wat verband hou met 'n voorwerp en gebruik word om
-      metadata omtrent die voorwerp te stoor, bv. die afmetings van 'n skikking.
+    term: eienskap
+    def: '''n Naam-waarde paar wat verband hou met ''n voorwerp en gebruik word om
+      metadata omtrent die voorwerp te stoor, bv. die afmetings van ''n skikking.
+
+      '
   de:
-    term: "Attribut"
-    def: >
-      Ein Name-Wert Paar welches einem Objekt zugewiesen ist und in der Regel Metadaten
-      über das Objekt, wie beispielsweise seine Größe, speichert.
+    term: Attribut
+    def: 'Ein Name-Wert Paar welches einem Objekt zugewiesen ist und in der Regel
+      Metadaten über das Objekt, wie beispielsweise seine Größe, speichert.
+
+      '
   id:
-    term: "atribut"
-    def: >
-      Pasangan nama-nilai yang merujuk kepada suatu objek, yang digunakan untuk menyimpan metadata tentang
-      suatu objek seperti dimensi dari array.
+    term: atribut
+    def: 'Pasangan nama-nilai yang merujuk kepada suatu objek, yang digunakan untuk
+      menyimpan metadata tentang suatu objek seperti dimensi dari array.
+
+      '
   tn:
-    term: "Tlhaloso_boleng jwa dilo/diteng"
-    def: >
-      Tlhaloso ya mokgwa kana tsela ya mabeelo a kitso ka e nngwe,go lebeletswe   popego ya kitso eo.
+    term: Tlhaloso_boleng jwa dilo/diteng
+    def: 'Tlhaloso ya mokgwa kana tsela ya mabeelo a kitso ka e nngwe,go lebeletswe   popego
+      ya kitso eo.
+
+      '
   am:
     term: አይነታ
-    def: >
-      የስም እሴት ጥንድ  ከእቃ ጋር የተዛመደ  እንደ ድርድር ልኬቶች ያሉ ነገሮች ለማከማቸት የሚጠቅም
+    def: 'የስም እሴት ጥንድ  ከእቃ ጋር የተዛመደ  እንደ ድርድር ልኬቶች ያሉ ነገሮች ለማከማቸት የሚጠቅም
+
+      '
   es:
-    term: "atributo"
-    def: >
-      Una pareja nombre-valor asociada a un objeto, usada para almacenar metadatos sobre
-      el objeto como, por ejemplo, las dimensiones de un arreglo.
+    term: atributo
+    def: 'Una pareja nombre-valor asociada a un objeto, usada para almacenar metadatos
+      sobre el objeto como, por ejemplo, las dimensiones de un arreglo.
+
+      '
   sw:
-    term: "sifa"
-    def: >
-      Jozi ya thamani ya jina inayohusishwa na kitu,
-      inayotumiwa kuhifadhi metadata kuhusu kitu kama vile vipimo vya mkusanyiko.
+    term: sifa
+    def: 'Jozi ya thamani ya jina inayohusishwa na kitu, inayotumiwa kuhifadhi metadata
+      kuhusu kitu kama vile vipimo vya mkusanyiko.
 
+      '
+- slug: auc
+  ref:
+  - roc_curve
+  - classification
+  en:
+    term: Area Under Curve
+    acronym: AUC
+    def: 'A performance metric for [classification](#classification) models, typically
+      referring to the area under the ROC (Receiver Operating Characteristic) curve.
+      AUC ranges from 0 to 1, where 1 indicates perfect classification and 0.5 indicates
+      random guessing.
 
+      '
 - slug: auto_completion
   en:
-    term: "auto-completion"
-    def: >
-      A feature that allows the user to finish a word or code quickly
-      by pressing the TAB key to list possible words or code from which the user can select.
+    term: auto-completion
+    def: 'A feature that allows the user to finish a word or code quickly by pressing
+      the TAB key to list possible words or code from which the user can select.
+
+      '
   fr:
-    term: "auto-complétion"
-    def: >
-      Une fonctionnalité permettant à l'utilisateur de finir rapidement un mot ou du
-      code à travers l'utilisation de la touche TAB qui affiche le mot ou le code
-      susceptible d'être choisi par l'utilisateur.
+    term: auto-complétion
+    def: 'Une fonctionnalité permettant à l''utilisateur de finir rapidement un mot
+      ou du code à travers l''utilisation de la touche TAB qui affiche le mot ou le
+      code susceptible d''être choisi par l''utilisateur.
+
+      '
   pt:
-    term: "auto-completar"
-    def: >
-      Uma funcionalidade que permite a pessoa usuária terminar uma palavra ou código rapidamente
-      ao pressinar a tecla TAB para listar possíveis palavras ou códigos que podem ser escolhidos.
+    term: auto-completar
+    def: 'Uma funcionalidade que permite a pessoa usuária terminar uma palavra ou
+      código rapidamente ao pressinar a tecla TAB para listar possíveis palavras ou
+      códigos que podem ser escolhidos.
+
+      '
   af:
-    term: "outomatiese voltooing"
-    def: >
-      'n Funksie wat 'n gebruiker toelaat om 'n woord of 'n kode vinnig te voltooi deur die
-      TAB sleutel te druk om 'n lys van moontlike woorde of kodes te vertoon waaruit die gebruiker
-      kan kies.
+    term: outomatiese voltooing
+    def: '''n Funksie wat ''n gebruiker toelaat om ''n woord of ''n kode vinnig te
+      voltooi deur die TAB sleutel te druk om ''n lys van moontlike woorde of kodes
+      te vertoon waaruit die gebruiker kan kies.
+
+      '
   de:
-    term: "Autovervollständigung"
-    def: >
-      Eine Funktionalität welche es dem Nutzer erlaubt in einer Eingabemaske, z.B. in einer
-      Konsole oder Text-Editor, schnell Wörter oder Ausdrücke zu vervollständigen. Normalweise
-      ist diese Funktion der Tabulatortaste (TAB) zugewiesen.
+    term: Autovervollständigung
+    def: 'Eine Funktionalität welche es dem Nutzer erlaubt in einer Eingabemaske,
+      z.B. in einer Konsole oder Text-Editor, schnell Wörter oder Ausdrücke zu vervollständigen.
+      Normalweise ist diese Funktion der Tabulatortaste (TAB) zugewiesen.
+
+      '
   am:
     term: ራስ-ማጠናቀቅ
-    def: >
-      ተጠቃሚው የ TAB ቁልፍን በመጫን በፍጥነት በአጠቃቀሙ አንድ ቃል ወይም ኮድ  እንዲጨርስ ተጠቃሚው ሊመርጥበት የሚያስችል ባህሪ ነዉ;;
-  es:
-    term: "auto-completar"
-    def: >
-     Funcionalidad que le permite a una persona usuaria terminar una palabra o código rapidamente
-     pulsando la tecla TAB para que aparezca una lista de posibles palabras o códigos entre los que
-     el usuario puede seleccionar la función que necesite.
-  sw:
-    term: "kukamilika kiotomatiki"
-    def: >
-      Kipengele kinachomruhusu mtumiaji kumaliza neno au msimbo haraka kwa
-      kubofya kitufe cha TAB ili kuorodhesha maneno au
-      msimbo unaowezekana ambao mtumiaji anaweza kuchagua.
+    def: 'ተጠቃሚው የ TAB ቁልፍን በመጫን በፍጥነት በአጠቃቀሙ አንድ ቃል ወይም ኮድ  እንዲጨርስ ተጠቃሚው ሊመርጥበት የሚያስችል
+      ባህሪ ነዉ;;
 
+      '
+  es:
+    term: auto-completar
+    def: 'Funcionalidad que le permite a una persona usuaria terminar una palabra
+      o código rapidamente pulsando la tecla TAB para que aparezca una lista de posibles
+      palabras o códigos entre los que el usuario puede seleccionar la función que
+      necesite.
+
+      '
+  sw:
+    term: kukamilika kiotomatiki
+    def: 'Kipengele kinachomruhusu mtumiaji kumaliza neno au msimbo haraka kwa kubofya
+      kitufe cha TAB ili kuorodhesha maneno au msimbo unaowezekana ambao mtumiaji
+      anaweza kuchagua.
+
+      '
 - slug: autocorrelation
   en:
-    term: "autocorrelation"
-    def: >
-      The degree of similarity between observations in the same series but separated by a time interval
-      (known as the "lag"). Autocorrelation analysis can be used to gain insight into time series
-      datasets by detecting repeating patterns that may be partially concealed by random noise, among
-      other uses.
+    term: autocorrelation
+    def: 'The degree of similarity between observations in the same series but separated
+      by a time interval (known as the "lag"). Autocorrelation analysis can be used
+      to gain insight into time series datasets by detecting repeating patterns that
+      may be partially concealed by random noise, among other uses.
+
+      '
   af:
-    term: "Autokorrelasie"
-    def: > 
-      Die graad van ooreenkoms tussen waarnemings in dieselfde reeks maar geskei deur 'n tydinterval 
-      (bekend as die "lag"). Autokorrelasie-analise kan gebruik word om insig te verkry in tydreeksdata deur 
-      herhalende patrone op te spoor wat moontlik deels versteek is deur lukrake ruis, onder andere gebruike.
+    term: Autokorrelasie
+    def: 'Die graad van ooreenkoms tussen waarnemings in dieselfde reeks maar geskei
+      deur ''n tydinterval  (bekend as die "lag"). Autokorrelasie-analise kan gebruik
+      word om insig te verkry in tydreeksdata deur  herhalende patrone op te spoor
+      wat moontlik deels versteek is deur lukrake ruis, onder andere gebruike.
+
+      '
   fr:
-    term: "autocorrélation"
-    def: >
-      Le degré de similarité entre les observations d'une même série mais séparées par un intervalle de temps (appelé « décalage »). L'analyse d'autocorrélation peut être utilisée pour mieux comprendre les ensembles de données de séries chronologiques en détectant des modèles répétitifs qui peuvent être partiellement masqués par un bruit aléatoire.
+    term: autocorrélation
+    def: 'Le degré de similarité entre les observations d''une même série mais séparées
+      par un intervalle de temps (appelé « décalage »). L''analyse d''autocorrélation
+      peut être utilisée pour mieux comprendre les ensembles de données de séries
+      chronologiques en détectant des modèles répétitifs qui peuvent être partiellement
+      masqués par un bruit aléatoire.
+
+      '
   sw:
-    term: "uhusiano wa kiotomatiki"
-    def: >
-      Kiwango cha ufanano kati ya uchunguzi katika mfululizo sawa lakini ukitenganishwa na muda (unaojulikana kama lag).
-      Uchanganuzi wa uunganisho otomatiki unaweza kutumika kupata maarifa kuhusu mkusanyiko wa data wa mfululizo wa saa kwa
-      kugundua ruwaza zinazorudiwa ambazo zinaweza kufichwa kwa kiasi na kelele nasibu,
-      miongoni mwa matumizi mengine.
+    term: uhusiano wa kiotomatiki
+    def: 'Kiwango cha ufanano kati ya uchunguzi katika mfululizo sawa lakini ukitenganishwa
+      na muda (unaojulikana kama lag). Uchanganuzi wa uunganisho otomatiki unaweza
+      kutumika kupata maarifa kuhusu mkusanyiko wa data wa mfululizo wa saa kwa kugundua
+      ruwaza zinazorudiwa ambazo zinaweza kufichwa kwa kiasi na kelele nasibu, miongoni
+      mwa matumizi mengine.
+
+      '
   de:
-    term: "Autokorrelation"
-    def: >
-
-      Der Grad der Ähnlichkeit zwischen Beobachtungen in derselben Reihe, die durch ein Zeitintervall ("Lag") voneinander
-      getrennt sind. Autokorrelationsanalyse kann verwendet werden, um einen Einblick in Zeitreihen zu gewinnen, indem
-      sie u. a. wiederkehrende Muster aufdeckt, die teilweise durch zufälliges Rauschen verdeckt werden können.
-      Der Grad der Ähnlichkeit zwischen Beobachtungen in derselben Reihe, die durch ein Zeitintervall ("Lag") voneinander 
-      getrennt sind. Autokorrelationsanalyse kann verwendet werden, um einen Einblick in Zeitreihen zu gewinnen, indem 
-      sie u. a. wiederkehrende Muster aufdeckt, die teilweise durch zufälliges Rauschen verdeckt werden können. 
+    term: Autokorrelation
+    def: "\nDer Grad der Ähnlichkeit zwischen Beobachtungen in derselben Reihe, die\
+      \ durch ein Zeitintervall (\"Lag\") voneinander getrennt sind. Autokorrelationsanalyse\
+      \ kann verwendet werden, um einen Einblick in Zeitreihen zu gewinnen, indem\
+      \ sie u. a. wiederkehrende Muster aufdeckt, die teilweise durch zufälliges Rauschen\
+      \ verdeckt werden können. Der Grad der Ähnlichkeit zwischen Beobachtungen in\
+      \ derselben Reihe, die durch ein Zeitintervall (\"Lag\") voneinander  getrennt\
+      \ sind. Autokorrelationsanalyse kann verwendet werden, um einen Einblick in\
+      \ Zeitreihen zu gewinnen, indem  sie u. a. wiederkehrende Muster aufdeckt, die\
+      \ teilweise durch zufälliges Rauschen verdeckt werden können. \n"
   es:
-    term: "autocorrelación"
-    def: >
-      El grado de similitud entre observaciones en la misma serie temporal (también conocida como serie de tiempo), pero separadas por un intervalo de tiempo 
-      (conocido como el "rezago"). El análisis de autocorrelación se puede usar para conocer más información 
-      sobre conjuntos de datos que son series temporales al detectar patrones repetitivos que pueden estar parcialmente 
-      ocultos por el ruido aleatorio, entre otros usos.
+    term: autocorrelación
+    def: 'El grado de similitud entre observaciones en la misma serie temporal (también
+      conocida como serie de tiempo), pero separadas por un intervalo de tiempo  (conocido
+      como el "rezago"). El análisis de autocorrelación se puede usar para conocer
+      más información  sobre conjuntos de datos que son series temporales al detectar
+      patrones repetitivos que pueden estar parcialmente  ocultos por el ruido aleatorio,
+      entre otros usos.
 
+      '
 - slug: automatic_variable
   ref:
-    - makefile
+  - makefile
   en:
-    term: "automatic variable"
-    def: >
-      A variable that is automatically given a value in a [build rule](#build_rule).
-      For example, Make automatically assigns the name of a rule's
-      [target](#build_target) to the automatic variable `$@`. Automatic variables are
-      frequently used when writing [pattern rules](#pattern_rule).
+    term: automatic variable
+    def: 'A variable that is automatically given a value in a [build rule](#build_rule).
+      For example, Make automatically assigns the name of a rule''s [target](#build_target)
+      to the automatic variable `$@`. Automatic variables are frequently used when
+      writing [pattern rules](#pattern_rule).
+
+      '
   af:
-    term: "outomatiese veranderlike"
-    def: >
-      'n Veranderlike waaraan daar outomaties 'n waarde toegeken word in [boureël](#build_rule). Byvoorbeeld, "Make" ken outomaties die naam van 'n reël se teiken aan die outomatiese veranderlike, '$@' toe. Outomatiese veranderlikes word dikwels gebruik tydens die skryf van [patroonreëls](#pattern_rule).
+    term: outomatiese veranderlike
+    def: '''n Veranderlike waaraan daar outomaties ''n waarde toegeken word in [boureël](#build_rule).
+      Byvoorbeeld, "Make" ken outomaties die naam van ''n reël se teiken aan die outomatiese
+      veranderlike, ''$@'' toe. Outomatiese veranderlikes word dikwels gebruik tydens
+      die skryf van [patroonreëls](#pattern_rule).
+
+      '
   am:
     term: ራስ-ሰር ተለዋዋጭ
-    def: >
-      በ [የግንባታ ደንብ](#build_rule) ውስጥ በራስ-ሰር ዋጋ የሚሰጠው ተለዋዋጭ። ለምሳሌ ፣ የደንቡን ስም በራስ-ሰር ይመድቡ [ዒላማ](#build_target) ወደ ራስ-ሰር ተለዋዋጭ "$ @"። ራስ-ሰር ተለዋዋጮች ናቸው በሚጽፉበት ጊዜ ብዙ ጊዜ ጥቅም ላይ ይውላሉ [የንድፍ ህጎች](#pattern_rule)።
+    def: 'በ [የግንባታ ደንብ](#build_rule) ውስጥ በራስ-ሰር ዋጋ የሚሰጠው ተለዋዋጭ። ለምሳሌ ፣ የደንቡን ስም በራስ-ሰር
+      ይመድቡ [ዒላማ](#build_target) ወደ ራስ-ሰር ተለዋዋጭ "$ @"። ራስ-ሰር ተለዋዋጮች ናቸው በሚጽፉበት ጊዜ ብዙ
+      ጊዜ ጥቅም ላይ ይውላሉ [የንድፍ ህጎች](#pattern_rule)።
 
+      '
 - slug: backpropagation
   en:
-    term: "backpropagation"
-    def: >
-      An algorithm that iteratively adjusts the weights used in a [neural
-      network](#neural_network). Backpropagation is often used to implement
-      [gradient descent](#gradient_descent).
+    term: backpropagation
+    def: 'An algorithm that iteratively adjusts the weights used in a [neural network](#neural_network).
+      Backpropagation is often used to implement [gradient descent](#gradient_descent).
+
+      '
   af:
-    term: "terugwaartse voortplanting"
-    def: >
-      'n Algoritme wat die gewigte wat in 'n [neurale netwerk](#neural_network) gebruik word iteratief aanpas. Terugwaartse
-      voortplanting word dikwels gebruik om [gradiënte afdaling](#gradient_descent) te implementeer.
+    term: terugwaartse voortplanting
+    def: '''n Algoritme wat die gewigte wat in ''n [neurale netwerk](#neural_network)
+      gebruik word iteratief aanpas. Terugwaartse voortplanting word dikwels gebruik
+      om [gradiënte afdaling](#gradient_descent) te implementeer.
+
+      '
   de:
-    term: "Fehlerrückführung"
-    def: >
-      Ein Algoritmus der die Gewichtung in einem [neuralen Netzwerk](#neural_network) iterativ anpasst.
-      Die Rückwärtspropagierung ist ein Spezialfall eines [allgemeinen Gradientenverfahrens](#gradient_descent)
-      in der Optimierung, basierend auf dem mittleren quadratischen Fehler.
+    term: Fehlerrückführung
+    def: 'Ein Algoritmus der die Gewichtung in einem [neuralen Netzwerk](#neural_network)
+      iterativ anpasst. Die Rückwärtspropagierung ist ein Spezialfall eines [allgemeinen
+      Gradientenverfahrens](#gradient_descent) in der Optimierung, basierend auf dem
+      mittleren quadratischen Fehler.
+
+      '
   am:
     term: የጀርባ ማሰራጨት
-    def: >
-      በ [ነርቭ) ውስጥ ጥቅም ላይ የዋሉ ክብደቶችን ያለማቋረጥ የሚያስተካክለው ስልተ ቀመር አውታረ መረብ](#neural_network)።
+    def: 'በ [ነርቭ) ውስጥ ጥቅም ላይ የዋሉ ክብደቶችን ያለማቋረጥ የሚያስተካክለው ስልተ ቀመር አውታረ መረብ](#neural_network)።
       የጀርባ ማሰራጨት ለመተግበር ብዙውን ጊዜ ጥቅም ላይ ይውላል [የግራዲያንት ዝርያ](#gradient_descent) ስልተ ቀመር
       አውታረ መረብ](#ነርቭ_አውታረ መረብ) በ [ነርቭ) ውስጥ ጥቅም ላይ የዋሉ ክብደቶችን ያለማቋረጥ የሚያስተካክለው  የጀርባ
       ማሰራጨት ብዙውን ጊዜ  [የግራዲያንት ዝርያ](#gradient_descent) ለመተግበር ጥቅም ላይ ይውላል
-  fr:
-    term: "backpropagation"
-    def: >
-     C'est un algorithme qui ajuste de manière itérative les pondérations utilisées dans un réseau de neurones. La rétropropagation est souvent utilisée pour implémenter la descente de gradient.
 
+      '
+  fr:
+    term: backpropagation
+    def: 'C''est un algorithme qui ajuste de manière itérative les pondérations utilisées
+      dans un réseau de neurones. La rétropropagation est souvent utilisée pour implémenter
+      la descente de gradient.
+
+      '
   es:
-    term: "retropropagación"
-    def: >
-      Un algoritmo que ajusta iterativamente los pesos utilizados en una [red neuronal](#neural_network). El algoritmo de retropropagación 
-      se usa a menudo para implementar el algoritmo llamado ["descenso del gradiente"](#gradient_descent).
-      
+    term: retropropagación
+    def: 'Un algoritmo que ajusta iterativamente los pesos utilizados en una [red
+      neuronal](#neural_network). El algoritmo de retropropagación  se usa a menudo
+      para implementar el algoritmo llamado ["descenso del gradiente"](#gradient_descent).
+
+      '
+- slug: backtracking
+  ref:
+  - recursion
+  - algorithm
+  en:
+    term: backtracking
+    def: 'An algorithmic technique for solving problems by trying to build a solution
+      incrementally, abandoning partial solutions ("backtracking") as soon as it determines
+      they cannot lead to a valid complete solution.
+
+      '
 - slug: backward_compatible
   en:
-    term: "backward-compatible"
-    def: >
-      A property of a system, hardware or software, that allows for interoperability
-      with an older legacy system, or with input designed for such a system.
-      For example, a [function](#function) written in [Python](#python) 3 that can be
-      run successfully with Python 2 is backward-compatible.
+    term: backward-compatible
+    def: 'A property of a system, hardware or software, that allows for interoperability
+      with an older legacy system, or with input designed for such a system. For example,
+      a [function](#function) written in [Python](#python) 3 that can be run successfully
+      with Python 2 is backward-compatible.
+
+      '
   af:
-    term: "terugwaarts versoenbaar"
-    def: >
-      'n Eienskap van 'n stelsel, hardeware of sagteware wat dit moontlik maak om
-      met 'n ouer weergawe van die stelsel, of met die toevoer ontwerp vir 'n ouer stelsel
-      te werk. Byvoorbeeld, 'n [funksie](#function) wat in [Python](#python) 3 geskryf is maar
-      sal werk in Python weergawe 2 is terugwaarts versoenbaar."
+    term: terugwaarts versoenbaar
+    def: '''n Eienskap van ''n stelsel, hardeware of sagteware wat dit moontlik maak
+      om met ''n ouer weergawe van die stelsel, of met die toevoer ontwerp vir ''n
+      ouer stelsel te werk. Byvoorbeeld, ''n [funksie](#function) wat in [Python](#python)
+      3 geskryf is maar sal werk in Python weergawe 2 is terugwaarts versoenbaar."
+
+      '
   fr:
-    term: "rétrocompatible"
-    def: >
-      Se dit d'un système, matériel ou logiciel, qui est capable d'être utilisé de la
-      même manière que ses versions précédentes sans difficulté.
-      Par exemple, une [fonction](#function) écrite en [Python](#python) 3 qui peut
-      être utilisée avec [Python](#python) 2 est rétrocompatible.
+    term: rétrocompatible
+    def: 'Se dit d''un système, matériel ou logiciel, qui est capable d''être utilisé
+      de la même manière que ses versions précédentes sans difficulté. Par exemple,
+      une [fonction](#function) écrite en [Python](#python) 3 qui peut être utilisée
+      avec [Python](#python) 2 est rétrocompatible.
+
+      '
   pt:
-    term: "compatibilidade reversa"
-    def: >
-      Software que pode ser usado da mesma maneira que versão anteriores de si mesmo
-      sem problemas. Também é chamado de retrocompatibilidade.
+    term: compatibilidade reversa
+    def: 'Software que pode ser usado da mesma maneira que versão anteriores de si
+      mesmo sem problemas. Também é chamado de retrocompatibilidade.
+
+      '
   de:
-    term: "abwärtskompatibel"
-    def: >
-      Bezeichnet die Eigenschaft eines Systems (z.B. Hardware oder Software), das dessen Funktionsfähigkeit
-      auch in Zusammenarbeit mit älteren oder obsoleten Versionen eines Systems garantiert. Beispielsweise
-      ist eine [Funktion](#function) in [Python](#python) 3 abwärtskompatibel, wenn diese auch in Python 2
-      ausgeführt werden kann.
+    term: abwärtskompatibel
+    def: 'Bezeichnet die Eigenschaft eines Systems (z.B. Hardware oder Software),
+      das dessen Funktionsfähigkeit auch in Zusammenarbeit mit älteren oder obsoleten
+      Versionen eines Systems garantiert. Beispielsweise ist eine [Funktion](#function)
+      in [Python](#python) 3 abwärtskompatibel, wenn diese auch in Python 2 ausgeführt
+      werden kann.
+
+      '
   es:
-    term: "retrocompatible"
-    def: >
-      Una propiedad de un sistema, hardware o software, que permite la interoperabilidad
-      con un sistema heredado más antiguo, o con la entrada diseñada para un sistema así.
-      Por ejemplo, una [función](#function) escrita en [Python](#python) 3 que puede ser ejecutada exitosamente en
-      Python versión 2 es retrocompatible.
+    term: retrocompatible
+    def: 'Una propiedad de un sistema, hardware o software, que permite la interoperabilidad
+      con un sistema heredado más antiguo, o con la entrada diseñada para un sistema
+      así. Por ejemplo, una [función](#function) escrita en [Python](#python) 3 que
+      puede ser ejecutada exitosamente en Python versión 2 es retrocompatible.
+
+      '
   am:
     term: ወደኋላ-ተኳሃኝ
-    def: >
-      እርስ በእርስ ለመተባበር የሚያስችል የአንድ ስርዓት ፣ ሃርድዌር ወይም ሶፍትዌር ንብረት በድሮው የቅርስ ስርዓት ወይም ለእንዲህ ዓይነቱ ስርዓት በተዘጋጀ ግብዓት። ለምሳሌ በ [ፓይዘን](#function) 3 ውስጥ የተፃፈ [ተግባር](#python) 3 ሊሆን ይችላል ከፓይዘን ስሪት 2 ጋር በተሳካ ሁኔታ ያሂዱ ከኋላ-ተኳሃኝ ነው። የአንድ ስርዓት ፣ ሃርድዌር ወይም ሶፍትዌር ንብረት በድሮው የቅርስ ስርዓት ወይም ለእንዲህ ዓይነቱ ስርዓት  እርስ በእርስ ለመተባበር እንዲያስችል የተዘጋጀ ግብዓት። ለምሳሌ [ተግባር](#python)  በ [ፓይዘን](#function) 3 ውስጥ የተፃፈ ከፓይዘን ስሪት 2 ጋር በተሳካ ሁኔታ የሚሄዱ ከኋላ-ተስማሚ ነው።
-  uk:
-    term: "зворотна сумісність"
-    def: >
-      Властивість системи, апаратного або програмного забезпечення, що дозволяє взаємодіяти
-      зі старішою системою або з вхідними даними, призначеними для такої системи.
-      Наприклад, [функція](#function), написана на [Python](#python) 3, яка може успішно 
-      виконуватися у Python 2, є зворотно сумісною.
+    def: 'እርስ በእርስ ለመተባበር የሚያስችል የአንድ ስርዓት ፣ ሃርድዌር ወይም ሶፍትዌር ንብረት በድሮው የቅርስ ስርዓት ወይም
+      ለእንዲህ ዓይነቱ ስርዓት በተዘጋጀ ግብዓት። ለምሳሌ በ [ፓይዘን](#function) 3 ውስጥ የተፃፈ [ተግባር](#python)
+      3 ሊሆን ይችላል ከፓይዘን ስሪት 2 ጋር በተሳካ ሁኔታ ያሂዱ ከኋላ-ተኳሃኝ ነው። የአንድ ስርዓት ፣ ሃርድዌር ወይም ሶፍትዌር
+      ንብረት በድሮው የቅርስ ስርዓት ወይም ለእንዲህ ዓይነቱ ስርዓት  እርስ በእርስ ለመተባበር እንዲያስችል የተዘጋጀ ግብዓት።
+      ለምሳሌ [ተግባር](#python)  በ [ፓይዘን](#function) 3 ውስጥ የተፃፈ ከፓይዘን ስሪት 2 ጋር በተሳካ ሁኔታ
+      የሚሄዱ ከኋላ-ተስማሚ ነው።
 
+      '
+  uk:
+    term: зворотна сумісність
+    def: 'Властивість системи, апаратного або програмного забезпечення, що дозволяє
+      взаємодіяти зі старішою системою або з вхідними даними, призначеними для такої
+      системи. Наприклад, [функція](#function), написана на [Python](#python) 3, яка
+      може успішно  виконуватися у Python 2, є зворотно сумісною.
+
+      '
 - slug: base_r
   ref:
-    - tidyverse
+  - tidyverse
   en:
-    term: "base R"
-    def: >
-      The basic functions making up the [R](#r_language) language. The base packages can be found in
-      `src/library` and are not updated outside of R; their version numbers follow R
-      version numbering. Base packages are installed and loaded with R, while priority
-      packages are installed with base R but must be loaded prior to use.
+    term: base R
+    def: 'The basic functions making up the [R](#r_language) language. The base packages
+      can be found in `src/library` and are not updated outside of R; their version
+      numbers follow R version numbering. Base packages are installed and loaded with
+      R, while priority packages are installed with base R but must be loaded prior
+      to use.
+
+      '
   af:
-    term: "R basis"
-    def: >
-      Die basiese funksies van die [R](#r_language) programmeertaal. Die basispakette kan in
-      `src/library`gevind word en kan nie onafhanklik van R opgedateer word nie. Die weergawenommers
-      van die pakette volg die R weergawenummering. Basispakette word geinstalleer en gelaai as
-      deel van R terwyl prioriteitpakette saam met R geinstalleer word maar moet gelaai word voor
-      hulle gebruik kan word.
+    term: R basis
+    def: 'Die basiese funksies van die [R](#r_language) programmeertaal. Die basispakette
+      kan in `src/library`gevind word en kan nie onafhanklik van R opgedateer word
+      nie. Die weergawenommers van die pakette volg die R weergawenummering. Basispakette
+      word geinstalleer en gelaai as deel van R terwyl prioriteitpakette saam met
+      R geinstalleer word maar moet gelaai word voor hulle gebruik kan word.
+
+      '
   pt:
-    term: "R base"
-    def: >
-      As funções básicas que compõe a linguagem [R](#r_language). Os pacotes de base podem ser encontrados
-      em `src/library` e não são atualizados fora do R; eles seguem a numeração de versão do
-      próprio R. Pacotes de base são instalados e carregados junto do R, enquanto pacotes
-      prioritários são instalados com o R base mas precisam ser carregados antes do uso.
+    term: R base
+    def: 'As funções básicas que compõe a linguagem [R](#r_language). Os pacotes de
+      base podem ser encontrados em `src/library` e não são atualizados fora do R;
+      eles seguem a numeração de versão do próprio R. Pacotes de base são instalados
+      e carregados junto do R, enquanto pacotes prioritários são instalados com o
+      R base mas precisam ser carregados antes do uso.
+
+      '
   es:
-    term: "R base"
-    def: >
-      Funciones básicas que conforman el lenguaje de programación [R](#r_language). Los paquetes base
-      pueden encontrarse en `src/library` y no son actualizados fuera de R; su número de versión
-      coincide con el de R. Los paquetes de R base se instalan y cargan junto con R, mientras que los
-      paquetes prioritarios se instalan con R, pero deben ser cargados antes de utilizarse.
+    term: R base
+    def: 'Funciones básicas que conforman el lenguaje de programación [R](#r_language).
+      Los paquetes base pueden encontrarse en `src/library` y no son actualizados
+      fuera de R; su número de versión coincide con el de R. Los paquetes de R base
+      se instalan y cargan junto con R, mientras que los paquetes prioritarios se
+      instalan con R, pero deben ser cargados antes de utilizarse.
+
+      '
   am:
     term: ቤዝ አር
-    def: >
-      የ [R](#r_language) ቋንቋን የመሠረቱ መሠረታዊ ተግባራት። የመሠረት እሽጎች በ ውስጥ ሊገኙ ይችላሉ "src / library" እና ከ R ውጭ አይዘመኑም; የእነሱ ስሪት ቁጥሮች አር የስሪት ቁጥር። የመሠረት ፓኬጆች ተጭነው በ R ተጭነዋል ፣ ቅድሚያ የሚሰጠው ግን ፓኬጆች ከመሠረታዊ አር ጋር ተጭነዋል ነገር ግን ከመጠቀምዎ በፊት መጫን አለባቸው ፡፡ የ [R](#r_language) ቋንቋን የመሠረቱ መሠረታዊ ተግባራት። የመሠረት እሽጎች በ "src/library" ውስጥ ሊገኙ ይችላሉ እና ከ R ውጭ አይሻሻሉም; የእነሱ ስሪት ቁጥሮች የአር  ስሪት ቁጥርን ይከተላሉ።  መሠረት ፓኬጆች ጋር ከR ተጭነዉ ይዘረጋሉ፣ ቅድሚያ የሚሰጠው ግን ፓኬጆች ከመሠረታዊ አር ጋር ተጭነዋል ነገር ግን ከመጠቀም በፊት መጫን አለባቸው ፡፡
+    def: 'የ [R](#r_language) ቋንቋን የመሠረቱ መሠረታዊ ተግባራት። የመሠረት እሽጎች በ ውስጥ ሊገኙ ይችላሉ "src
+      / library" እና ከ R ውጭ አይዘመኑም; የእነሱ ስሪት ቁጥሮች አር የስሪት ቁጥር። የመሠረት ፓኬጆች ተጭነው በ R
+      ተጭነዋል ፣ ቅድሚያ የሚሰጠው ግን ፓኬጆች ከመሠረታዊ አር ጋር ተጭነዋል ነገር ግን ከመጠቀምዎ በፊት መጫን አለባቸው ፡፡
+      የ [R](#r_language) ቋንቋን የመሠረቱ መሠረታዊ ተግባራት። የመሠረት እሽጎች በ "src/library" ውስጥ ሊገኙ
+      ይችላሉ እና ከ R ውጭ አይሻሻሉም; የእነሱ ስሪት ቁጥሮች የአር  ስሪት ቁጥርን ይከተላሉ።  መሠረት ፓኬጆች ጋር ከR ተጭነዉ
+      ይዘረጋሉ፣ ቅድሚያ የሚሰጠው ግን ፓኬጆች ከመሠረታዊ አር ጋር ተጭነዋል ነገር ግን ከመጠቀም በፊት መጫን አለባቸው ፡፡
 
+      '
   fr:
-    term: "base R"
-    def: >
-      Les fonctions de base composant le langage R. Les packages de base peuvent être trouvés dans src/library et ne sont pas mis à jour en dehors de R; leurs numéros de version suivent la numérotation des versions R. Les packages de base sont installés et chargés avec R, tandis que les packages prioritaires sont installés avec base R mais doivent être chargés avant utilisation.
+    term: base R
+    def: 'Les fonctions de base composant le langage R. Les packages de base peuvent
+      être trouvés dans src/library et ne sont pas mis à jour en dehors de R; leurs
+      numéros de version suivent la numérotation des versions R. Les packages de base
+      sont installés et chargés avec R, tandis que les packages prioritaires sont
+      installés avec base R mais doivent être chargés avant utilisation.
+
+      '
   ar:
-    term: "آر الأساس"
-    def: >
-      `src/library` يمكن الحصول علي الحزم الأساسية في .[R](#r_language) الوظائف الأساسية التي تتكون منها لغة آر
-      R الحزم الأساسية مثبتة ويتم تحميلها مع R أرقام نسختها تتبع ترقيم نسخة R لايمكن تحديث الحزم الأساسية خارج
-      ولكن يجب أن يتم تحميل قبل استخدامها .  R بينما الحزم ذات الألوية يتم تثبيتها مع
+    term: آر الأساس
+    def: '`src/library` يمكن الحصول علي الحزم الأساسية في .[R](#r_language) الوظائف
+      الأساسية التي تتكون منها لغة آر R الحزم الأساسية مثبتة ويتم تحميلها مع R أرقام
+      نسختها تتبع ترقيم نسخة R لايمكن تحديث الحزم الأساسية خارج ولكن يجب أن يتم تحميل
+      قبل استخدامها .  R بينما الحزم ذات الألوية يتم تثبيتها مع
 
+      '
+- slug: batch_size
+  ref:
+  - machine_learning
+  - neural_network
+  en:
+    term: batch size
+    def: 'In [machine learning](#machine_learning), the number of training examples
+      used in one iteration of model training. Larger batch sizes provide more stable
+      gradient estimates but require more memory.
 
+      '
 - slug: bayes_rule
   en:
-    term: "Bayes' Rule"
-    def: >
-      See [Bayes' Theorem](#bayes_theorem).
+    term: Bayes' Rule
+    def: 'See [Bayes'' Theorem](#bayes_theorem).
+
+      '
   af:
-    term: "Bayes se rëel"
-    def: >
-      Sien [Bayes se stelling](#bayes_theorem).
+    term: Bayes se rëel
+    def: 'Sien [Bayes se stelling](#bayes_theorem).
+
+      '
   am:
     term: የባየስ ደንብ
-    def: >
-      [የባየስ ቲዎረም](#bayes_theorem) ይመልከቱ።
+    def: '[የባየስ ቲዎረም](#bayes_theorem) ይመልከቱ።
 
+      '
 - slug: bayes_theorem
   ref:
-    - bayesian_network
-    - naive_bayes_classifier
-    - prior_distribution
+  - bayesian_network
+  - naive_bayes_classifier
+  - prior_distribution
   en:
-    term: "Bayes' Theorem"
-    def: >
-      An equation for calculating the probability that something is [true](#true) if something
-      related to it is true. If P(X) is the probability that X is true and P(X`|`Y) is
-      the probability that X is true given Y is true, then P(X`|`Y) = P(Y`|`X) * P(X) / P(Y).
+    term: Bayes' Theorem
+    def: 'An equation for calculating the probability that something is [true](#true)
+      if something related to it is true. If P(X) is the probability that X is true
+      and P(X`|`Y) is the probability that X is true given Y is true, then P(X`|`Y)
+      = P(Y`|`X) * P(X) / P(Y).
+
+      '
   af:
-    term: "Bayes se stelling"
-    def: >
-      'n Vergelyking om die waarskynlikheid te bepaal dat iets [waar](#true) is indien iets
-      verwant ook waar is. As P(X) die waarskynlikheid is dat X waar is en P(X`|`Y) is die
-      waarskynlikheid dat X waar is indien die gegewe Y waar is, dan is P(X`|`Y) = P(Y`|`X) * P(X) / P(Y).
+    term: Bayes se stelling
+    def: '''n Vergelyking om die waarskynlikheid te bepaal dat iets [waar](#true)
+      is indien iets verwant ook waar is. As P(X) die waarskynlikheid is dat X waar
+      is en P(X`|`Y) is die waarskynlikheid dat X waar is indien die gegewe Y waar
+      is, dan is P(X`|`Y) = P(Y`|`X) * P(X) / P(Y).
+
+      '
   es:
-    term: "Teorema de Bayes"
-    def: >
-      Una ecuación para calcular la probabilidad de que algo sea [verdadero](#true) si algo    
-      relacionado con ello es verdadero. Si P(X) es la probabilidad de que X is verdadero y P(X`|`Y) es    
-      la probabilidad de que X es verdadero dado que Y sea verdadero, entonces P(X`|`Y) = P(Y`|`X) * P(X) / P(Y).
+    term: Teorema de Bayes
+    def: 'Una ecuación para calcular la probabilidad de que algo sea [verdadero](#true)
+      si algo     relacionado con ello es verdadero. Si P(X) es la probabilidad de
+      que X is verdadero y P(X`|`Y) es     la probabilidad de que X es verdadero dado
+      que Y sea verdadero, entonces P(X`|`Y) = P(Y`|`X) * P(X) / P(Y).
 
-
+      '
 - slug: bayesian_network
   ref:
-    - bayes_theorem
-    - markov_chain
-    - naive_bayes_classifier
+  - bayes_theorem
+  - markov_chain
+  - naive_bayes_classifier
   en:
-    term: "Bayesian network"
-    def: >
-      A graph that represents the relationships among random variables for a given problem.
-  es:
-    term: "Red Bayesiana"
-    def: >
-      Un grafo que representa la relacion entre las variables aleatorias para un determinado problema.
+    term: Bayesian network
+    def: 'A graph that represents the relationships among random variables for a given
+      problem.
 
+      '
+  es:
+    term: Red Bayesiana
+    def: 'Un grafo que representa la relacion entre las variables aleatorias para
+      un determinado problema.
+
+      '
   am:
     term: የባዬያን አውታረመረብ
-    def: >
-      ለተሰጠው ችግር በዘፈቀደ ተለዋዋጮች መካከል ያሉትን ግንኙነቶች የሚወክል ግራፍ ፡፡ በዘፈቀደ ተለዋዋጮች እና በተሰጠው ችግር  መካከል ያሉትን ግንኙነቶች የሚወክል ግራፍ ፡፡
+    def: 'ለተሰጠው ችግር በዘፈቀደ ተለዋዋጮች መካከል ያሉትን ግንኙነቶች የሚወክል ግራፍ ፡፡ በዘፈቀደ ተለዋዋጮች እና በተሰጠው
+      ችግር  መካከል ያሉትን ግንኙነቶች የሚወክል ግራፍ ፡፡
 
+      '
   af:
     term: Bayesian-netwerk
-    def: >
-      'n Grafiek wat die verhoudings tussen lukrake veranderlikes vir 'n gegewe probleem verteenwoordig.
+    def: '''n Grafiek wat die verhoudings tussen lukrake veranderlikes vir ''n gegewe
+      probleem verteenwoordig.
 
+      '
+- slug: bayesian_statistics
+  ref:
+  - probability
+  - bayesian_network
+  en:
+    term: Bayesian statistics
+    def: 'An approach to statistics based on Bayes'' theorem, where [probability](#probability)
+      represents a degree of belief about an event. Bayesian methods update beliefs
+      as new evidence becomes available.
+
+      '
 - slug: bias
   ref:
-    - variance
-    - overfitting
-    - classification
-    - systematic_error
+  - variance
+  - overfitting
+  - classification
+  - systematic_error
   en:
-    term: "bias"
-    def: >
-      A statistic is biased if it is systematically or consistently different from the
-      parameter it is supposed to estimate.
+    term: bias
+    def: 'A statistic is biased if it is systematically or consistently different
+      from the parameter it is supposed to estimate.
 
-  af: 
-    term: "vooroordeel"
-    def: >
-      'n Statistiek is bevooroordeeld as dit sistematies of konsekwent verskil van die parameter
-      wat dit veronderstel is om te skat.
+      '
+  af:
+    term: vooroordeel
+    def: '''n Statistiek is bevooroordeeld as dit sistematies of konsekwent verskil
+      van die parameter wat dit veronderstel is om te skat.
+
+      '
   es:
-    term: "sesgo"
-    def: >
-      Un estadístico está sesgado si es sistemática o consistentemente diferente
+    term: sesgo
+    def: 'Un estadístico está sesgado si es sistemática o consistentemente diferente
       del parámetro que se supone que debe estimar.
+
+      '
   pt:
-    term: "viés"
-    def: >
-      Uma estatística é enviesada se estiver sistemática ou consistentemente diferente
+    term: viés
+    def: 'Uma estatística é enviesada se estiver sistemática ou consistentemente diferente
       do parâmetro que deveria estimar.
+
+      '
   tn:
-    term: "go tsaya letlhakore"
-    def: >
-      Dipalopalo di tsaya letlhakore fa ele gore maduo a ditshakatsheko tsa tsone, gangwe le gape ga a ana neelano le maduo aa akanyeditsweng.
+    term: go tsaya letlhakore
+    def: 'Dipalopalo di tsaya letlhakore fa ele gore maduo a ditshakatsheko tsa tsone,
+      gangwe le gape ga a ana neelano le maduo aa akanyeditsweng.
+
+      '
   xh:
-    term: "Umkhethe"
-    def: >
-      Ubalo-manani lunomkhethe ukuba lwenziwe ngendlela echanekileyo okanye ngokungaguquguqukiyo ngokwahlukileyo kwiparameter emele ukuba iqikelele.
+    term: Umkhethe
+    def: 'Ubalo-manani lunomkhethe ukuba lwenziwe ngendlela echanekileyo okanye ngokungaguquguqukiyo
+      ngokwahlukileyo kwiparameter emele ukuba iqikelele.
+
+      '
   de:
-    term: "Verzerrung"
-    def: >
-      Auch systematische Abweichung genannt. Ein Messwert wird dann als verzerrt beschrieben, wenn er
-      systematisch von dem wahren Wert einer Messgröße abweicht.
+    term: Verzerrung
+    def: 'Auch systematische Abweichung genannt. Ein Messwert wird dann als verzerrt
+      beschrieben, wenn er systematisch von dem wahren Wert einer Messgröße abweicht.
+
+      '
   sw:
-    term: "upendeleo"
-    def: >
-      Takwimu ni upendeleo ikiwa ni tofauti kwa mfumo au kwa kawaida na vigezo inavyopaswa kukadiria.
-      Takwimu inachukuliwa kuwa na upendeleo ikiwa inapotosha au kupotoka kwa njia ya mara kwa mara au ya kudumu kutoka kwa kigezo halisi inachopaswa kukadiria.
+    term: upendeleo
+    def: 'Takwimu ni upendeleo ikiwa ni tofauti kwa mfumo au kwa kawaida na vigezo
+      inavyopaswa kukadiria. Takwimu inachukuliwa kuwa na upendeleo ikiwa inapotosha
+      au kupotoka kwa njia ya mara kwa mara au ya kudumu kutoka kwa kigezo halisi
+      inachopaswa kukadiria.
+
+      '
   am:
     term: ወገንተኝነት
-    def: >
-      ስታትስቲክስ በስርዓት ወይም በወጥነት ከ ‹የተለየ› ከሆነ አድሏዊ ነው ልኬት ሊገምተው ይገባል ፡፡ በስርዓት ወይም በወጥነት ከ ‹የተለየ› ከሆነ  ስታትስቲክስ አድሏዊ ነው ልኬት ሊገምተው ይገባል ፡፡
-  fr:
-    term: "bias"
-    def: >
-      Une statistique est biaisée si elle est systématiquement ou régulièrement différente du paramètre qu'elle est censée estimer.
+    def: 'ስታትስቲክስ በስርዓት ወይም በወጥነት ከ ‹የተለየ› ከሆነ አድሏዊ ነው ልኬት ሊገምተው ይገባል ፡፡ በስርዓት ወይም
+      በወጥነት ከ ‹የተለየ› ከሆነ  ስታትስቲክስ አድሏዊ ነው ልኬት ሊገምተው ይገባል ፡፡
 
+      '
+  fr:
+    term: bias
+    def: 'Une statistique est biaisée si elle est systématiquement ou régulièrement
+      différente du paramètre qu''elle est censée estimer.
+
+      '
 - slug: big_data
   ref:
-    - three_vs
+  - three_vs
   en:
-    term: "big data"
-    def: >
-      Any data that until recently was too big for most people to work with on a
-      single computer.
+    term: big data
+    def: 'Any data that until recently was too big for most people to work with on
+      a single computer.
+
+      '
   ar:
-    term: "البيانات الضخمة"
-    def: >
-      أي بيانات كانت حتى وقت قريب أكبر من أن يشتغل عليها معظم الأشخاص على جهاز كمبيوتر واحد.
+    term: البيانات الضخمة
+    def: 'أي بيانات كانت حتى وقت قريب أكبر من أن يشتغل عليها معظم الأشخاص على جهاز
+      كمبيوتر واحد.
+
+      '
   de:
-    term: "Big Data"
-    def: >
-      Alle Datenmengen, die bis vor Kurzem vor zu umfangreich für die Analyse mit
-      nur einem Computer waren.
+    term: Big Data
+    def: 'Alle Datenmengen, die bis vor Kurzem vor zu umfangreich für die Analyse
+      mit nur einem Computer waren.
+
+      '
   es:
-    term: "Big Data"
-    def: >
-      Cualquier dato que hasta hace poco tiempo era muy grande para que la mayoria de las personas pudieran trabajar con ellos en una sola computadora.
+    term: Big Data
+    def: 'Cualquier dato que hasta hace poco tiempo era muy grande para que la mayoria
+      de las personas pudieran trabajar con ellos en una sola computadora.
+
+      '
   af:
-    term: "Groot Data"
-    def: >
-      Enige data wat tot onlangs toe nog te veel was om met net een rekenaar te
+    term: Groot Data
+    def: 'Enige data wat tot onlangs toe nog te veel was om met net een rekenaar te
       analiseer.
+
+      '
   tn:
-    term: "kitso_ kgolo"
-    def: >
-      Tsamaiso e e tlhatlhobang kana e kanoka mekgwa ya ka fa kitso e ka ntshiwang ka teng.
-      Tsamaiso e,e ama go kanokowa ga kitso e ntsi e e mo ditlhopheng mme e bile go se motlhofo gore e ka kanokiwa ka tsamaiso e e tlwaelesegileng.
-      Enige data wat tot onlangs toe nog te veel was om met net een rekenaar te analiseer.
+    term: kitso_ kgolo
+    def: 'Tsamaiso e e tlhatlhobang kana e kanoka mekgwa ya ka fa kitso e ka ntshiwang
+      ka teng. Tsamaiso e,e ama go kanokowa ga kitso e ntsi e e mo ditlhopheng mme
+      e bile go se motlhofo gore e ka kanokiwa ka tsamaiso e e tlwaelesegileng. Enige
+      data wat tot onlangs toe nog te veel was om met net een rekenaar te analiseer.
+
+      '
   am:
     term: ትልቅ መረጃ
-    def: >
-      ብዙ ሰዎች እስከ ቅርብ ጊዜ ድረስ በጣም ትልቅ ለነበሩት ብዙ መረጃዎች በ ‹ሀ› ላይ ለመስራት ነጠላ ኮምፒተር. ብዙ ሰዎች እስከ ቅርብ ጊዜ ድረስ በነጠላ ኮምፒተር በጣም ትልቅ ለነበሩት ብዙ መረጃዎች ሰርተዋል::
-  sw:
-    term: "Data kubwa"
-    def: >
-      Data inahitaji kutumikwa kwa kichakato kizito.
-  zu:
-    term: "Idatha Enkulu"
-    def: >
-      Noma iyiphi idatha kuze kube kamuva nje ibinkulu kakhulu ukuthi abantu abaningi basebenze ngayo kukhompuyutha eyodwa.
-  fr:
-    term: "big data"
-    def: >
-      Toutes les données qui, jusqu'à récemment, étaient trop volumineuses pour que la plupart des gens puissent les utiliser sur un seul ordinateur.
-  uk:
-    term: "великі дані (big data)"
-    def: >
-      Будь-які дані, що до недавнього часу були занадто великими для обробки на одному комп'ютері
-      через обмежені можливості апаратного та програмного забезпечення.
+    def: 'ብዙ ሰዎች እስከ ቅርብ ጊዜ ድረስ በጣም ትልቅ ለነበሩት ብዙ መረጃዎች በ ‹ሀ› ላይ ለመስራት ነጠላ ኮምፒተር. ብዙ
+      ሰዎች እስከ ቅርብ ጊዜ ድረስ በነጠላ ኮምፒተር በጣም ትልቅ ለነበሩት ብዙ መረጃዎች ሰርተዋል::
 
+      '
+  sw:
+    term: Data kubwa
+    def: 'Data inahitaji kutumikwa kwa kichakato kizito.
+
+      '
+  zu:
+    term: Idatha Enkulu
+    def: 'Noma iyiphi idatha kuze kube kamuva nje ibinkulu kakhulu ukuthi abantu abaningi
+      basebenze ngayo kukhompuyutha eyodwa.
+
+      '
+  fr:
+    term: big data
+    def: 'Toutes les données qui, jusqu''à récemment, étaient trop volumineuses pour
+      que la plupart des gens puissent les utiliser sur un seul ordinateur.
+
+      '
+  uk:
+    term: великі дані (big data)
+    def: 'Будь-які дані, що до недавнього часу були занадто великими для обробки на
+      одному комп''ютері через обмежені можливості апаратного та програмного забезпечення.
+
+      '
 - slug: binary
   en:
-    term: "binary"
-    def: >
-      A system which can have one of two possible states. In computing, often
+    term: binary
+    def: 'A system which can have one of two possible states. In computing, often
       represented as being in the state 0 or 1. Represented in [Boolean](#boolean)
       logic as [false](#false) (0) or [true](#true) (1). Computers are built upon
       systems which store 0s and 1s as [bits](#bit).
-  af: 
-    term: "binêr"
-    def: >
-     'n Stelsel wat een van twee moontlike toestande kan hê. In berekening word dit dikwels 
-     voorgestel as in die toestand 0 of 1. In [Boole-logika](#boolean) word dit verteenwoordig as [vals](#false) (0) of [waar](#true) (1). 
-     Rekenaars is gebou op stelsels wat 0's en 1's as [bis](#bit) stoor. 
+
+      '
+  af:
+    term: binêr
+    def: "'n Stelsel wat een van twee moontlike toestande kan hê. In berekening word\
+      \ dit dikwels  voorgestel as in die toestand 0 of 1. In [Boole-logika](#boolean)\
+      \ word dit verteenwoordig as [vals](#false) (0) of [waar](#true) (1).  Rekenaars\
+      \ is gebou op stelsels wat 0's en 1's as [bis](#bit) stoor. \n"
   pt:
-    term: "binário"
-    def: >
-      Um sistema que pode ter dois estados possíveis. Em computação, frequentemente
-      sendo no estado 0 ou 1. Representado na lógica [Booleana](#boolean) como
-      [falso](#false) (0) ou [verdadeiro](#true) (1). Computadores são construídos
-      sobre sistemas que armazenam 0s e 1s como [bits](#bit).
+    term: binário
+    def: 'Um sistema que pode ter dois estados possíveis. Em computação, frequentemente
+      sendo no estado 0 ou 1. Representado na lógica [Booleana](#boolean) como [falso](#false)
+      (0) ou [verdadeiro](#true) (1). Computadores são construídos sobre sistemas
+      que armazenam 0s e 1s como [bits](#bit).
+
+      '
   de:
-    term: "Binärsystem"
-    def: >
-      Ein System welches nur aus zwei Zuständen besteht. In der Informationstechnik oft
-      in den Zuständen 0 oder 1 dargestellt. In der [Boolschen Logik](#boolean) auch als
-      [falsch](#false) (0) oder [wahr](#true) (1). Computer verwenden als kleinste
-      Speichereinheit ein [Bit](#bit) welches entweder eine 0 oder 1 enthalten kann.
+    term: Binärsystem
+    def: 'Ein System welches nur aus zwei Zuständen besteht. In der Informationstechnik
+      oft in den Zuständen 0 oder 1 dargestellt. In der [Boolschen Logik](#boolean)
+      auch als [falsch](#false) (0) oder [wahr](#true) (1). Computer verwenden als
+      kleinste Speichereinheit ein [Bit](#bit) welches entweder eine 0 oder 1 enthalten
+      kann.
+
+      '
   es:
-    term: "sistema binario"
-    def: >
-      Un sistema donde puede haber dos posibilidades de estado. En la computación, el sistema binario se representa con el estado de 0 ó 1. En el sistema lógico [Booleano](#boolean), [falso](#false) se representa con (0) y [verdadero](#true) con (1). Las computadoras operan en sistemas  binarios donde almacenan [bits](#bit).
+    term: sistema binario
+    def: 'Un sistema donde puede haber dos posibilidades de estado. En la computación,
+      el sistema binario se representa con el estado de 0 ó 1. En el sistema lógico
+      [Booleano](#boolean), [falso](#false) se representa con (0) y [verdadero](#true)
+      con (1). Las computadoras operan en sistemas  binarios donde almacenan [bits](#bit).
+
+      '
   am:
     term: ሁለትዮሽ
-    def: >
-      ከሁለት ሊሆኑ ከሚችሉ ግዛቶች ውስጥ አንዱን ሊኖረው የሚችል ስርዓት ፡፡ በኮምፒተር ውስጥ ብዙ ጊዜ በክፍለ-ግዛቱ 0 ወይም 1. የተወከለው በ [ቦሊያን](#boolean) ውስጥ ተወክሏል አመክንዮ እንደ [ሐሰት](#false) (0) ወይም [እውነት](#true) (1)። ኮምፒውተሮች ተገንብተዋል 0s እና 1s እንደ [ቢት](#bit) የሚያከማቹ ስርዓቶች ከሁለት በአንዱ ግዛቶች ውስጥ ሊኖር የሚችል ስርዓት ፡፡ በኮምፒተር ውስጥ ብዙ ጊዜ በ 0 ወይም 1 ይወከላል.  በ [ቦሊያን](#boolean) ውስጥ የተወከለው አመክንዮ እንደ [ሐሰት](#false) (0) ወይም [እውነት](#true) (1)። ኮምፒውተሮች  0s እና 1s እንደ [ቢት](#bit) እንዲያከማቹ ተገንብተዋል::
-  fr:
-    term: "binaire"
-    def: >
-      Un système qui peut avoir l'un des deux états possibles. En informatique souvent représenté comme étant à l'état 0 ou 1. Représenté en logique booléenne comme faux (0) ou vrai (1). Les ordinateurs sont construits sur des systèmes qui stockent les 0 et les 1 sous forme de bits.
-  uk:
-    term: "бінарна (система)"
-    def: >
-      Система, яка може мати один з двох можливих станів. В інформатиці часто
-      представлена як 0 або 1, у [булевій](#boolean)
-      логіці - як [хибність](#false) (0) або [істина](#true) (1). Комп'ютери побудовані на системах,
-      які зберігають 0 та 1 як [біти](#bit).
+    def: 'ከሁለት ሊሆኑ ከሚችሉ ግዛቶች ውስጥ አንዱን ሊኖረው የሚችል ስርዓት ፡፡ በኮምፒተር ውስጥ ብዙ ጊዜ በክፍለ-ግዛቱ
+      0 ወይም 1. የተወከለው በ [ቦሊያን](#boolean) ውስጥ ተወክሏል አመክንዮ እንደ [ሐሰት](#false) (0) ወይም
+      [እውነት](#true) (1)። ኮምፒውተሮች ተገንብተዋል 0s እና 1s እንደ [ቢት](#bit) የሚያከማቹ ስርዓቶች ከሁለት
+      በአንዱ ግዛቶች ውስጥ ሊኖር የሚችል ስርዓት ፡፡ በኮምፒተር ውስጥ ብዙ ጊዜ በ 0 ወይም 1 ይወከላል.  በ [ቦሊያን](#boolean)
+      ውስጥ የተወከለው አመክንዮ እንደ [ሐሰት](#false) (0) ወይም [እውነት](#true) (1)። ኮምፒውተሮች  0s እና
+      1s እንደ [ቢት](#bit) እንዲያከማቹ ተገንብተዋል::
 
+      '
+  fr:
+    term: binaire
+    def: 'Un système qui peut avoir l''un des deux états possibles. En informatique
+      souvent représenté comme étant à l''état 0 ou 1. Représenté en logique booléenne
+      comme faux (0) ou vrai (1). Les ordinateurs sont construits sur des systèmes
+      qui stockent les 0 et les 1 sous forme de bits.
+
+      '
+  uk:
+    term: бінарна (система)
+    def: 'Система, яка може мати один з двох можливих станів. В інформатиці часто
+      представлена як 0 або 1, у [булевій](#boolean) логіці - як [хибність](#false)
+      (0) або [істина](#true) (1). Комп''ютери побудовані на системах, які зберігають
+      0 та 1 як [біти](#bit).
+
+      '
 - slug: binary_expression
   ref:
-    - nullary_expression
-    - ternary_expression
-    - unary_expression
+  - nullary_expression
+  - ternary_expression
+  - unary_expression
   en:
-    term: "binary expression"
-    def: >
-      An expression which has two parameters and takes two arguments, such as `1 + 2`.
-  af:
-    term: "binêre uitdrukking"
-    def: >
-      'n Uitdrukking wat twee parameters het en twee argumente neem, soos bv. `1 + 2`.
-  pt:
-    term: "expressão binária"
-    def: >
-      Uma expressão com dois argumentos ou parâmetros, como `1 + 2`, por exemplo.
-  tn:
-    term: "Tlhaloso ka go tlhakanya dilo tse pedi."
-    def: >
-      Ke tlhaloso e e supagalang mo diemong tse pedi.sekai...go ka tlhakanngwa bongwe le bobedi.
+    term: binary expression
+    def: 'An expression which has two parameters and takes two arguments, such as
+      `1 + 2`.
 
+      '
+  af:
+    term: binêre uitdrukking
+    def: '''n Uitdrukking wat twee parameters het en twee argumente neem, soos bv.
+      `1 + 2`.
+
+      '
+  pt:
+    term: expressão binária
+    def: 'Uma expressão com dois argumentos ou parâmetros, como `1 + 2`, por exemplo.
+
+      '
+  tn:
+    term: Tlhaloso ka go tlhakanya dilo tse pedi.
+    def: 'Ke tlhaloso e e supagalang mo diemong tse pedi.sekai...go ka tlhakanngwa
+      bongwe le bobedi.
+
+      '
   am:
     term: ሁለትዮሽ አገላለጽ
-    def: >
-      ሁለት መለኪያዎች ያሉት እና እንደ "1 + 2" ያሉ ሁለት ክርክሮችን የሚወስድ አገላለጽ።
-  nl:
-    term: "binaire expressie"
-    def: >
-      Een expressie met twee parameters of argumenten, zoals `1 + 2`.
+    def: 'ሁለት መለኪያዎች ያሉት እና እንደ "1 + 2" ያሉ ሁለት ክርክሮችን የሚወስድ አገላለጽ።
 
+      '
+  nl:
+    term: binaire expressie
+    def: 'Een expressie met twee parameters of argumenten, zoals `1 + 2`.
+
+      '
+- slug: binary_tree
+  ref:
+  - tree
+  - node
+  en:
+    term: binary tree
+    def: 'A [tree](#tree) data structure in which each [node](#node) has at most two
+      children, typically referred to as the left child and right child. Binary trees
+      are used in many algorithms and data structures like binary search trees and
+      heaps.
+
+      '
 - slug: binomial_distribution
   ref:
-    - discrete_random_variable
-    - histogram
+  - discrete_random_variable
+  - histogram
   en:
-    term: "binomial distribution"
-    def: >
-      A [probability distribution](#probability_distribution) that arises when there
-      are a fixed number of trials, each of which can produce one of two outcomes, and
-      the probability of those outcomes does not change. As the number of trials
+    term: binomial distribution
+    def: 'A [probability distribution](#probability_distribution) that arises when
+      there are a fixed number of trials, each of which can produce one of two outcomes,
+      and the probability of those outcomes does not change. As the number of trials
       increases, the binomial distribution approximates a [normal distribution](#normal_distribution).
-  pt:
-    term: "distribuição binomial"
-    def: >
-      Uma [distribuição de probabilidade](#probability_distribution) que emerge quando há
-      um número fixo de tentativas, cada uma das quais podendo produzir um de dois resultados e
-      quando a probabilidade destes resultados não muda. Na medida em que o número de tentativas aumenta,
-      a distribuição binomial se aproxima da [distribuição normal](#normal_distribution).
 
+      '
+  pt:
+    term: distribuição binomial
+    def: 'Uma [distribuição de probabilidade](#probability_distribution) que emerge
+      quando há um número fixo de tentativas, cada uma das quais podendo produzir
+      um de dois resultados e quando a probabilidade destes resultados não muda. Na
+      medida em que o número de tentativas aumenta, a distribuição binomial se aproxima
+      da [distribuição normal](#normal_distribution).
+
+      '
   am:
     term: ቢኖሚያል ስርጭት
-    def: >
-      እዚያ ሲኖር የሚነሳ አንድ [ፕሮባቢሊቲ ስርጭት](#probability_distribution) እነዚህ እያንዳንዳቸው ከሁለት ውጤቶች አንዱን ሊያወጡ የሚችሉ የተወሰኑ የሙከራ ሙከራዎች ናቸው የእነዚህ ውጤቶች ዕድል አይለወጥም ፡፡ እንደ ሙከራዎች ብዛት ይጨምራል ፣ የሁለትዮሽ ስርጭት አንድ [መደበኛ ስርጭት](#normal_distribution) በግምት። የተስተካከለ የሙከራ ቁጥር ሲኖር የሚነሳ አንድ [ፕሮባቢሊቲ ስርጭት](#probability_distribution) እያንዳንዳቸው ከሁለቱ ውጤቶች አንዱን ሊያመጣ ይችላል ፣ እናም የእነዚህ ውጤቶች ዕድል አይቀየርም። የሙከራዎች ቁጥር እየጨመረ በሄደ መጠን የሁለትዮሽ ማሰራጫው ወደ [መደበኛ ስርጭት](#normal_distribution) በግምት
+    def: 'እዚያ ሲኖር የሚነሳ አንድ [ፕሮባቢሊቲ ስርጭት](#probability_distribution) እነዚህ እያንዳንዳቸው
+      ከሁለት ውጤቶች አንዱን ሊያወጡ የሚችሉ የተወሰኑ የሙከራ ሙከራዎች ናቸው የእነዚህ ውጤቶች ዕድል አይለወጥም ፡፡ እንደ ሙከራዎች
+      ብዛት ይጨምራል ፣ የሁለትዮሽ ስርጭት አንድ [መደበኛ ስርጭት](#normal_distribution) በግምት። የተስተካከለ
+      የሙከራ ቁጥር ሲኖር የሚነሳ አንድ [ፕሮባቢሊቲ ስርጭት](#probability_distribution) እያንዳንዳቸው ከሁለቱ
+      ውጤቶች አንዱን ሊያመጣ ይችላል ፣ እናም የእነዚህ ውጤቶች ዕድል አይቀየርም። የሙከራዎች ቁጥር እየጨመረ በሄደ መጠን የሁለትዮሽ
+      ማሰራጫው ወደ [መደበኛ ስርጭት](#normal_distribution) በግምት
 
+      '
   af:
-    term: "binomiale verspreiding"
-    def: >
-      ’n [Waarskynlikheidsverspreiding](#probability_distribution) wat ontstaan wanneer daar ’n vaste aantal proewe is, en elke proef kan een van twee uitkomste lewer,
-      met konstante waarskynlikhede. Soos die aantal proewe toeneem, benader die binomiale verspreiding ’n [normale verspreiding](#normal_distribution).
+    term: binomiale verspreiding
+    def: '’n [Waarskynlikheidsverspreiding](#probability_distribution) wat ontstaan
+      wanneer daar ’n vaste aantal proewe is, en elke proef kan een van twee uitkomste
+      lewer, met konstante waarskynlikhede. Soos die aantal proewe toeneem, benader
+      die binomiale verspreiding ’n [normale verspreiding](#normal_distribution).
 
-
+      '
 - slug: bit
   ref:
-    - binary
-    - boolean
+  - binary
+  - boolean
   en:
-    term: "bit"
-    def: >
-      A unit of information representing alternatives, yes/no,
-      [true](#true)/[false](#false). In computing, a state of either 0 or 1.
+    term: bit
+    def: 'A unit of information representing alternatives, yes/no, [true](#true)/[false](#false).
+      In computing, a state of either 0 or 1.
+
+      '
   pt:
-    term: "bit"
-    def: >
-      Uma unidade de informação representando alternativas, sim/não,
-      [verdadeiro](#true)/[falso](#false). Em computação, um estado de 0 ou 1.
+    term: bit
+    def: 'Uma unidade de informação representando alternativas, sim/não, [verdadeiro](#true)/[falso](#false).
+      Em computação, um estado de 0 ou 1.
+
+      '
   es:
-    term: "bit"
-    def: >
-      Unidad de información representando alternativas sí/no, [verdadero](#true)/[falso](#false).
+    term: bit
+    def: 'Unidad de información representando alternativas sí/no, [verdadero](#true)/[falso](#false).
       En computación, un estado de ser 0 ó 1.
+
+      '
   de:
-    term: "Bit"
-    def: >
-      Ein Bit ist eine Informationseinheit, die nur zwei Alternativen
-      darstellen kann. Beispiele hierfür sind Ja/ Nein, Wahr / Falsch. In der
-      Computerwelt als 0 und 1 dargestellt.
+    term: Bit
+    def: 'Ein Bit ist eine Informationseinheit, die nur zwei Alternativen darstellen
+      kann. Beispiele hierfür sind Ja/ Nein, Wahr / Falsch. In der Computerwelt als
+      0 und 1 dargestellt.
+
+      '
   id:
-    term: "bit"
-    def: >
-      Sebuah unit informasi yang merepresentasikan beberapa alternatif, ya/tidak, (true)[#true]/(false)[#false].
-      Di dalam komputasi, bit adalah 0 atau 1.
+    term: bit
+    def: 'Sebuah unit informasi yang merepresentasikan beberapa alternatif, ya/tidak,
+      (true)[#true]/(false)[#false]. Di dalam komputasi, bit adalah 0 atau 1.
+
+      '
   tn:
-    term: "Kitso_ potlana"
-    def: >
-      Ke selekanyo sa kitso e nnye kana e e kwa tlase. Selekanyo se sa kitso, se ka emelwa ke lefela kana bongwe.
+    term: Kitso_ potlana
+    def: 'Ke selekanyo sa kitso e nnye kana e e kwa tlase. Selekanyo se sa kitso,
+      se ka emelwa ke lefela kana bongwe.
+
+      '
   am:
     term: ቢት
-    def: >
-      አማራጮችን የሚወክል የመረጃ ክፍል ፣ አዎ / አይደለም ፣ (እውነት) (#true) / [ውሸት](#false) የ 0 ወይም የ 1 ሁኔታን በማስላት ላይ ፡፡ አዎ / አይደለም ፣ (እውነት) (#true) / [ውሸት](#false) አማራጮችን የሚወክል የመረጃ ክፍል የ 0 ወይም የ 1 ሁኔታን በማስላት ላይ ፡፡
+    def: 'አማራጮችን የሚወክል የመረጃ ክፍል ፣ አዎ / አይደለም ፣ (እውነት) (#true) / [ውሸት](#false) የ 0
+      ወይም የ 1 ሁኔታን በማስላት ላይ ፡፡ አዎ / አይደለም ፣ (እውነት) (#true) / [ውሸት](#false) አማራጮችን
+      የሚወክል የመረጃ ክፍል የ 0 ወይም የ 1 ሁኔታን በማስላት ላይ ፡፡
+
+      '
   fr:
-    term: "bit"
-    def: >
-      Une unité d'information ne pouvant prendre que deux valeurs, souvent désignées par les alternatives oui/non
-      ou vrai/faux. En informatique cela représente un état de 0 ou 1.
+    term: bit
+    def: 'Une unité d''information ne pouvant prendre que deux valeurs, souvent désignées
+      par les alternatives oui/non ou vrai/faux. En informatique cela représente un
+      état de 0 ou 1.
+
+      '
   af:
     term: bis
-    def: >
-      'n Eenheid van inligting wat alternatiewe voorstel, ja/nee, waar/vals. Dit kan voorgestel work as 0 of 1.
+    def: '''n Eenheid van inligting wat alternatiewe voorstel, ja/nee, waar/vals.
+      Dit kan voorgestel work as 0 of 1.
+
+      '
   nl:
     term: bit
-    def: >
-      Een eenheid van informatie, die alternatieven representeert, zoals ja/nee, waar/onwaar. In de informatica wordt dit gerepresenteerd als een 0 of een 1.
+    def: 'Een eenheid van informatie, die alternatieven representeert, zoals ja/nee,
+      waar/onwaar. In de informatica wordt dit gerepresenteerd als een 0 of een 1.
 
+      '
   sw:
-    term: "biti"
-    def: >
-      Sehemu ya habari inayowakilisha njia mbadala, ndiyo/hapana,
-      [true](#true)/[false](#false). Katika kuhesabu hali ya 0 au 1.
-  uk:
-    term: "біт"
-    def: >
-      Одиниця інформації, яка представляє дві альтернативи, наприклад: так/ні, 
-      [істина](#true)/[хибність](#false), 1 або 0 тощо.
+    term: biti
+    def: 'Sehemu ya habari inayowakilisha njia mbadala, ndiyo/hapana, [true](#true)/[false](#false).
+      Katika kuhesabu hali ya 0 au 1.
 
+      '
+  uk:
+    term: біт
+    def: 'Одиниця інформації, яка представляє дві альтернативи, наприклад: так/ні,  [істина](#true)/[хибність](#false),
+      1 або 0 тощо.
+
+      '
 - slug: blob
   en:
-    term: "binary large object"
-    acronym: "BLOB"
-    def: >
-      Data that is stored in a database without being interpreted in any way, such as
-      an audio file. The term is also now used to refer to data transferred over a
-      network or stored in a [version control](#version_control_system)
-      [repository](#repository) as uninterpreted bits.
+    term: binary large object
+    acronym: BLOB
+    def: 'Data that is stored in a database without being interpreted in any way,
+      such as an audio file. The term is also now used to refer to data transferred
+      over a network or stored in a [version control](#version_control_system) [repository](#repository)
+      as uninterpreted bits.
+
+      '
   tn:
-    term: "Selekanyo sa kitso e e mo sedirisiweng se segolo"
-    def: >
-      Ke kitso e e beilweng e le mo seemong kana sedirisiweng se setona mo lefelong le le lengwe fela.
+    term: Selekanyo sa kitso e e mo sedirisiweng se segolo
+    def: 'Ke kitso e e beilweng e le mo seemong kana sedirisiweng se setona mo lefelong
+      le le lengwe fela.
 
+      '
   af:
-    term: "binêre groot voorwerp"
-    def: >
-      Data wat in 'n databasis gestoor word sonder om op enige manier geïnterpreteer te word, soos 'n 
-      klanklêer. Die term word ook nou gebruik om te verwys na data wat oor 'n netwerk oorgedra word 
-      of in 'n [weergawebeheerstelsel-repository](#version_control_system) as ongeïnterpreteerde bis gestoor word.      
-
-
+    term: binêre groot voorwerp
+    def: "Data wat in 'n databasis gestoor word sonder om op enige manier geïnterpreteer\
+      \ te word, soos 'n  klanklêer. Die term word ook nou gebruik om te verwys na\
+      \ data wat oor 'n netwerk oorgedra word  of in 'n [weergawebeheerstelsel-repository](#version_control_system)\
+      \ as ongeïnterpreteerde bis gestoor word.      \n"
   sw:
-    term: "kitu kikubwa cha binary"
-    def: >
-      Data ambayo imehifadhiwa katika hifadhidata bila kufasiriwa kwa njia yoyote,
-      kama vile faili ya sauti. Neno hili pia sasa linatumika kurejelea data
-      iliyohamishwa kupitia mtandao au kuhifadhiwa katika
-      [version control](#version_control_system) [repository](#repository)
-      kama biti zisizotafsiriwa.
+    term: kitu kikubwa cha binary
+    def: 'Data ambayo imehifadhiwa katika hifadhidata bila kufasiriwa kwa njia yoyote,
+      kama vile faili ya sauti. Neno hili pia sasa linatumika kurejelea data iliyohamishwa
+      kupitia mtandao au kuhifadhiwa katika [version control](#version_control_system)
+      [repository](#repository) kama biti zisizotafsiriwa.
 
-
+      '
 - slug: block_comment
   en:
-    term: "block comment"
-    def: >
-      A [comment](#comment) that spans multiple lines. Block comments may be marked
+    term: block comment
+    def: 'A [comment](#comment) that spans multiple lines. Block comments may be marked
       with special start and end symbols, like `/*` and `*/` in C and its descendents,
       or each line may be prefixed with a marker like `#`.
+
+      '
   af:
-    term: "blokkommentaar"
-    def: >
-      Kommentaar in rekenaarprogrammeerkode wat oor meer as een lyn strek. Blokkomentaar word gewoonlik aangedui 
-      deur begin- en eindsimbole, bv. /* en */ in C en soortgelyke tale, of elke lyn word begin met 'n simbool bv. #
+    term: blokkommentaar
+    def: 'Kommentaar in rekenaarprogrammeerkode wat oor meer as een lyn strek. Blokkomentaar
+      word gewoonlik aangedui  deur begin- en eindsimbole, bv. /* en */ in C en soortgelyke
+      tale, of elke lyn word begin met ''n simbool bv. #
+
+      '
   pt:
-    term: "bloco de comentário"
-    def: >
-      Um [comentário](#comment) que abrange múltiplas linhas. Blocos de comentários
+    term: bloco de comentário
+    def: 'Um [comentário](#comment) que abrange múltiplas linhas. Blocos de comentários
       podem ser indicados com símbolos especiais, como `/*` e `*/` em C e linguagens
-      herdeiras dessa sintaxe, ou cada linha pode ser prefixada com uma indicação como `#`.
+      herdeiras dessa sintaxe, ou cada linha pode ser prefixada com uma indicação
+      como `#`.
+
+      '
   de:
-    term: "Blockkommentar"
-    def: >
-      Ein [Kommentar](#comment) welcher mehrere Zeilen umfasst. Blockkommentare haben
-      spezifische Start- und Endsymbole, z.B. `/*` und `*/` in C und verwandten Sprachen.
-      Manche Sprachen kennen keine Blockkommentare und so werden diese mit einem
-      Einzelkommentarsymbol in jeder Zeile, z.B. `#`, gekennzeichnet.
+    term: Blockkommentar
+    def: 'Ein [Kommentar](#comment) welcher mehrere Zeilen umfasst. Blockkommentare
+      haben spezifische Start- und Endsymbole, z.B. `/*` und `*/` in C und verwandten
+      Sprachen. Manche Sprachen kennen keine Blockkommentare und so werden diese mit
+      einem Einzelkommentarsymbol in jeder Zeile, z.B. `#`, gekennzeichnet.
 
+      '
   sw:
-    term: "Maoni Mapana"
-    def: >
-      Maoni [comment](#comment) ambayo yanajumuisha mistari mingi.
-      Maoni mapana yanaweza kuwekewa alama maalum za kuanza na kumalizia,
-      kama vile `/*` na `*/` katika C na vizazi vyake, au kila mstari unaweza kuanikwa kwa alama kama `#`.
+    term: Maoni Mapana
+    def: 'Maoni [comment](#comment) ambayo yanajumuisha mistari mingi. Maoni mapana
+      yanaweza kuwekewa alama maalum za kuanza na kumalizia, kama vile `/*` na `*/`
+      katika C na vizazi vyake, au kila mstari unaweza kuanikwa kwa alama kama `#`.
 
-
+      '
   am:
     term: አግድ አስተያየት
-    def: >
-      በርካታ መስመሮችን የሚያልፍ [አስተያየት](#comment)። የማገጃ አስተያየቶች ምልክት ሊደረግባቸው ይችላል እንደ "/ *" እና "* /" ባሉ ልዩ የመጀመሪያ እና መጨረሻ ምልክቶች በ C እና በትውልዶቹ ፣ ወይም እያንዳንዱ መስመር እንደ ‹#› ባለው ጠቋሚ ቅድመ-ቅጥያ ሊሆን ይችላል ፡፡ [አስተያየት](#comment) የበርካታ መስመሮች rመzt ። የማገጃ አስተያየቶች mnአlባtምልክት ሊደረግባቸው ይችላል እንደ "/ *" እና "* /" ባሉ ልዩ የመጀመሪያ እና መጨረሻ ምልክቶች በ C እና በትውልዶቹ ፣ ወይም እያንዳንዱ መስመር እንደ ‹#› ባለው ጠቋሚ ቅድመ-ቅጥያ ሊሆን ይችላል ፡፡
+    def: 'በርካታ መስመሮችን የሚያልፍ [አስተያየት](#comment)። የማገጃ አስተያየቶች ምልክት ሊደረግባቸው ይችላል እንደ
+      "/ *" እና "* /" ባሉ ልዩ የመጀመሪያ እና መጨረሻ ምልክቶች በ C እና በትውልዶቹ ፣ ወይም እያንዳንዱ መስመር እንደ
+      ‹#› ባለው ጠቋሚ ቅድመ-ቅጥያ ሊሆን ይችላል ፡፡ [አስተያየት](#comment) የበርካታ መስመሮች rመzt ። የማገጃ አስተያየቶች
+      mnአlባtምልክት ሊደረግባቸው ይችላል እንደ "/ *" እና "* /" ባሉ ልዩ የመጀመሪያ እና መጨረሻ ምልክቶች በ C እና
+      በትውልዶቹ ፣ ወይም እያንዳንዱ መስመር እንደ ‹#› ባለው ጠቋሚ ቅድመ-ቅጥያ ሊሆን ይችላል ፡፡
 
+      '
 - slug: boilerplate
   en:
-    term: "boilerplate"
-    def: >
-      Standard text that is included in legal contracts, licenses, and so on.
-      Also parts of the source code that have to be repeated very often to get basic functionality.
-      In [object-oriented programs](#oop) these segments are used to encapsulate variables
-      of objects. Some languages require a lot of these statements and are termed boilerplate
-      languages, e.g. Java, which means that they are frequently generated automatically or by
-      using [auto-completion](#auto_completion).
+    term: boilerplate
+    def: 'Standard text that is included in legal contracts, licenses, and so on.
+      Also parts of the source code that have to be repeated very often to get basic
+      functionality. In [object-oriented programs](#oop) these segments are used to
+      encapsulate variables of objects. Some languages require a lot of these statements
+      and are termed boilerplate languages, e.g. Java, which means that they are frequently
+      generated automatically or by using [auto-completion](#auto_completion).
+
+      '
   de:
-    term: "Boilerplate"
-    def: >
-      Standardisierte Texte welche sehr häufig Anwendung finden, beispielsweise für Verträge, Lizenzen, usw.
-      Desweiteren werden damit Codesegmente oder Textbausteine bezeichnet, welche an mehreren Stellen wiederholt werden müssen um
-      ein funktionierendes Programm zu erhalten. Boilerplate Code enthält allerdings wichtige
-      Informationen um beispielsweise Variablen in der [objektorientierten Programmierung](#oop)
-      zu kapseln. Manche Programmiersprachen sind sehr wortreich und erfordern viel Code um einfache
-      Funktionalitäten zu erhalten, z.B. Java, sodass dieser Code häufig automatisch oder mittels
-      [Autovervollständigung](#auto_completion) erstellt wird.
+    term: Boilerplate
+    def: 'Standardisierte Texte welche sehr häufig Anwendung finden, beispielsweise
+      für Verträge, Lizenzen, usw. Desweiteren werden damit Codesegmente oder Textbausteine
+      bezeichnet, welche an mehreren Stellen wiederholt werden müssen um ein funktionierendes
+      Programm zu erhalten. Boilerplate Code enthält allerdings wichtige Informationen
+      um beispielsweise Variablen in der [objektorientierten Programmierung](#oop)
+      zu kapseln. Manche Programmiersprachen sind sehr wortreich und erfordern viel
+      Code um einfache Funktionalitäten zu erhalten, z.B. Java, sodass dieser Code
+      häufig automatisch oder mittels [Autovervollständigung](#auto_completion) erstellt
+      wird.
 
-
+      '
   sw:
-    term: "boilerplate"
-    def: >
-      Maandishi ya kawaida ambayo yanajumuishwa katika mikataba ya kisheria, leseni, na kadhalika.
-      Pia sehemu za msimbo wa chanzo ambazo zinapaswa kurudiwa mara nyingi sana ili kupata utendakazi msingi.
-      Katika [object-oriented programs](#oop) sehemu hizi hutumika kujumuisha viambajengo vya vitu.
-      Lugha zingine zinahitaji mengi ya kauli hizi na huitwa lugha za boilerplate, k.m. Java,
-      ambayo ina maana kwamba huzalishwa kiotomatiki mara kwa mara au kwa
-      kutumia [auto-completion](#auto_completion).
+    term: boilerplate
+    def: 'Maandishi ya kawaida ambayo yanajumuishwa katika mikataba ya kisheria, leseni,
+      na kadhalika. Pia sehemu za msimbo wa chanzo ambazo zinapaswa kurudiwa mara
+      nyingi sana ili kupata utendakazi msingi. Katika [object-oriented programs](#oop)
+      sehemu hizi hutumika kujumuisha viambajengo vya vitu. Lugha zingine zinahitaji
+      mengi ya kauli hizi na huitwa lugha za boilerplate, k.m. Java, ambayo ina maana
+      kwamba huzalishwa kiotomatiki mara kwa mara au kwa kutumia [auto-completion](#auto_completion).
 
+      '
   am:
     term: ቦይለር ፕሌት
-    def: >
-      በሕጋዊ ኮንትራቶች ፣ ፈቃዶች ፣ ወዘተ ውስጥ የተካተተ መደበኛ ጽሑፍ ፡፡
+    def: 'በሕጋዊ ኮንትራቶች ፣ ፈቃዶች ፣ ወዘተ ውስጥ የተካተተ መደበኛ ጽሑፍ ፡፡
 
+      '
   af:
-    term: "boilerplate"
-    def: >
-      Standaardteks wat in regsverdrae, lisensies en soortgelyke dokumente ingesluit word. Dit verwys ook na dele van bronkode wat baie gereeld herhaal moet word om basiese funksionaliteit te verkry.
-      In [objekgeoriënteerde programme](#oop) word hierdie segmente gebruik om veranderlikes van voorwerpe te enkapsuleer. Sommige programmeertale, soos Java, vereis baie van hierdie stellings en word daarom as boilerplate-tale beskou,
-      wat beteken dat sulke kode dikwels outomaties gegenereer word of met behulp van [outovoltooiing](#auto_completion).
+    term: boilerplate
+    def: 'Standaardteks wat in regsverdrae, lisensies en soortgelyke dokumente ingesluit
+      word. Dit verwys ook na dele van bronkode wat baie gereeld herhaal moet word
+      om basiese funksionaliteit te verkry. In [objekgeoriënteerde programme](#oop)
+      word hierdie segmente gebruik om veranderlikes van voorwerpe te enkapsuleer.
+      Sommige programmeertale, soos Java, vereis baie van hierdie stellings en word
+      daarom as boilerplate-tale beskou, wat beteken dat sulke kode dikwels outomaties
+      gegenereer word of met behulp van [outovoltooiing](#auto_completion).
 
+      '
 - slug: boolean
   ref:
-    - truthy
-    - falsy
-    - binary
+  - truthy
+  - falsy
+  - binary
   en:
-    term: "Boolean"
-    def: >
-      Relating to a variable or data type that can have either a logical value of
-      [true](#true) or [false](#false). Named for George Boole, a 19th
-      century mathematician. Binary systems, like all computers, are built on this
-      foundation of systems of logical evaluations between states of true and false, 1
-      or 0.
-  ar:
-    term: "التعبير المنطقي"
-    def: >
-        التعبير المنطقي هو عبارة عن تعبير يُستخدم لإنشاء جُمل إما تحمل
-        [القيمة صح](#true)
-        أو
-        [القيمة خطأ](#false)
-         وتستخدم التعبيرات المنطقية مع العبارات الشرطية في محركات البحث والخوارزميات،
-         كما تُسمى التعبيرات المنطقية أيضا تعبيرات المقارنة والتعبيرات الشرطية
-         والتعبيرات العلائقية.
-  pt:
-    term: "Booleano"
-    def: >
-      Relacionado a uma variável ou tipo de dado que pode ter um valor lógico de
-      [verdadeiro](#true) ou [falso](#false). Nomeado em referêcia à George Boole, um
-      matemático do século XIX. Sistemas binários, como todos os computadores, são construídos
-      com base em sistemas de avaliação entre estados de verdadeiro e falso, 0 ou 1.
-  es:
-    term: "Booleano"
-    def: >
-     Relacionado a una variable o tipo de dato que puede tomar un valor lógico.
-     Un valor lógico puede ser [verdadero](#true) o [falso](#false).
-     El termino "booleano" viene en honor a George Boole, un matematico del siglo XIX.
-     El concepto del computador esta fundamentado en el sistema binario,
-     en el qual se evalua entre estados de verdedero o falso.
-  de:
-    term: "Boolean"
-    def: >
-      Eine Art der Variable oder eines Datentyps welche entweder den logischen Wert [wahr](#true)
-      oder [falsch](#false) haben kann. Benannt nach George Boole, einem Mathematiker aus dem 19.
-      Jahrhundert. Binärsysteme, wie alle Computer, beruhen auf der Verarbeitung von logischen
-      Wahr-Falsch-Zuständen, 1 oder 0.
-  id:
-    term: "Boolean"
-    def: >
-      Berkaitan dengan variabel atau tipe data yang dapat memiliki nilai logika benar atau salah.
-      Istilah boolean diambil dari nama George Boole, seorang matematikawan abad ke-19. Sistem biner,
-      seperti semua komputer, dibangun di atas dasar sistem evaluasi logis true / false, 1 atau 0.
+    term: Boolean
+    def: 'Relating to a variable or data type that can have either a logical value
+      of [true](#true) or [false](#false). Named for George Boole, a 19th century
+      mathematician. Binary systems, like all computers, are built on this foundation
+      of systems of logical evaluations between states of true and false, 1 or 0.
 
+      '
+  ar:
+    term: التعبير المنطقي
+    def: "التعبير المنطقي هو عبارة عن تعبير يُستخدم لإنشاء جُمل إما تحمل [القيمة صح](#true)\
+      \ أو [القيمة خطأ](#false)\n وتستخدم التعبيرات المنطقية مع العبارات الشرطية في\
+      \ محركات البحث والخوارزميات،\n كما تُسمى التعبيرات المنطقية أيضا تعبيرات المقارنة\
+      \ والتعبيرات الشرطية\n والتعبيرات العلائقية.\n"
+  pt:
+    term: Booleano
+    def: 'Relacionado a uma variável ou tipo de dado que pode ter um valor lógico
+      de [verdadeiro](#true) ou [falso](#false). Nomeado em referêcia à George Boole,
+      um matemático do século XIX. Sistemas binários, como todos os computadores,
+      são construídos com base em sistemas de avaliação entre estados de verdadeiro
+      e falso, 0 ou 1.
+
+      '
+  es:
+    term: Booleano
+    def: 'Relacionado a una variable o tipo de dato que puede tomar un valor lógico.
+      Un valor lógico puede ser [verdadero](#true) o [falso](#false). El termino "booleano"
+      viene en honor a George Boole, un matematico del siglo XIX. El concepto del
+      computador esta fundamentado en el sistema binario, en el qual se evalua entre
+      estados de verdedero o falso.
+
+      '
+  de:
+    term: Boolean
+    def: 'Eine Art der Variable oder eines Datentyps welche entweder den logischen
+      Wert [wahr](#true) oder [falsch](#false) haben kann. Benannt nach George Boole,
+      einem Mathematiker aus dem 19. Jahrhundert. Binärsysteme, wie alle Computer,
+      beruhen auf der Verarbeitung von logischen Wahr-Falsch-Zuständen, 1 oder 0.
+
+      '
+  id:
+    term: Boolean
+    def: 'Berkaitan dengan variabel atau tipe data yang dapat memiliki nilai logika
+      benar atau salah. Istilah boolean diambil dari nama George Boole, seorang matematikawan
+      abad ke-19. Sistem biner, seperti semua komputer, dibangun di atas dasar sistem
+      evaluasi logis true / false, 1 atau 0.
+
+      '
   am:
     term: ቡሊያን
-    def: "የሎጂካዊ እሴት ሊኖረው ከሚችለው ተለዋዋጭ ወይም የውሂብ ዓይነት ጋር ማዛመድ (እውነት) (#true) ወይም [ሐሰት](#false)
-      ፡፡ ለ 19 ኛ ጆርጅ ቡሌ ተብሎ ተሰይሟል ክፍለ ዘመን የሂሳብ ሊቅ የሁለትዮሽ ስርዓቶች ልክ እንደ ሁሉም ኮምፒውተሮች በዚህ
-      ላይ ተገንብተዋል በእውነተኛ እና በሐሰት ግዛቶች መካከል የሎጂካዊ ግምገማዎች ስርዓት መሠረት ፣ 1 የሎጂካዊ እሴት ሊኖረው
-      ከሚችለው ተለዋዋጭ ወይም የውሂብ ዓይነት ጋር ማዛመድ (እውነት)(#true) ወይም [ሐሰት](#false) ፡፡ የ19 ኛ ክፍለ
-      ዘመን የሂሳብ ሊቅ ጆርጅ ቡሌ ተብሎ ይጠራል :: የሁለትዮሽ ስርዓቶች ልክ እንደ ሁሉም ኮምፒውተሮች  በእውነተኛ,1 እና
-      በሐሰት,0  መሠረት ተገንብተዋል \n"
-
+    def: "የሎጂካዊ እሴት ሊኖረው ከሚችለው ተለዋዋጭ ወይም የውሂብ ዓይነት ጋር ማዛመድ (እውነት) (#true) ወይም [ሐሰት](#false)\
+      \ ፡፡ ለ 19 ኛ ጆርጅ ቡሌ ተብሎ ተሰይሟል ክፍለ ዘመን የሂሳብ ሊቅ የሁለትዮሽ ስርዓቶች ልክ እንደ ሁሉም ኮምፒውተሮች\
+      \ በዚህ ላይ ተገንብተዋል በእውነተኛ እና በሐሰት ግዛቶች መካከል የሎጂካዊ ግምገማዎች ስርዓት መሠረት ፣ 1 የሎጂካዊ እሴት\
+      \ ሊኖረው ከሚችለው ተለዋዋጭ ወይም የውሂብ ዓይነት ጋር ማዛመድ (እውነት)(#true) ወይም [ሐሰት](#false) ፡፡\
+      \ የ19 ኛ ክፍለ ዘመን የሂሳብ ሊቅ ጆርጅ ቡሌ ተብሎ ይጠራል :: የሁለትዮሽ ስርዓቶች ልክ እንደ ሁሉም ኮምፒውተሮች \
+      \ በእውነተኛ,1 እና በሐሰት,0  መሠረት ተገንብተዋል \n"
   sw:
-    term: "Boolean"
-    def: >
-      Kuhusiana na aina au aina ya data ambayo inaweza kuwa na thamani ya kimantiki ya [true](#true) au [false](#false).
-      Imetajwa kwa George Boole, mwanahisabati wa karne ya 19.
-      Mifumo ya binary, kama kompyuta zote,
-      imejengwa juu ya msingi huu wa mifumo ya tathmini ya kimantiki kati ya majimbo ya kweli na ya uwongo, 1 au 0.
-  uk:
-    term: "булевий вираз"
-    def: >
-      Пов'язаний зі змінною або типом даних, які можуть мати логічне значення [істини](#true) або [хибності](#false). 
-      Цей термін походить від імені Джорджа Буля, математика 19-го століття. Двійкові системи, як і всі комп'ютери, 
-      будуються на основі системи логічного обчислення між станами істини та хибності (1 або 0).
+    term: Boolean
+    def: 'Kuhusiana na aina au aina ya data ambayo inaweza kuwa na thamani ya kimantiki
+      ya [true](#true) au [false](#false). Imetajwa kwa George Boole, mwanahisabati
+      wa karne ya 19. Mifumo ya binary, kama kompyuta zote, imejengwa juu ya msingi
+      huu wa mifumo ya tathmini ya kimantiki kati ya majimbo ya kweli na ya uwongo,
+      1 au 0.
 
+      '
+  uk:
+    term: булевий вираз
+    def: 'Пов''язаний зі змінною або типом даних, які можуть мати логічне значення
+      [істини](#true) або [хибності](#false).  Цей термін походить від імені Джорджа
+      Буля, математика 19-го століття. Двійкові системи, як і всі комп''ютери,  будуються
+      на основі системи логічного обчислення між станами істини та хибності (1 або
+      0).
+
+      '
   af:
-    term: "Booleaans"
-    def: >
-      Verwys na ’n veranderlike of datatipe wat ’n logiese waarde van [waar](#true) of [vals](#false) kan hê. Die term is vernoem na George Boole,
-      ’n Wiskundige uit die 19de eeu. Binêre stelsels, soos alle rekenaars, is gebou op hierdie fondasie van logiese evaluasies tussen toestande van waar en vals, 1 of 0.
-    
+    term: Booleaans
+    def: 'Verwys na ’n veranderlike of datatipe wat ’n logiese waarde van [waar](#true)
+      of [vals](#false) kan hê. Die term is vernoem na George Boole, ’n Wiskundige
+      uit die 19de eeu. Binêre stelsels, soos alle rekenaars, is gebou op hierdie
+      fondasie van logiese evaluasies tussen toestande van waar en vals, 1 of 0.
+
+      '
 - slug: branch
   en:
-    term: "branch"
-    def: >
-      See [Git branch](#git_branch).
+    term: branch
+    def: 'See [Git branch](#git_branch).
 
+      '
   am:
     term: ቅርንጫፍ
-    def: >
-      [Git ቅርንጫፍ](#git_branch) ይመልከቱ።
+    def: '[Git ቅርንጫፍ](#git_branch) ይመልከቱ።
 
+      '
   sw:
-    term: "tawi"
-    def: >
-      rejelea [Git branch](#git_branch).
+    term: tawi
+    def: 'rejelea [Git branch](#git_branch).
+
+      '
   uk:
-    term: "гілка"
-    def: >
-      Дивіться [гілка Git](#git_branch).
+    term: гілка
+    def: 'Дивіться [гілка Git](#git_branch).
 
+      '
   af:
-    term: "tak"
-    def: >
-      Sien [Git-tak](#git_branch).
+    term: tak
+    def: 'Sien [Git-tak](#git_branch).
 
+      '
 - slug: branch_per_feature_workflow
   en:
-    term: "branch-per-feature workflow"
-    def: >
-      A common strategy for managing work with [Git](#git) and other [version control
-      systems](#version_control_system) in which a separate [branch](#git_branch) is
-      created for work on each new feature or each [bug](#bug) fix and merged when that work
-      is completed. This isolates changes from one another until they are completed.
+    term: branch-per-feature workflow
+    def: 'A common strategy for managing work with [Git](#git) and other [version
+      control systems](#version_control_system) in which a separate [branch](#git_branch)
+      is created for work on each new feature or each [bug](#bug) fix and merged when
+      that work is completed. This isolates changes from one another until they are
+      completed.
 
+      '
   af:
-    term: "tak-per-kenmerk werkstroom"
-    def: >
-      'n Algemene strategie om werk in [Git](#git), en ander [weergawe beheerstelsels](#version_control_system),
-      te organiseer, deur 'n afgesonderde [tak](#git_branch) te skep vir elke nuwe kenmerk of [bug](#bug)-korreksie.
-      Die tak word dan saamgesmelt wanneer die werk voltooi is. Die werkstroom isoleer verskillende veranderinge 
-      van mekaar totdat hulle voltooi is.
+    term: tak-per-kenmerk werkstroom
+    def: '''n Algemene strategie om werk in [Git](#git), en ander [weergawe beheerstelsels](#version_control_system),
+      te organiseer, deur ''n afgesonderde [tak](#git_branch) te skep vir elke nuwe
+      kenmerk of [bug](#bug)-korreksie. Die tak word dan saamgesmelt wanneer die werk
+      voltooi is. Die werkstroom isoleer verskillende veranderinge  van mekaar totdat
+      hulle voltooi is.
 
+      '
   am:
     term: የቅርንጫፍ-በእያንዳንዱ-ባህርይ የስራ ፍሰት
-    def: >
-      ሥራን በ [Git](#git) እና በሌሎች [ስሪት ቁጥጥር] ጋር ለማስተዳደር የተለመደ ስልት ስርዓቶች] (#version_control_system) የተለየ [ቅርንጫፍ](#git_branch) ባለበት ለእያንዳንዱ አዲስ ባህሪ ወይም ለእያንዳንዱ [ሳንካ](#git) ጥገና እና ሥራ ሲሠራ ተዋህዷል ተጠናቅቋል ፡፡ ይህ እስኪጠናቀቁ ድረስ ለውጦች እርስ በእርስ ይለየዋቸዋል።
+    def: 'ሥራን በ [Git](#git) እና በሌሎች [ስሪት ቁጥጥር] ጋር ለማስተዳደር የተለመደ ስልት ስርዓቶች] (#version_control_system)
+      የተለየ [ቅርንጫፍ](#git_branch) ባለበት ለእያንዳንዱ አዲስ ባህሪ ወይም ለእያንዳንዱ [ሳንካ](#git) ጥገና እና
+      ሥራ ሲሠራ ተዋህዷል ተጠናቅቋል ፡፡ ይህ እስኪጠናቀቁ ድረስ ለውጦች እርስ በእርስ ይለየዋቸዋል።
 
+      '
 - slug: breadcrumbs
   af:
-    term: "broodkrummels"
-    def: >
-      n Ontwerppatroon vir webwerwe wat bykomende navigasieskakels plaas, gewoonlik bo-aan die 
-      bladsy. Broodkrummel-navigasieskakels wys die gebruiker waar hulle, relatief tot die res van 
-      die webwerf, is. Die term is gebaseer op die sprokie Hansie en Grietjie, waarin die kinders 
-      'n spoor van broodkrummels agterlaat om hul pad terug huis toe te vind.
-  en:
-    term: "breadcrumbs"
-    def: >
-      A set of supplementary navigational links included in many websites, usually
-      placed at the top of the page. Breadcrumbs show the users where the current page
-      lies in the website; the term comes from a fairy tale in which children left a
-      trail of breadcrumbs behind themselves so that they could find their way home.
-  es:
-    term: "guías de navegación"
-    def: >
-      Literalmente: “migas,” “migas de pan,” “migaja;” en esto contexto: “árbol de navegación,”
-      “guías de navegación,” “navegación de migas,“ o “rastro de navegación.” Un grupo de enlaces
-      de navegación incluidos en muchos sitios web, generalmente ubicados en la parte superior
-      de una página. “Breadcrumbs” muestran a los usuarios dónde se encuentra la página
-      en el sitio web; la palabra proviene de un cuento de hadas en que unos niños
-      habían dejado atrás un rastro de migas de pan para que pudieran encontrar su camino a casa.
-  de:
-    term: "Brotkrümelnavigation"
-    def: >
-      Ein Entwurfsmuster für Webseiten welches zusätzliche Navigationslinks, normalerweise im oberen Bereich,
-      platziert. Brotkrümelnavigationslinks zeigen dem Nutzer wo er sich gerade relativ zum Rest
-      der Webseite befindet. Der Begriff ist in Anlehnung an das Märchen Hänsel und Gretel
-      entstanden, in welchem die Kinder eine Spur aus Brotkrümeln hinterlassen um den Weg zurück
-      zu finden.
-  uk:
-    term: "навігаційні стежки (хлібні крихти)"
-    def: >
-      Набір навігаційних посилань на багатьох веб-сайтах, які зазвичай розміщуються у
-      верхній частині сторінки. Навігаці́йні стежки показують користувачам, де вони знаходяться відносно поточної сторінки веб-сайту.
-      Термін походить від казки "Гензель і Гретель", в якій діти залишали за собою слід з хлібних крихт, щоб знайти дорогу додому.
+    term: broodkrummels
+    def: 'n Ontwerppatroon vir webwerwe wat bykomende navigasieskakels plaas, gewoonlik
+      bo-aan die  bladsy. Broodkrummel-navigasieskakels wys die gebruiker waar hulle,
+      relatief tot die res van  die webwerf, is. Die term is gebaseer op die sprokie
+      Hansie en Grietjie, waarin die kinders  ''n spoor van broodkrummels agterlaat
+      om hul pad terug huis toe te vind.
 
+      '
+  en:
+    term: breadcrumbs
+    def: 'A set of supplementary navigational links included in many websites, usually
+      placed at the top of the page. Breadcrumbs show the users where the current
+      page lies in the website; the term comes from a fairy tale in which children
+      left a trail of breadcrumbs behind themselves so that they could find their
+      way home.
+
+      '
+  es:
+    term: guías de navegación
+    def: 'Literalmente: “migas,” “migas de pan,” “migaja;” en esto contexto: “árbol
+      de navegación,” “guías de navegación,” “navegación de migas,“ o “rastro de navegación.”
+      Un grupo de enlaces de navegación incluidos en muchos sitios web, generalmente
+      ubicados en la parte superior de una página. “Breadcrumbs” muestran a los usuarios
+      dónde se encuentra la página en el sitio web; la palabra proviene de un cuento
+      de hadas en que unos niños habían dejado atrás un rastro de migas de pan para
+      que pudieran encontrar su camino a casa.
+
+      '
+  de:
+    term: Brotkrümelnavigation
+    def: 'Ein Entwurfsmuster für Webseiten welches zusätzliche Navigationslinks, normalerweise
+      im oberen Bereich, platziert. Brotkrümelnavigationslinks zeigen dem Nutzer wo
+      er sich gerade relativ zum Rest der Webseite befindet. Der Begriff ist in Anlehnung
+      an das Märchen Hänsel und Gretel entstanden, in welchem die Kinder eine Spur
+      aus Brotkrümeln hinterlassen um den Weg zurück zu finden.
+
+      '
+  uk:
+    term: навігаційні стежки (хлібні крихти)
+    def: 'Набір навігаційних посилань на багатьох веб-сайтах, які зазвичай розміщуються
+      у верхній частині сторінки. Навігаці́йні стежки показують користувачам, де вони
+      знаходяться відносно поточної сторінки веб-сайту. Термін походить від казки
+      "Гензель і Гретель", в якій діти залишали за собою слід з хлібних крихт, щоб
+      знайти дорогу додому.
+
+      '
 - slug: breadth_first
   ref:
-    - depth_first
+  - depth_first
   en:
-    term: "breadth first"
-    def: >
-      To go through a nested data structure such as a [tree](#tree) by exploring all
-      of one level, then going on to the next level and so on, or to explore a problem
-      by examining the first step of each possible solution, and then trying the next step
-      for each.
+    term: breadth first
+    def: 'To go through a nested data structure such as a [tree](#tree) by exploring
+      all of one level, then going on to the next level and so on, or to explore a
+      problem by examining the first step of each possible solution, and then trying
+      the next step for each.
 
+      '
   am:
     term: መጀመሪያ ስፋት
-    def: >
-      "ሁሉንም በመዳሰስ እንደ [ዛፍ](#tree) ያለ ጎጆ ባለው የውሂብ መዋቅር ውስጥ ማለፍ የአንድ ደረጃ ፣ ከዚያ ወደ
+    def: '"ሁሉንም በመዳሰስ እንደ [ዛፍ](#tree) ያለ ጎጆ ባለው የውሂብ መዋቅር ውስጥ ማለፍ የአንድ ደረጃ ፣ ከዚያ ወደ
       ቀጣዩ ደረጃ እና የመሳሰሉት መሄድ ፣ ወይም አንድ ችግርን ለመዳሰስ የእያንዳንዱን መፍትሄ የመጀመሪያ እርምጃ በመመርመር
       እና ቀጣዩን እርምጃ በመሞከር ለእያንዳንድ. የእያንዳንዱን መፍትሄ የመጀመሪያ እርምጃ በመመርመር እና ቀጣዩን እርምጃ በመሞከር
       ለእያንዳንድ. ሁሉንም በመዳሰስ እንደ [ዛፍ](#tree) ያለ ጎጆ ባለው የውሂብ መዋቅር ውስጥ ማለፍ የአንድ ደረጃ ፣ ከዚያ
       ወደ ቀጣዩ ደረጃ እና የመሳሰሉት መሄድ ፣ ወይም አንድ ችግርን ለመዳሰስ"
 
+      '
 - slug: browser_cache
   en:
-    term: "browser cache"
-    def: >
-      A place where web browsers keep copies of previously retrieved files (web pages, data files)
-      in order to save time when they're requested again. Sometimes, issues may arise if there is
-      a newer version of the file online, but the browser doesn't notice it.
-  de:
-    term: "Browser-Cache"
-    def: >
-      Ein [Puffer-Speicherort](#cache) auf dem Rechner des Benutzers, an dem der Webbrowser bereits
-      abgerufene Ressourcen wie z.B. Texte und Bilder als Kopie aufbewahrt. Dadurch können Zeit und
-      Netzwerkverkehr reduziert werden, wenn die Ressourcen erneut angefragt werden. Es kann durch
-      die Verwendung des Browser-Caches jedoch auch passieren, dass veraltete Informationen angezeigt
-      werden, wenn sich die Ressourcen in der Zwischenzeit geändert haben.
-  def:
-    term: "кеш браузера"
-    def: >
-      Місце, де веб-браузери зберігають копії раніше завантажених файлів (веб-сторінок, файлів даних)
-      для економії часу при повторному запиті. Іноді можуть виникати проблеми, якщо в Інтернеті є
-      нова версія файлу, але браузер її не завантажує.
+    term: browser cache
+    def: 'A place where web browsers keep copies of previously retrieved files (web
+      pages, data files) in order to save time when they''re requested again. Sometimes,
+      issues may arise if there is a newer version of the file online, but the browser
+      doesn''t notice it.
 
+      '
+  de:
+    term: Browser-Cache
+    def: 'Ein [Puffer-Speicherort](#cache) auf dem Rechner des Benutzers, an dem der
+      Webbrowser bereits abgerufene Ressourcen wie z.B. Texte und Bilder als Kopie
+      aufbewahrt. Dadurch können Zeit und Netzwerkverkehr reduziert werden, wenn die
+      Ressourcen erneut angefragt werden. Es kann durch die Verwendung des Browser-Caches
+      jedoch auch passieren, dass veraltete Informationen angezeigt werden, wenn sich
+      die Ressourcen in der Zwischenzeit geändert haben.
+
+      '
+  def:
+    term: кеш браузера
+    def: 'Місце, де веб-браузери зберігають копії раніше завантажених файлів (веб-сторінок,
+      файлів даних) для економії часу при повторному запиті. Іноді можуть виникати
+      проблеми, якщо в Інтернеті є нова версія файлу, але браузер її не завантажує.
+
+      '
 - slug: bug
   en:
-    term: "bug"
-    def: >
-      A missing or undesirable [feature](#feature_software) of a piece of software;
+    term: bug
+    def: 'A missing or undesirable [feature](#feature_software) of a piece of software;
       the digital equivalent of a weed.
+
+      '
   de:
-    term: "Bug"
-    def: >
-      Ein Bug ist ein Fehler oder Fehlfunktion einer Software.
+    term: Bug
+    def: 'Ein Bug ist ein Fehler oder Fehlfunktion einer Software.
+
+      '
   tn:
-    term: "Mogare o o borai mo boranyaneng"
-    def: >
-      Sengwe se se sa siamang, se le borai mo khompiutareng/sebalamakgolo. Se ka ama khompiutara/ sebalamakgolo le kitso e e mo go yone.
+    term: Mogare o o borai mo boranyaneng
+    def: 'Sengwe se se sa siamang, se le borai mo khompiutareng/sebalamakgolo. Se
+      ka ama khompiutara/ sebalamakgolo le kitso e e mo go yone.
+
+      '
   am:
     term: ሳንካ
-    def: >
-      የአንድ ሶፍትዌር ቁራጭ የጠፋ ወይም የማይፈለግ [ባህሪ](#feature_software); የአንድ አረም ዲጂታል አቻ ፡፡ የአንድ አረም ዲጂታል አቻ ; የአንድ ሶፍትዌር ቁራጭ የጠፋ ወይም የማይፈለግ [ባህሪ](#feature_software) ፡፡
+    def: 'የአንድ ሶፍትዌር ቁራጭ የጠፋ ወይም የማይፈለግ [ባህሪ](#feature_software); የአንድ አረም ዲጂታል አቻ
+      ፡፡ የአንድ አረም ዲጂታል አቻ ; የአንድ ሶፍትዌር ቁራጭ የጠፋ ወይም የማይፈለግ [ባህሪ](#feature_software)
+      ፡፡
+
+      '
   es:
-    term: "bug"
-    def: >
-      Una [carasterística](#feature_software) faltante o indeseada de un software.
+    term: bug
+    def: 'Una [carasterística](#feature_software) faltante o indeseada de un software.
+
+      '
   af:
     term: bug
-    def: >
-      'n Ontbrekende of ongewenste kenmerk van 'n stuk sagteware; die digitale ekwivalent van 'n onkruid.
-  uk:
-    term: "дефект (bug)"
-    def: >-
-      Несправність або помилка, яка призводить до небажаної поведінки програми.
+    def: '''n Ontbrekende of ongewenste kenmerk van ''n stuk sagteware; die digitale
+      ekwivalent van ''n onkruid.
 
+      '
+  uk:
+    term: дефект (bug)
+    def: Несправність або помилка, яка призводить до небажаної поведінки програми.
 - slug: bug_report
   en:
-    term: "bug report"
-    def: >
-      A collection of files, [logs](#log), or related information that describes either an
-      unexpected output of some code or program, or an unexpected error or warning.
-      This information is used to help find and fix a [bug](#bug) in the program or code.
+    term: bug report
+    def: 'A collection of files, [logs](#log), or related information that describes
+      either an unexpected output of some code or program, or an unexpected error
+      or warning. This information is used to help find and fix a [bug](#bug) in the
+      program or code.
+
+      '
   de:
-    term: "Fehlerbericht"
-    def: >
-      Ein Fehlerbericht ist eine Sammlung von Dateien / Einträgen oder damit
-      zusammenhängenden Informationen, die einen unbeabsichtigten Fehler
-      beschreiben. Der Fehlerbericht wird für die Identifikation und Behebung
-      seines des Softwarefehlers / Codefehlers gebraucht.
+    term: Fehlerbericht
+    def: 'Ein Fehlerbericht ist eine Sammlung von Dateien / Einträgen oder damit zusammenhängenden
+      Informationen, die einen unbeabsichtigten Fehler beschreiben. Der Fehlerbericht
+      wird für die Identifikation und Behebung seines des Softwarefehlers / Codefehlers
+      gebraucht.
+
+      '
   am:
     term: የሳንካ ሪፖርት
-    def: >
-      የፋይሎች ስብስብ ፣ [መዝገቦች](#log) ፣ ወይም አንድን የሚገልጽ ተዛማጅ መረጃ የአንዳንድ ኮድ ወይም ፕሮግራም ያልተጠበቀ ውጤት ፣ ወይም ያልተጠበቀ ስህተት ወይም ማስጠንቀቂያ።  ይህ መረጃ በፕሮግራሙ ወይም በኮዱ ውስጥ [ሳንካ](#bug) ፈልጎ እንዲያስተካክል ለማገዝ ይጠቅማል ፡፡ የአንዳንድ ኮድ ወይም ፕሮግራም ያልተጠበቀ ውጤት ፣ ወይም ያልተጠበቀ ስህተት ወይም ማስጠንቀቂያ ወይም ተዛማጅ መረጃ የሚገልጽ  የፋይሎች ስብስብ ፣ [መዝገቦች](#log) ።  ይህ መረጃ በፕሮግራሙ ወይም በኮዱ ውስጥ [ሳንካ](#bug) ፈልጎ እንዲያስተካክል ለማገዝ ይጠቅማል ፡፡
+    def: 'የፋይሎች ስብስብ ፣ [መዝገቦች](#log) ፣ ወይም አንድን የሚገልጽ ተዛማጅ መረጃ የአንዳንድ ኮድ ወይም ፕሮግራም
+      ያልተጠበቀ ውጤት ፣ ወይም ያልተጠበቀ ስህተት ወይም ማስጠንቀቂያ።  ይህ መረጃ በፕሮግራሙ ወይም በኮዱ ውስጥ [ሳንካ](#bug)
+      ፈልጎ እንዲያስተካክል ለማገዝ ይጠቅማል ፡፡ የአንዳንድ ኮድ ወይም ፕሮግራም ያልተጠበቀ ውጤት ፣ ወይም ያልተጠበቀ ስህተት
+      ወይም ማስጠንቀቂያ ወይም ተዛማጅ መረጃ የሚገልጽ  የፋይሎች ስብስብ ፣ [መዝገቦች](#log) ።  ይህ መረጃ በፕሮግራሙ
+      ወይም በኮዱ ውስጥ [ሳንካ](#bug) ፈልጎ እንዲያስተካክል ለማገዝ ይጠቅማል ፡፡
+
+      '
   uk:
-    term: "звіт про дефект"
-    def: >
-      Збірка файлів, [журналів](#log) або пов'язаної інформації, яка описує або несподіваний
-      результат роботи коду чи програми, або несподівану помилку чи попередження.
+    term: звіт про дефект
+    def: 'Збірка файлів, [журналів](#log) або пов''язаної інформації, яка описує або
+      несподіваний результат роботи коду чи програми, або несподівану помилку чи попередження.
       Ця інформація використовується для допомоги у виявленні та виправленні [дефектів](#bug)
       у програмі.
-      
+
+      '
 - slug: bug_tracker
   en:
-    term: "bug tracker"
-    def: >
-      A system that tracks and manages [reported bugs](#bug_report) for a software
+    term: bug tracker
+    def: 'A system that tracks and manages [reported bugs](#bug_report) for a software
       program, to make it easier to address and fix the [bugs](#bug).
+
+      '
   am:
     term: ሳንካ መከታተያ
-    def: >
-      "ለሶፍትዌር [ሪፖርት የተደረጉ ስህተቶችን](#bug_report) የሚከታተል እና የሚያስተዳድር ስርዓት ፕሮግራሙን ፣
-      \"ሳንካዎቹን\" [bugs](#bug) ለማስተካከል እና ለማስተካከል ቀላል ለማድረግ። ሪፖርት የተደረጉ ስህተቶችን (#bug_report)
+    def: '"ለሶፍትዌር [ሪፖርት የተደረጉ ስህተቶችን](#bug_report) የሚከታተል እና የሚያስተዳድር ስርዓት ፕሮግራሙን
+      ፣ \"ሳንካዎቹን\" [bugs](#bug) ለማስተካከል እና ለማስተካከል ቀላል ለማድረግ። ሪፖርት የተደረጉ ስህተቶችን (#bug_report)
       ለማስተካከል እና ቀላል ለማድረግ የሶፍትዌር ፕሮግራም የሚከታተል እና የሚያስተዳድር ስርዓት :: \n"
+
+      '
   uk:
-    term: "трекер дефектів"
-    def: >
-      Система для обліку виявлених дефектів у програмному забезпеченні, яка допомагає їх виправленню.
-      
+    term: трекер дефектів
+    def: 'Система для обліку виявлених дефектів у програмному забезпеченні, яка допомагає
+      їх виправленню.
+
+      '
 - slug: build_manager
   ref:
-    - build_rule
-    - dependency
-    - makefile
+  - build_rule
+  - dependency
+  - makefile
   en:
-    term: "build manager"
-    def: >
-      A program that keeps track of how files depend on one another and runs commands
-      to update any files that are out-of-date. Build managers were invented to
-      [compile](#compile) only those parts of programs that had changed, but are now
-      often used to implement workflows in which plots depend on results files, which
-      in turn depend on raw data files or configuration files.
+    term: build manager
+    def: 'A program that keeps track of how files depend on one another and runs commands
+      to update any files that are out-of-date. Build managers were invented to [compile](#compile)
+      only those parts of programs that had changed, but are now often used to implement
+      workflows in which plots depend on results files, which in turn depend on raw
+      data files or configuration files.
+
+      '
   am:
     term: የግንባታ ሥራ አስኪያጅ
-    def: >
-      ፋይሎች እንዴት እርስ በእርስ እንደሚተያዩ የሚከታተል እና ትዕዛዞችን የሚያከናውን ፕሮግራም ጊዜ ያለፈባቸውን ማናቸውንም ፋይሎች ለማዘመን ፡፡ የግንባታ ሥራ አስኪያጆች ተፈለሰፉባቸው እነዚያን የተለወጡ የፕሮግራሞቹን ክፍሎች ብቻ ያጠናቅሩ (ግን ያጠናቅሩ) ፣ ግን አሁን ናቸው ሴራዎች በውጤቶች ፋይሎች ላይ የሚመረኮዙባቸውን የሥራ ፍሰቶች ለመተግበር ብዙ ጊዜ ጥቅም ላይ ይውላሉ በምላሹ በጥሬ መረጃ ፋይሎች ወይም በውቅር ፋይሎች ላይ የተመሠረተ ነው። ጊዜ ያለፈባቸውን ማናቸውንም ፋይሎች ለማዘመን ፋይሎች እንዴት እርስ በእርስ እንደሚተያዩ የሚከታተል እና ትዕዛዞችን የሚያከናውን ፕሮግራም  ፡፡  የግንባታ ሥራ አስኪያጆች ተፈለሰፉባቸው እነዚያን የተለወጡ የፕሮግራሞቹን ክፍሎች ብቻ ያጠናቅሩ (ግን ያጠናቅሩ) ፣ ግን አሁን ናቸው ሴራዎች በውጤቶች ፋይሎች ላይ የሚመረኮዙባቸውን የሥራ ፍሰቶች ለመተግበር ብዙ ጊዜ ጥቅም ላይ ይውላሉ በምላሹ በጥሬ መረጃ ፋይሎች ወይም በውቅር ፋይሎች ላይ የተመሠረተ ነው።
-  uk:
-    term: "менеджер збірок"
-    def: >
-      Програма, яка відстежує залежність файлів один від одного та виконує
-      дії лише з тими файлами, які змінилися після попереднього виклику програми.
-      Менеджери збірок були винайдені для [компіляції](#compile) лише тих частин
-      програм, які змінилися, але зараз часто використовуються для автоматизації
-      процесів обробки даних, у яких графіки залежать від файлів результатів, які,
-      у свою чергу, залежать від файлів з вихідними даними або файлів конфігурації.
+    def: 'ፋይሎች እንዴት እርስ በእርስ እንደሚተያዩ የሚከታተል እና ትዕዛዞችን የሚያከናውን ፕሮግራም ጊዜ ያለፈባቸውን ማናቸውንም
+      ፋይሎች ለማዘመን ፡፡ የግንባታ ሥራ አስኪያጆች ተፈለሰፉባቸው እነዚያን የተለወጡ የፕሮግራሞቹን ክፍሎች ብቻ ያጠናቅሩ (ግን
+      ያጠናቅሩ) ፣ ግን አሁን ናቸው ሴራዎች በውጤቶች ፋይሎች ላይ የሚመረኮዙባቸውን የሥራ ፍሰቶች ለመተግበር ብዙ ጊዜ ጥቅም
+      ላይ ይውላሉ በምላሹ በጥሬ መረጃ ፋይሎች ወይም በውቅር ፋይሎች ላይ የተመሠረተ ነው። ጊዜ ያለፈባቸውን ማናቸውንም ፋይሎች
+      ለማዘመን ፋይሎች እንዴት እርስ በእርስ እንደሚተያዩ የሚከታተል እና ትዕዛዞችን የሚያከናውን ፕሮግራም  ፡፡  የግንባታ ሥራ
+      አስኪያጆች ተፈለሰፉባቸው እነዚያን የተለወጡ የፕሮግራሞቹን ክፍሎች ብቻ ያጠናቅሩ (ግን ያጠናቅሩ) ፣ ግን አሁን ናቸው ሴራዎች
+      በውጤቶች ፋይሎች ላይ የሚመረኮዙባቸውን የሥራ ፍሰቶች ለመተግበር ብዙ ጊዜ ጥቅም ላይ ይውላሉ በምላሹ በጥሬ መረጃ ፋይሎች
+      ወይም በውቅር ፋይሎች ላይ የተመሠረተ ነው።
 
+      '
+  uk:
+    term: менеджер збірок
+    def: 'Програма, яка відстежує залежність файлів один від одного та виконує дії
+      лише з тими файлами, які змінилися після попереднього виклику програми. Менеджери
+      збірок були винайдені для [компіляції](#compile) лише тих частин програм, які
+      змінилися, але зараз часто використовуються для автоматизації процесів обробки
+      даних, у яких графіки залежать від файлів результатів, які, у свою чергу, залежать
+      від файлів з вихідними даними або файлів конфігурації.
+
+      '
 - slug: build_recipe
   en:
-    term: "build recipe"
-    def: >
-      The part of a [build rule](#build_rule) that describes how to update something
+    term: build recipe
+    def: 'The part of a [build rule](#build_rule) that describes how to update something
       that has fallen out-of-date.
+
+      '
   am:
     term: ግንባታ የምግብ አሰራር
-    def: >
-      አንድን ነገር እንዴት ማዘመን እንደሚቻል የሚገልጽ የ [የግንባታ ደንብ](#build_rule) ክፍል ጊዜው ያለፈበት ነው ፡፡ ክፍል ጊዜው ያለፈበትን አንድን ነገር እንዴት ማዘመን እንደሚቻል የሚገልጽ የ [የግንባታ ደንብ](#build_rule)  ነው ፡፡
+    def: 'አንድን ነገር እንዴት ማዘመን እንደሚቻል የሚገልጽ የ [የግንባታ ደንብ](#build_rule) ክፍል ጊዜው ያለፈበት
+      ነው ፡፡ ክፍል ጊዜው ያለፈበትን አንድን ነገር እንዴት ማዘመን እንደሚቻል የሚገልጽ የ [የግንባታ ደንብ](#build_rule)  ነው
+      ፡፡
 
+      '
 - slug: build_rule
   en:
-    term: "build rule"
-    def: >
-      A specification for a [build manager](#build_manager) that describes how some
-      files depend on others and what to do if those files are out-of-date.
+    term: build rule
+    def: 'A specification for a [build manager](#build_manager) that describes how
+      some files depend on others and what to do if those files are out-of-date.
+
+      '
   am:
     term: ደንብ ይገንቡ
-    def: >
-      የተወሰኑትን እንዴት እንደሚገልፅ ለ [የግንባታ ሥራ አስኪያጅ](#build_manager) ዝርዝር ፋይሎች በሌሎች ላይ ይወሰናሉ እና እነዚያ ፋይሎች ጊዜው ያለፈባቸው ከሆኑ ምን ማድረግ እንዳለባቸው ፡፡ የተወሰኑትን ፋይሎች በሌሎች ላይ ይወሰናሉ  እና እነዚያ ፋይሎች ጊዜው ያለፈባቸው ከሆኑ ምን ማድረግ እንዳለባቸው የሚገልፅ [የግንባታ ሥራ አስኪያጅ](#build_manager) ዝርዝር ነዉ ::
-  uk:
-    term: "правило збірки"
-    def: >
-      Інструкція для [менеджера збірок](#build_manager), яка описує як деякі
-      файли залежать від інших, та що робити, якщо вони застаріли.
+    def: 'የተወሰኑትን እንዴት እንደሚገልፅ ለ [የግንባታ ሥራ አስኪያጅ](#build_manager) ዝርዝር ፋይሎች በሌሎች ላይ
+      ይወሰናሉ እና እነዚያ ፋይሎች ጊዜው ያለፈባቸው ከሆኑ ምን ማድረግ እንዳለባቸው ፡፡ የተወሰኑትን ፋይሎች በሌሎች ላይ ይወሰናሉ  እና
+      እነዚያ ፋይሎች ጊዜው ያለፈባቸው ከሆኑ ምን ማድረግ እንዳለባቸው የሚገልፅ [የግንባታ ሥራ አስኪያጅ](#build_manager)
+      ዝርዝር ነዉ ::
 
+      '
+  uk:
+    term: правило збірки
+    def: 'Інструкція для [менеджера збірок](#build_manager), яка описує як деякі файли
+      залежать від інших, та що робити, якщо вони застаріли.
+
+      '
 - slug: build_stale
   en:
-    term: "stale (in build)"
-    def: >
-      To be out-of-date compared to a [prerequisite](#prerequisite). A [build
-      manager](#build_manager)'s job is to find and update things that are stale.
+    term: stale (in build)
+    def: 'To be out-of-date compared to a [prerequisite](#prerequisite). A [build
+      manager](#build_manager)''s job is to find and update things that are stale.
+
+      '
   am:
     term: የቆየ (በግንባታ ላይ)
-    def: >
-      ከ [ቅድመ ሁኔታ](#prerequisite) ጋር ሲነፃፀር ጊዜው ያለፈበት መሆን። አንድ [ግንባታ አስተዳዳሪ](#build_manager) ሥራ የቆዩ ነገሮችን ፈልጎ ማዘመን ነው ፡፡
+    def: 'ከ [ቅድመ ሁኔታ](#prerequisite) ጋር ሲነፃፀር ጊዜው ያለፈበት መሆን። አንድ [ግንባታ አስተዳዳሪ](#build_manager)
+      ሥራ የቆዩ ነገሮችን ፈልጎ ማዘመን ነው ፡፡
 
+      '
 - slug: build_target
   ref:
-    - makefile
-    - default_target
+  - makefile
+  - default_target
   en:
-    term: "build target"
-    def: >
-      The file(s) that a [build rule](#build_rule) will update if they are out-of-date
+    term: build target
+    def: 'The file(s) that a [build rule](#build_rule) will update if they are out-of-date
       compared to their [dependencies](#dependency).
+
+      '
   am:
     term: ግንባታ ዒላ ግንባታ ዒላማ
-    def: >
-      ጊዜው ያለፈባቸው ከሆኑ [የግንባታ ደንብ](#build_rule) የሚዘመኑ ፋይሎች (ሎች) ከእነሱ [ጥገኞች] ጋር ሲነፃፀር[dependencies](#dependency)።
-  uk:
-    term: "мета (у менеджері збірок)"
-    def: >
-      Один чи декілька файлів, які будуть оновлені у відповідності із
-      [правилом збірки](#build_rule), якщо вони старіші ніж їх [залежності](#dependency).
+    def: 'ጊዜው ያለፈባቸው ከሆኑ [የግንባታ ደንብ](#build_rule) የሚዘመኑ ፋይሎች (ሎች) ከእነሱ [ጥገኞች] ጋር ሲነፃፀር[dependencies](#dependency)።
 
+      '
+  uk:
+    term: мета (у менеджері збірок)
+    def: 'Один чи декілька файлів, які будуть оновлені у відповідності із [правилом
+      збірки](#build_rule), якщо вони старіші ніж їх [залежності](#dependency).
+
+      '
 - slug: byte
   en:
-    term: "byte"
-    def: >
-      A unit of digital information that typically consists of eight [binary](#binary) digits, or [bits](#bit).
-  es:
-    term: "byte"
-    def: >
-      Unidad de información digital que típicamente consiste de ocho dígitos [binarios](#binary), o [bits](#bit).
-  fr:
-    term: "octet"
-    def: >
-      Un octet est une information numerique composée de huit chiffres binaires, appelés bits.
-  de:
-    term: "Byte"
-    def: >
-      Ein Byte ist eine digitale Einheit, die aus acht Binärziffern oder Bits
-      besteht.
-  tn:
-    term: "Selekanyetso_ kitso ya boranyane"
-    def: >
-      Selekanyetso sa kitso ya boranyane se se agiwang ka kitso ya dipalo tse di ferang bobedi.
-  uk:
-    term: "байт"
-    def: >-
-      Одиниця цифрової інформації, яка зазвичай складається з восьми [двійкових](#binary) цифр, або [бітів](#bit).
+    term: byte
+    def: 'A unit of digital information that typically consists of eight [binary](#binary)
+      digits, or [bits](#bit).
 
+      '
+  es:
+    term: byte
+    def: 'Unidad de información digital que típicamente consiste de ocho dígitos [binarios](#binary),
+      o [bits](#bit).
+
+      '
+  fr:
+    term: octet
+    def: 'Un octet est une information numerique composée de huit chiffres binaires,
+      appelés bits.
+
+      '
+  de:
+    term: Byte
+    def: 'Ein Byte ist eine digitale Einheit, die aus acht Binärziffern oder Bits
+      besteht.
+
+      '
+  tn:
+    term: Selekanyetso_ kitso ya boranyane
+    def: 'Selekanyetso sa kitso ya boranyane se se agiwang ka kitso ya dipalo tse
+      di ferang bobedi.
+
+      '
+  uk:
+    term: байт
+    def: Одиниця цифрової інформації, яка зазвичай складається з восьми [двійкових](#binary)
+      цифр, або [бітів](#bit).
 - slug: byte_code
   en:
-    term: "byte code"
-    def: >
-      A set of instructions designed to be executed efficiently by an [interpreter](#interpreter).
+    term: byte code
+    def: 'A set of instructions designed to be executed efficiently by an [interpreter](#interpreter).
+
+      '
   tn:
-    term: "Setlhopha sa melawana"
-    def: >
-      Melawana e e kaetsweng ka sekao e le mo setlhopheng go ka ntshiwa ke moranodi ka tolamo.
+    term: Setlhopha sa melawana
+    def: 'Melawana e e kaetsweng ka sekao e le mo setlhopheng go ka ntshiwa ke moranodi
+      ka tolamo.
+
+      '
   am:
     term: ባይት ኮድ
-    def: >
-      በ [አስተርጓሚ](#interpreter) በብቃት ለመፈፀም የታቀዱ መመሪያዎች ስብስብ።
+    def: 'በ [አስተርጓሚ](#interpreter) በብቃት ለመፈፀም የታቀዱ መመሪያዎች ስብስብ።
 
+      '
 - slug: cache
   en:
-    term: "cache"
-    def: >
-      Something that stores copies of data so that future requests for it can be
-      satisfied more quickly. The CPU in a computer uses a hardware cache to hold
-      recently-accessed values; many programs rely on a software cache to reduce
-      network traffic and latency. Figuring out when something in a cache is out-of-date
-      and should be replaced is one of the [two hard problems in computer science](#two_hard_problems).
+    term: cache
+    def: 'Something that stores copies of data so that future requests for it can
+      be satisfied more quickly. The CPU in a computer uses a hardware cache to hold
+      recently-accessed values; many programs rely on a software cache to reduce network
+      traffic and latency. Figuring out when something in a cache is out-of-date and
+      should be replaced is one of the [two hard problems in computer science](#two_hard_problems).
 
+      '
   am:
     term: መሸጎጫ
-    def: >
-      ለወደፊቱ የሚጠየቁ ጥያቄዎች በበለጠ ፍጥነት እንዲረካ  የውሂብ ቅጅዎችን የሚያከማች ነገር :: በኮምፒተር ውስጥ ያለው ሲፒዩ ለመያዝ የሃርድዌር መሸጎጫ ይጠቀማል በቅርብ ጊዜ የተደረሱ እሴቶች; ብዙ ፕሮግራሞች ለመቀነስ በሶፍትዌር መሸጎጫ ላይ ይተማመናሉ የኔትወርክ ትራፊክ እና መዘግየት። በመሸጎጫ ውስጥ አንድ ነገር ጊዜው ያለፈበት መሆኑን ማወቅ መተካት ያለበት ከ [በኮምፒተር ሳይንስ ውስጥ ሁለት ከባድ ችግሮች] አንዱ ነው (#two_hard_problems) ፡፡
-  de:
-    term: "Cache"
-    def: >
-      Cache ist ein Pufferspeicher, der (wiederholte) Datenzugriffe und -berechnungen
-      zu vermeiden hilft. Im Cache abgelegte Daten können schneller abgerufen werden.
-      Ein Hardware-Cache wird beispielsweise in Computerprozessoren verwendet und ein
-      Beispiel für einen Software-Cache ist der [Browser-Cache](#browser_cache).
-  es:
-    term: "cache"
-    def: >
-      Algo que guarda copias de datos para que futuras consultas puedan ser respondidas más rápido.
-      El CPU de una computadora usa un cache de hardware para guardar valores recientemente accedidos;
-      muchos programas dependen de un cache de software para disminuir el tráfico y latencia de red.
-      Averiguar cuando algo en cache se ha vuelto anticuado y debe ser reemplazado es uno de los [dos problemas difíciles de la ciencia de computación](#two_hard_problems).
-  uk:
-    term: "кеш"
-    def: >
-      Програмний або апаратний механізм, що зберігає копії даних, щоб майбутні запити до них могли бути виконані швидше.
-      Центральний процесор в комп'ютері використовує апаратний кеш для зберігання
-      нещодавно доступних значень; багато програм використовують програмний кеш для зменшення мережевого
-      трафіку та затримок. Перевірка того, чи містить кеш застарілі дані, які потрібно оновити, є однією з
-      [двох найскладніших проблем в інформатиці](#two_hard_problems).
+    def: 'ለወደፊቱ የሚጠየቁ ጥያቄዎች በበለጠ ፍጥነት እንዲረካ  የውሂብ ቅጅዎችን የሚያከማች ነገር :: በኮምፒተር ውስጥ ያለው
+      ሲፒዩ ለመያዝ የሃርድዌር መሸጎጫ ይጠቀማል በቅርብ ጊዜ የተደረሱ እሴቶች; ብዙ ፕሮግራሞች ለመቀነስ በሶፍትዌር መሸጎጫ ላይ
+      ይተማመናሉ የኔትወርክ ትራፊክ እና መዘግየት። በመሸጎጫ ውስጥ አንድ ነገር ጊዜው ያለፈበት መሆኑን ማወቅ መተካት ያለበት
+      ከ [በኮምፒተር ሳይንስ ውስጥ ሁለት ከባድ ችግሮች] አንዱ ነው (#two_hard_problems) ፡፡
 
+      '
+  de:
+    term: Cache
+    def: 'Cache ist ein Pufferspeicher, der (wiederholte) Datenzugriffe und -berechnungen
+      zu vermeiden hilft. Im Cache abgelegte Daten können schneller abgerufen werden.
+      Ein Hardware-Cache wird beispielsweise in Computerprozessoren verwendet und
+      ein Beispiel für einen Software-Cache ist der [Browser-Cache](#browser_cache).
+
+      '
+  es:
+    term: cache
+    def: 'Algo que guarda copias de datos para que futuras consultas puedan ser respondidas
+      más rápido. El CPU de una computadora usa un cache de hardware para guardar
+      valores recientemente accedidos; muchos programas dependen de un cache de software
+      para disminuir el tráfico y latencia de red. Averiguar cuando algo en cache
+      se ha vuelto anticuado y debe ser reemplazado es uno de los [dos problemas difíciles
+      de la ciencia de computación](#two_hard_problems).
+
+      '
+  uk:
+    term: кеш
+    def: 'Програмний або апаратний механізм, що зберігає копії даних, щоб майбутні
+      запити до них могли бути виконані швидше. Центральний процесор в комп''ютері
+      використовує апаратний кеш для зберігання нещодавно доступних значень; багато
+      програм використовують програмний кеш для зменшення мережевого трафіку та затримок.
+      Перевірка того, чи містить кеш застарілі дані, які потрібно оновити, є однією
+      з [двох найскладніших проблем в інформатиці](#two_hard_problems).
+
+      '
 - slug: caching
   en:
-    term: "caching"
-    def: >
-      To save a copy of some data in a local [cache](#cache) to make future access faster.
-  es:
-    term: "caching"
-    def: >
-      Guardar una copia de algún dato en el [caché](#cache) local para hacer su acceso futuro más rápido.
-  uk:
-    term: "кешування"
-    def: >
-      Зберігання копії деяких даних у локальному [кеші](#cache), щоб прискорити майбутній доступ.
+    term: caching
+    def: 'To save a copy of some data in a local [cache](#cache) to make future access
+      faster.
 
+      '
+  es:
+    term: caching
+    def: 'Guardar una copia de algún dato en el [caché](#cache) local para hacer su
+      acceso futuro más rápido.
+
+      '
+  uk:
+    term: кешування
+    def: 'Зберігання копії деяких даних у локальному [кеші](#cache), щоб прискорити
+      майбутній доступ.
+
+      '
 - slug: call_stack
   en:
-    term: "call stack"
-    def: >
-      A data structure that stores information about the subroutines currently being executed.
+    term: call stack
+    def: 'A data structure that stores information about the subroutines currently
+      being executed.
+
+      '
   id:
-    term: "call stack"
-    def: >
-      Sebuah struktur data yang berguna untuk menyimpan informasi mengenai subrutin aktif yang sedang dijalankan.
+    term: call stack
+    def: 'Sebuah struktur data yang berguna untuk menyimpan informasi mengenai subrutin
+      aktif yang sedang dijalankan.
+
+      '
   fr:
-    term: "pile d'exécution"
-    def: >
-      aussi appelée pile d'appels, il s'agit d'une structure de données qui enregistre des informations sur les sous-routines qui sont actuellement exécutées. 
+    term: pile d'exécution
+    def: "aussi appelée pile d'appels, il s'agit d'une structure de données qui enregistre\
+      \ des informations sur les sous-routines qui sont actuellement exécutées. \n"
   am:
     term: የጥሪ ቁልል
     def: "የተተገበሩ  ንቁ ንዑስ አንቀጾች መረጃን የሚያከማች የውሂብ መዋቅር ።\t\n"
   uk:
-    term: "стек викликів"
-    def: >
-      Структура даних, яка зберігає інформацію про підпрограми, що виконуються в даний момент, 
-      включаючи параметри, локальні змінні та інструкції повернення.
+    term: стек викликів
+    def: 'Структура даних, яка зберігає інформацію про підпрограми, що виконуються
+      в даний момент,  включаючи параметри, локальні змінні та інструкції повернення.
 
+      '
 - slug: callback
   en:
-    term: "callback function"
-    def: >
-      A function A that is passed to another function B so that B can call it at some
-      later point. Callbacks can be used [synchronously](#synchronous), as in generic
-      functions like `map` that invoke a callback function once for each element in a
-      collection, or [asynchronously](#asynchronous), as in a [client](#client) that
-      runs a callback when a [response](#http_response) is received in answer to a [request](#http_request).
-  de:
-    term: "Rückruffunktion"
-    def: >
-      Rückruffunktionen sind Funktionen, welche anderen Funktionen als
-      Parameter übergeben werden um sie zu einem späteren Zeitpunkt
-      auszuführen. Bei der Parallelisierung werden häufig durch den Befehl
-      `map` Rückruffunktionen [synchron/gleichzeitig](#synchronous) für mehrere
-      Elemente in einer Kollektion ausgeführt, während bei
-      [Klient](#client)/[Server](#server) Verbindungen auf
-      [Anrufe](#http_request) [asynchron](#asynchronous) eine
-      [Antwort](#http_response) geliefert wird.
+    term: callback function
+    def: 'A function A that is passed to another function B so that B can call it
+      at some later point. Callbacks can be used [synchronously](#synchronous), as
+      in generic functions like `map` that invoke a callback function once for each
+      element in a collection, or [asynchronously](#asynchronous), as in a [client](#client)
+      that runs a callback when a [response](#http_response) is received in answer
+      to a [request](#http_request).
 
+      '
+  de:
+    term: Rückruffunktion
+    def: 'Rückruffunktionen sind Funktionen, welche anderen Funktionen als Parameter
+      übergeben werden um sie zu einem späteren Zeitpunkt auszuführen. Bei der Parallelisierung
+      werden häufig durch den Befehl `map` Rückruffunktionen [synchron/gleichzeitig](#synchronous)
+      für mehrere Elemente in einer Kollektion ausgeführt, während bei [Klient](#client)/[Server](#server)
+      Verbindungen auf [Anrufe](#http_request) [asynchron](#asynchronous) eine [Antwort](#http_response)
+      geliefert wird.
+
+      '
   am:
     term: የመልሶ መደወያ ተግባር
-    def: >
-      ተግባር ሀ ወደ ሌላ ተግባር ለ እንዲተላለፍ ስለዚህ ተግባር ለን ተመሳሳይ ነዉ ይሉታል ።  እንደ ጀነሬክ ሁሉ ኮልባክ [synchronously](#synchronous) መጠቀም ይቻላል እንደ 'ካርታ' ያሉ ተግባሮች ለእያንዳንዱ ንጥረ ነገር አንድ ጊዜ የጥሪ ተግባራትን የሚሰሩ ናቸው ስብስብ, ወይም [asynchronously](#asynchronous), ልክ እንደ [ደንበኛ](#client) አንድ [ምላሽ] (#http_response) ለአንድ [ጥያቄ](#http_request) መልስ ሲደርሰው ጥሪውን ያካሄዳሉ።
+    def: 'ተግባር ሀ ወደ ሌላ ተግባር ለ እንዲተላለፍ ስለዚህ ተግባር ለን ተመሳሳይ ነዉ ይሉታል ።  እንደ ጀነሬክ ሁሉ ኮልባክ
+      [synchronously](#synchronous) መጠቀም ይቻላል እንደ ''ካርታ'' ያሉ ተግባሮች ለእያንዳንዱ ንጥረ ነገር
+      አንድ ጊዜ የጥሪ ተግባራትን የሚሰሩ ናቸው ስብስብ, ወይም [asynchronously](#asynchronous), ልክ እንደ
+      [ደንበኛ](#client) አንድ [ምላሽ] (#http_response) ለአንድ [ጥያቄ](#http_request) መልስ ሲደርሰው
+      ጥሪውን ያካሄዳሉ።
 
+      '
 - slug: camel_case
   ref:
-    - kebab_case
-    - pothole_case
+  - kebab_case
+  - pothole_case
   en:
-    term: "camel case"
-    def: >
-      A style of writing code that involves naming variables and objects with no
-      space, underscore (`_`), dot (`.`), or dash (`-`) characters, with each word being
-      capitalized. Examples include `CalculateSum` and `findPattern`.
+    term: camel case
+    def: 'A style of writing code that involves naming variables and objects with
+      no space, underscore (`_`), dot (`.`), or dash (`-`) characters, with each word
+      being capitalized. Examples include `CalculateSum` and `findPattern`.
+
+      '
   af:
     term: Kameelgeval
-    def: >
-      Die styl van kodeskryf wat behels dat veranderlikes en objekte benoem word sonder spasies, 
-      onderstreep (_) punte (.), of strepies (-) karakters, met elke woord wat gekapitaliseer word. 
-      Voorbeelde hiervan sluit in BerekenSom en VindPatroon.    
+    def: "Die styl van kodeskryf wat behels dat veranderlikes en objekte benoem word\
+      \ sonder spasies,  onderstreep (_) punte (.), of strepies (-) karakters, met\
+      \ elke woord wat gekapitaliseer word.  Voorbeelde hiervan sluit in BerekenSom\
+      \ en VindPatroon.    \n"
   de:
-    term: "camel case (dt. Kamel-Schreibung)"
-    def: >
-      Schreibstil der die Benennung von Variablen und Objekten vorgibt. Bei
-      "camel case" werden keine Leerzeichen, Unterstriche (`_`), Punkte (`.`)
-      oder Bindestriche (`-`) verwandt und jedes Wort großgeschrieben.
-      Beispiele sind: `BerechneSumme` oder `findeMuster`.
-  tn:
-    term: "Mokwalo wa Kamela"
-    def: >
-      Ke mokgwa wa go kwala dikaelo tsa khomputara ka go sa tsenye matshwao a sekgala (space),
-      thalela (`_`), khutlo (`.`) kana thaladi (`-`) mo maineng a maemedi a boleng jo bo fetogang (variables) kana a dilo (objects).
-      Mo godimo ga moo, lefoko lengwe le lengwe mo maineng a le simolola ka tlhakakgolo.
-      Dikai tsa mokwalo o ke `CalculateSum` le `findPattern`.
-  uk:
-    term: "верблюдячий регістр (camel case)"
-    def: >
-      Стиль написання коду, який передбачає іменування змінних та об'єктів без пробілів, 
-      символів підкреслення (`_`), крапки (`.`) або тире (`-`). Кожне слово пишеться з великої літери.
-      Перше слово може писатися з маленької літери. Наприклад: `CalculateSum`, `findPattern`.
+    term: camel case (dt. Kamel-Schreibung)
+    def: 'Schreibstil der die Benennung von Variablen und Objekten vorgibt. Bei "camel
+      case" werden keine Leerzeichen, Unterstriche (`_`), Punkte (`.`) oder Bindestriche
+      (`-`) verwandt und jedes Wort großgeschrieben. Beispiele sind: `BerechneSumme`
+      oder `findeMuster`.
 
+      '
+  tn:
+    term: Mokwalo wa Kamela
+    def: 'Ke mokgwa wa go kwala dikaelo tsa khomputara ka go sa tsenye matshwao a
+      sekgala (space), thalela (`_`), khutlo (`.`) kana thaladi (`-`) mo maineng a
+      maemedi a boleng jo bo fetogang (variables) kana a dilo (objects). Mo godimo
+      ga moo, lefoko lengwe le lengwe mo maineng a le simolola ka tlhakakgolo. Dikai
+      tsa mokwalo o ke `CalculateSum` le `findPattern`.
+
+      '
+  uk:
+    term: верблюдячий регістр (camel case)
+    def: 'Стиль написання коду, який передбачає іменування змінних та об''єктів без
+      пробілів,  символів підкреслення (`_`), крапки (`.`) або тире (`-`). Кожне слово
+      пишеться з великої літери. Перше слово може писатися з маленької літери. Наприклад:
+      `CalculateSum`, `findPattern`.
+
+      '
 - slug: catch_exception
   ref:
-    - condition
-    - handle_condition
+  - condition
+  - handle_condition
   en:
-    term: "catch (an exception)"
-    def: >
-      To accept responsibility for handling an error or other unexpected event. [R](#r_language)
-      prefers "handling a condition" to "catching an exception." [Python](#python), on the other hand,
-      encourages raising and catching exceptions, and in some situations, requires it.
-  ar:
-    term: "إستثناء"
-    def: >
-      الإستثناء هو الشرط الخاص الذي يُعالج به الشذوذ أو الشيء الغير متوقع الذي حدث
-      أثناء تنفيذ البرنامج.
-  de:
-    term: "abfangen (eines Fehlers)"
-    def: >
-      Möglichkeit einen Fehler oder andere unerwartete Ereignisse abzufangen
-      und Informationen darüber zu verarbeiten. In [R](#r_language) sollen
-      Fehler möglichst über vordefinierte Bedingungen abgefangen werden,
-      während in anderen Sprachen, z.B. in [Python](#python) Fehler und
-      Fehlermeldungen bewusst eingesetzt werden um Probleme einfacher zu lösen.
-      Häufig werden neben der Art des Fehlers auch weitere Daten erhoben um
-      mögliche Ursachen zu finden.
+    term: catch (an exception)
+    def: 'To accept responsibility for handling an error or other unexpected event.
+      [R](#r_language) prefers "handling a condition" to "catching an exception."
+      [Python](#python), on the other hand, encourages raising and catching exceptions,
+      and in some situations, requires it.
 
+      '
+  ar:
+    term: إستثناء
+    def: 'الإستثناء هو الشرط الخاص الذي يُعالج به الشذوذ أو الشيء الغير متوقع الذي
+      حدث أثناء تنفيذ البرنامج.
+
+      '
+  de:
+    term: abfangen (eines Fehlers)
+    def: 'Möglichkeit einen Fehler oder andere unerwartete Ereignisse abzufangen und
+      Informationen darüber zu verarbeiten. In [R](#r_language) sollen Fehler möglichst
+      über vordefinierte Bedingungen abgefangen werden, während in anderen Sprachen,
+      z.B. in [Python](#python) Fehler und Fehlermeldungen bewusst eingesetzt werden
+      um Probleme einfacher zu lösen. Häufig werden neben der Art des Fehlers auch
+      weitere Daten erhoben um mögliche Ursachen zu finden.
+
+      '
   am:
     term: ማጥመድ (ለየት ያለ)
-    def: >
-      አንድን ስህተት ወይም ሌላ ያልተጠበቀ ክስተት የመፍታት ኃላፊነትን መቀበል። [R](#r_language)"ለየት ያለ ነገር ከመያዝ"ይልቅ"ሁኔታን መያዝ"ይመርጣል። [Python](#python) በሌላ በኩል፣ ለየት ያሉ ሁኔታዎችን ማሳደግና መያዝን ያበረታታል ፤ በአንዳንድ ሁኔታዎች ደግሞ ይህን ማድረግ ያስፈልጋል ።
+    def: 'አንድን ስህተት ወይም ሌላ ያልተጠበቀ ክስተት የመፍታት ኃላፊነትን መቀበል። [R](#r_language)"ለየት ያለ
+      ነገር ከመያዝ"ይልቅ"ሁኔታን መያዝ"ይመርጣል። [Python](#python) በሌላ በኩል፣ ለየት ያሉ ሁኔታዎችን ማሳደግና
+      መያዝን ያበረታታል ፤ በአንዳንድ ሁኔታዎች ደግሞ ይህን ማድረግ ያስፈልጋል ።
+
+      '
   uk:
-    term: "перехопити (помилку)"
-    def: >
-      Можливість перехопити помилку або інші несподівані події та обробити інформацію про них. 
-      У R рекомендується обробляти помилки за допомогою попередньо визначених умов, тоді
-      як в інших мовах, таких як Python, помилки та повідомлення про них використовуються
-      свідомо для спрощення вирішення проблем. Часто, крім типу помилки, збираються також
-      додаткові дані для визначення можливих причин.
-    
+    term: перехопити (помилку)
+    def: 'Можливість перехопити помилку або інші несподівані події та обробити інформацію
+      про них.  У R рекомендується обробляти помилки за допомогою попередньо визначених
+      умов, тоді як в інших мовах, таких як Python, помилки та повідомлення про них
+      використовуються свідомо для спрощення вирішення проблем. Часто, крім типу помилки,
+      збираються також додаткові дані для визначення можливих причин.
+
+      '
 - slug: causation
   en:
-    term: "causation"
-    def: >
-      A relationship between distinct events, where it is asserted that one event is responsible for
-      producing or affecting change in the other.
- 
+    term: causation
+    def: 'A relationship between distinct events, where it is asserted that one event
+      is responsible for producing or affecting change in the other.
+
+      '
   fr:
-    term: "causalité"
-    def: >
-      Une relation entre des événements distincts, où il est affirmé qu'un événement est responsable de
-      produire ou d'affecter un changement dans l'autre.
+    term: causalité
+    def: 'Une relation entre des événements distincts, où il est affirmé qu''un événement
+      est responsable de produire ou d''affecter un changement dans l''autre.
+
+      '
   de:
-    term: "Kausalität"
-    def: >
-      Eine Beziehung zwischen zwei Ereignissen oder Zuständen, wobei klar ist,
-      dass es einen ursächlichen oder anlässlichen Zusammenhang zwischen den beiden gibt.
+    term: Kausalität
+    def: 'Eine Beziehung zwischen zwei Ereignissen oder Zuständen, wobei klar ist,
+      dass es einen ursächlichen oder anlässlichen Zusammenhang zwischen den beiden
+      gibt.
+
+      '
   sw:
-    term: "Kusababisha"
-    def: >
-      Uhusiano kati ya matukio tofauti, ambapo inadaiwa kuwa tukio moja linawajibika
+    term: Kusababisha
+    def: 'Uhusiano kati ya matukio tofauti, ambapo inadaiwa kuwa tukio moja linawajibika
       kuzalisha au kuathiri mabadiliko katika nyingine.
 
+      '
   am:
     term: causation
-    def: >
-      አንድ ክስተት ተጠያቂ ነው ተብሎ በሚነገርበት በልዩ ልዩ ክስተቶች መካከል ያለው ግንኙነት በሌላው ላይ ለውጥ መፍጠር ወይም ተፅዕኖ ማሳደር።
-  uk:
-    term: "причинно-наслідковий зв'язок"
-    def: >
-      Взаємозв’язок між окремими подіями, за якого одна подія розглядається як причина, що зумовлює 
-      виникнення, зміну чи наслідки іншої події.
+    def: 'አንድ ክስተት ተጠያቂ ነው ተብሎ በሚነገርበት በልዩ ልዩ ክስተቶች መካከል ያለው ግንኙነት በሌላው ላይ ለውጥ መፍጠር
+      ወይም ተፅዕኖ ማሳደር።
 
+      '
+  uk:
+    term: причинно-наслідковий зв'язок
+    def: 'Взаємозв’язок між окремими подіями, за якого одна подія розглядається як
+      причина, що зумовлює  виникнення, зміну чи наслідки іншої події.
+
+      '
 - slug: cc_0
   en:
-    term: "CC-0"
-    def: >
-      A [Creative Commons](#cc_license) [license](#license) waiver that imposes no
-      restrictions whatsover, thereby putting a work in the public domain.
+    term: CC-0
+    def: 'A [Creative Commons](#cc_license) [license](#license) waiver that imposes
+      no restrictions whatsover, thereby putting a work in the public domain.
+
+      '
   pt:
-    term: "CC-0"
-    def: >
-      Uma [licença](#license) [Creative Commons](#cc_license) que não impõe
-      qualquer tipo de restrição, consequentemente colocando o trabalho em domínio público.
+    term: CC-0
+    def: 'Uma [licença](#license) [Creative Commons](#cc_license) que não impõe qualquer
+      tipo de restrição, consequentemente colocando o trabalho em domínio público.
+
+      '
   es:
-    term: "CC-0"
-    def: >
-      Una [licencia](#license) de [Creative Commons](#cc_license) que no impone ninguna
-      restricción, por lo que pone a la obra en dominio público.
+    term: CC-0
+    def: 'Una [licencia](#license) de [Creative Commons](#cc_license) que no impone
+      ninguna restricción, por lo que pone a la obra en dominio público.
+
+      '
   de:
-    term: "CC-0"
-    def: >
-      Eine [Creative-Commons](#cc_license) [Lizenz](#license) welche den
-      Verzicht auf sämtliche Schutzrechte erklärt und das Werk in die
-      Gemeinfreiheit überführt.
+    term: CC-0
+    def: 'Eine [Creative-Commons](#cc_license) [Lizenz](#license) welche den Verzicht
+      auf sämtliche Schutzrechte erklärt und das Werk in die Gemeinfreiheit überführt.
+
+      '
   uk:
-    term: "CC-0"
-    def: >
-      Різновид ліцензії [Creative Commons](#cc_license), який дозволяє
-      автору добровільно відмовитися від усіх авторських прав на
-      свій твір і передати його у суспільне надбання без жодних умов чи обмежень.
+    term: CC-0
+    def: 'Різновид ліцензії [Creative Commons](#cc_license), який дозволяє автору
+      добровільно відмовитися від усіх авторських прав на свій твір і передати його
+      у суспільне надбання без жодних умов чи обмежень.
+
+      '
   am:
     term: ሲሲ-0
-    def: >
-      [Creative Commons](#cc_license)ምንም የማይጥል ፍቃድ] ይህ ደግሞ በሕዝብ ክልል ውስጥ ሥራ እንዲከናውን ያደርጋል ።
+    def: '[Creative Commons](#cc_license)ምንም የማይጥል ፍቃድ] ይህ ደግሞ በሕዝብ ክልል ውስጥ ሥራ እንዲከናውን
+      ያደርጋል ።
 
+      '
 - slug: cc_by
   en:
-    term: "CC-BY"
-    def: >
-      The [Creative Commons](#cc_license) - Attribution [license](#license), which
-      requires people to give credit to the author of a work, but imposes no other restrictions.
+    term: CC-BY
+    def: 'The [Creative Commons](#cc_license) - Attribution [license](#license), which
+      requires people to give credit to the author of a work, but imposes no other
+      restrictions.
+
+      '
   pt:
-    term: "CC-BY"
-    def: >
-      Uma [licença](#license) [Creative Commons](#cc_license) com Atribuição, que requer que
-      seja dado crédito às pessoas autoras do trabalho, mas que não impõe outras restrições.
+    term: CC-BY
+    def: 'Uma [licença](#license) [Creative Commons](#cc_license) com Atribuição,
+      que requer que seja dado crédito às pessoas autoras do trabalho, mas que não
+      impõe outras restrições.
+
+      '
   de:
-    term: "CC-BY"
-    def: >
-      Eine [Creative-Commons](#cc_license) [Lizenz](#license) welche eine
-      Namensnennung der Urheber verlangt aber sonst keine weiteren
-      Restriktionen auferlegt.
+    term: CC-BY
+    def: 'Eine [Creative-Commons](#cc_license) [Lizenz](#license) welche eine Namensnennung
+      der Urheber verlangt aber sonst keine weiteren Restriktionen auferlegt.
+
+      '
   uk:
-    term: "CC-BY"
-    def: >
-      [Creative Commons](#cc_license) - Attribution [license](#license):
-      ліцензія, яка дозволяє вільно використовувати, змінювати і поширювати
-      твір за умови обов'язкового зазначення авторства, без інших обмежень.
+    term: CC-BY
+    def: '[Creative Commons](#cc_license) - Attribution [license](#license): ліцензія,
+      яка дозволяє вільно використовувати, змінювати і поширювати твір за умови обов''язкового
+      зазначення авторства, без інших обмежень.
+
+      '
   am:
     term: ሲሲ-ባይ
-    def: >
-      [Creative Commons](#cc_license) - Attribution [license](#license) ፈጠራ ኮመንስ ሲሲ-ፍቃድ- አበይት ፍቃድ ሰዎች ለአንድ ጽሑፍ ደራሲ ክብር እንዲሰጡ የሚጠይቅ ቢሆንም ሌላ ምንም ዓይነት እገዳ አይጥልም ።
+    def: '[Creative Commons](#cc_license) - Attribution [license](#license) ፈጠራ ኮመንስ
+      ሲሲ-ፍቃድ- አበይት ፍቃድ ሰዎች ለአንድ ጽሑፍ ደራሲ ክብር እንዲሰጡ የሚጠይቅ ቢሆንም ሌላ ምንም ዓይነት እገዳ አይጥልም
+      ።
 
+      '
 - slug: cc_license
   en:
     term: Creative Commons license
-    def: >
-      A set of [licenses](#license) that can be applied to published work. Each license is formed by concatenating one or more of `-BY` (Attribution): users must cite the original source; `-SA` (ShareAlike): users must share their own work under a similar license; `-NC` (NonCommercial): work may not be used for commercial purposes without the creator's permission; `-ND` (NoDerivatives): no derivative works (e.g., translations) can be created without the creator's permission. Thus, `CC-BY-NC` means "users must give attribution and cannot use commercially without permission." The term `CC-0` (zero, not letter 'O') is sometimes used to mean "no restrictions," i.e., the work is in the public domain.
+    def: 'A set of [licenses](#license) that can be applied to published work. Each
+      license is formed by concatenating one or more of `-BY` (Attribution): users
+      must cite the original source; `-SA` (ShareAlike): users must share their own
+      work under a similar license; `-NC` (NonCommercial): work may not be used for
+      commercial purposes without the creator''s permission; `-ND` (NoDerivatives):
+      no derivative works (e.g., translations) can be created without the creator''s
+      permission. Thus, `CC-BY-NC` means "users must give attribution and cannot use
+      commercially without permission." The term `CC-0` (zero, not letter ''O'') is
+      sometimes used to mean "no restrictions," i.e., the work is in the public domain.
+
+      '
   pt:
     term: Licença Creative Commons
-    def: >
-      Um conjunto de [licenças](#license) que podem ser aplicadas à trabalhos publicados. Cada licença é formada pela concatenação de um ou mais dos termos a seguir: `-BY` (Atribuição): pessoas usuárias devem citar a fonte original; `-SA` (CompartilhaIgual): pessoas usuárias devem compartilhar o seu próprio trabalho utilizando uma licença similar; `-NC` (NãoComercial): o trabalho não pode ser usado para fins comerciais sem a permissão das pessoas criadoras; `-ND` (SemDerivações): nenhum trabalho derivado (como traduções, por exemplo) pode ser criado sem a permissão das pessoas criadoras. Assim, `CC-BY-NC` quer dizer "pessoas usuárias devem atribuir autoria e não podem o conteúdo de forma comercial sem permissão". O termo `CC-0` (zero, não a letra 'O') é às vezes usado com o sentido de "sem restrições", isto é, que o trabalho é de domínio público.
+    def: 'Um conjunto de [licenças](#license) que podem ser aplicadas à trabalhos
+      publicados. Cada licença é formada pela concatenação de um ou mais dos termos
+      a seguir: `-BY` (Atribuição): pessoas usuárias devem citar a fonte original;
+      `-SA` (CompartilhaIgual): pessoas usuárias devem compartilhar o seu próprio
+      trabalho utilizando uma licença similar; `-NC` (NãoComercial): o trabalho não
+      pode ser usado para fins comerciais sem a permissão das pessoas criadoras; `-ND`
+      (SemDerivações): nenhum trabalho derivado (como traduções, por exemplo) pode
+      ser criado sem a permissão das pessoas criadoras. Assim, `CC-BY-NC` quer dizer
+      "pessoas usuárias devem atribuir autoria e não podem o conteúdo de forma comercial
+      sem permissão". O termo `CC-0` (zero, não a letra ''O'') é às vezes usado com
+      o sentido de "sem restrições", isto é, que o trabalho é de domínio público.
+
+      '
   de:
     term: Creative Commons Lizenz
-    def: >
-      Eine Sammlung von [Lizenzen](#license) welche verschiedene, einfache Lizenzvereinbarungen für beliebige Werke bereitstellt. Jede Lizenz kann zusätzlichen Bedingungen unterliegen: `-BY` (Namensnennung): Nutzer müssen den Autor des Werks nennen. `-SA` (Gleiche Bedingungen): Nutzer dürfen das Werk nur unter den gleichen Bedingungen weiter verbreiten. `-NC` (Nicht-Kommerziell): Ohne vorherige Zustimmung darf das Werk nur nicht kommerziell verwendet werden. `-ND` (Keine Bearbeitung): Ohne vorherige Zustimmung darf das Werk nicht verändert werden. Diese Bedingungen werden mit dem Prefix "CC" verknüpft um kombinierte Lizenzen zu kreieren. So bedeutet `CC-BY-NC` das die Nutzer den Namen des Autors nennen müssen und das Werk nur mit Zustimmung kommerziell nutzen dürfen. Der Begriff [CC0](#cc_0) beschreibt ein Werk "ohne Einschränkungen", d.h. das Werk ist gemeinfrei.
+    def: 'Eine Sammlung von [Lizenzen](#license) welche verschiedene, einfache Lizenzvereinbarungen
+      für beliebige Werke bereitstellt. Jede Lizenz kann zusätzlichen Bedingungen
+      unterliegen: `-BY` (Namensnennung): Nutzer müssen den Autor des Werks nennen.
+      `-SA` (Gleiche Bedingungen): Nutzer dürfen das Werk nur unter den gleichen Bedingungen
+      weiter verbreiten. `-NC` (Nicht-Kommerziell): Ohne vorherige Zustimmung darf
+      das Werk nur nicht kommerziell verwendet werden. `-ND` (Keine Bearbeitung):
+      Ohne vorherige Zustimmung darf das Werk nicht verändert werden. Diese Bedingungen
+      werden mit dem Prefix "CC" verknüpft um kombinierte Lizenzen zu kreieren. So
+      bedeutet `CC-BY-NC` das die Nutzer den Namen des Autors nennen müssen und das
+      Werk nur mit Zustimmung kommerziell nutzen dürfen. Der Begriff [CC0](#cc_0)
+      beschreibt ein Werk "ohne Einschränkungen", d.h. das Werk ist gemeinfrei.
+
+      '
   am:
     term: የፈጠራ ኮመንስ ፍቃድ
-    def: >
-      ለህትመት ሥራ ሊመለከቱ የሚችሉ [ፍቃዶች](#license) እያንዳንዳቸው ፍቃድ ሚመሰረተው የ '-ባይ' (Attribution) ተጠቃሚዎችን አንድ ወይም ከዚያ በላይ በመመደብ ነው must cite cite the original source; '-SA' (ShareAlike) ተጠቃሚዎች የራሳቸውን ማጋራት አለባቸው በተመሳሳይ ፈቃድ ሥራ መሥራት፤ '-ኤን ሲ' (NonCommercial) ስራ ላይውል ይችላል ያለ ፈጣሪ ፈቃድ የንግድ ዓላማዎች፤ '-ND' (NoDerivatives) አይደለም የተዋሕዶ ስራዎች (ለምሳሌ፣ ትርጉሞች) ያለ ፈጣሪ ሊፈጠሩ ይችላሉ ፍቃድ። በመሆኑም 'CC-BY-ኤንሲ' ማለት"ተጠቃሚዎች ባህሪ መስጠት አለባቸው እና መጠቀም አይችሉም ለንግድ ያለ ፈቃድ". 'ሲሲ-0' (ዜሮ እንጂ ፊደል 'ኦ' አይደለም) የሚለው ቃል ነው አንዳንድ ጊዜ"እገዳ የለም"ማለትም ሥራው በሕዝብ ክልል ውስጥ ይገኛል።
+    def: 'ለህትመት ሥራ ሊመለከቱ የሚችሉ [ፍቃዶች](#license) እያንዳንዳቸው ፍቃድ ሚመሰረተው የ ''-ባይ'' (Attribution)
+      ተጠቃሚዎችን አንድ ወይም ከዚያ በላይ በመመደብ ነው must cite cite the original source; ''-SA''
+      (ShareAlike) ተጠቃሚዎች የራሳቸውን ማጋራት አለባቸው በተመሳሳይ ፈቃድ ሥራ መሥራት፤ ''-ኤን ሲ'' (NonCommercial)
+      ስራ ላይውል ይችላል ያለ ፈጣሪ ፈቃድ የንግድ ዓላማዎች፤ ''-ND'' (NoDerivatives) አይደለም የተዋሕዶ ስራዎች
+      (ለምሳሌ፣ ትርጉሞች) ያለ ፈጣሪ ሊፈጠሩ ይችላሉ ፍቃድ። በመሆኑም ''CC-BY-ኤንሲ'' ማለት"ተጠቃሚዎች ባህሪ መስጠት
+      አለባቸው እና መጠቀም አይችሉም ለንግድ ያለ ፈቃድ". ''ሲሲ-0'' (ዜሮ እንጂ ፊደል ''ኦ'' አይደለም) የሚለው ቃል
+      ነው አንዳንድ ጊዜ"እገዳ የለም"ማለትም ሥራው በሕዝብ ክልል ውስጥ ይገኛል።
+
+      '
   uk:
     term: Creative Commons license
-    def: >
-      Набір ліцензій, які можна застосовувати до опублікованого твору.
-      Кожна ліцензія формується шляхом конкатенації одного або кількох із
-      -BY (зазначення авторства): користувачі повинні цитувати першоджерело;
-      -SA (ShareAlike): користувачі повинні ділитися власними творами
-      за аналогічною ліцензією;
-      -NC (некомерційний): твір не може використовуватися в комерційних
-      цілях без дозволу автора;
-      -ND (NoDerivatives): жодні похідні твори (наприклад, переклади)
-      не можуть бути створені без дозволу автора.
-      Таким чином, CC-BY-NC означає, що "користувачі повинні вказати
-      авторство та не можуть використовувати в комерційних цілях без дозволу".
-      Термін CC-0 (нуль, а не літера "О") іноді використовується для
-      позначення "немає обмежень, тобто твір є суспільним надбанням.
+    def: 'Набір ліцензій, які можна застосовувати до опублікованого твору. Кожна ліцензія
+      формується шляхом конкатенації одного або кількох із -BY (зазначення авторства):
+      користувачі повинні цитувати першоджерело; -SA (ShareAlike): користувачі повинні
+      ділитися власними творами за аналогічною ліцензією; -NC (некомерційний): твір
+      не може використовуватися в комерційних цілях без дозволу автора; -ND (NoDerivatives):
+      жодні похідні твори (наприклад, переклади) не можуть бути створені без дозволу
+      автора. Таким чином, CC-BY-NC означає, що "користувачі повинні вказати авторство
+      та не можуть використовувати в комерційних цілях без дозволу". Термін CC-0 (нуль,
+      а не літера "О") іноді використовується для позначення "немає обмежень, тобто
+      твір є суспільним надбанням.
 
+      '
 - slug: centroid
   en:
     term: centroid
-    def: >
-      The center or anchor of a group created by a [clustering](#clustering) algorithm.
+    def: 'The center or anchor of a group created by a [clustering](#clustering) algorithm.
+
+      '
   pt:
     term: centróide
-    def: >
-      O centro ou âncora de um grupo criado por um algoritmo de [agrupamento](#clustering).
+    def: 'O centro ou âncora de um grupo criado por um algoritmo de [agrupamento](#clustering).
+
+      '
   am:
     term: ሴንትሮይድ
-    def: >
-      በ [ክምችት](#clustering) አልጎሪዝም የተፈጠረ ቡድን ማእከል ወይም መልህቅ። የተፈጠረ ቡድን ማእከል ወይም መልህቅ በ [ክምችት](#clustering) አልጎሪዝም ።
+    def: 'በ [ክምችት](#clustering) አልጎሪዝም የተፈጠረ ቡድን ማእከል ወይም መልህቅ። የተፈጠረ ቡድን ማእከል ወይም
+      መልህቅ በ [ክምችት](#clustering) አልጎሪዝም ።
 
+      '
 - slug: character_encoding
   en:
     term: character encoding
-    def: >
-      A specification of how characters are stored as bytes. The most commonly-used encoding today is [UTF-8](#utf_8).
+    def: 'A specification of how characters are stored as bytes. The most commonly-used
+      encoding today is [UTF-8](#utf_8).
+
+      '
   ar:
     term: ترميز
-    def: >
-      إعادة تمثيل البيانات بصياغة أُخرى ليسهل التعامل معها وحفظها كبايت (bytes)
-       ولا علاقة للترميز بالسرية والتشفير مطلقا، ومن صيغ ترميز البيانات المشهورة
-       هو
-       يو تي إف
-       [(UTF-8)](#utf_8).
+    def: "إعادة تمثيل البيانات بصياغة أُخرى ليسهل التعامل معها وحفظها كبايت (bytes)\n\
+      \ ولا علاقة للترميز بالسرية والتشفير مطلقا، ومن صيغ ترميز البيانات المشهورة\n\
+      \ هو\n يو تي إف\n [(UTF-8)](#utf_8).\n"
   es:
     term: codificación de caracteres
-    def: >
-      Especificación sobre cómo los caracteres están guardados como bytes. En la actualidad, la codificación más utilizada es [UTF-8](#utf_8).
+    def: 'Especificación sobre cómo los caracteres están guardados como bytes. En
+      la actualidad, la codificación más utilizada es [UTF-8](#utf_8).
+
+      '
   am:
     term: የባህርይ ኮድ
-    def: >
-      ባለታሪኮች እንደ ባይት እንዴት እንደሚቀመጡ የሚገልጽ መመሪያ። ዛሬ በብዛት ጥቅም ላይ የሚውለው encoding  [UTF-8](#utf_8).
+    def: 'ባለታሪኮች እንደ ባይት እንዴት እንደሚቀመጡ የሚገልጽ መመሪያ። ዛሬ በብዛት ጥቅም ላይ የሚውለው encoding  [UTF-8](#utf_8).
 
+      '
 - slug: chi_square_test
   en:
     term: chi-square test
-    def: >
-      A statistical method for estimating whether two variables in a cross tabulation are [correlated](#correlation). A chi-square distribution varies from a [normal distribution](#normal_distribution) based on the [degrees of freedom](#degrees_of_freedom) used to calculate it.
+    def: 'A statistical method for estimating whether two variables in a cross tabulation
+      are [correlated](#correlation). A chi-square distribution varies from a [normal
+      distribution](#normal_distribution) based on the [degrees of freedom](#degrees_of_freedom)
+      used to calculate it.
+
+      '
   af:
     term: chi-kwadraattoets
-    def: >
-      'n Statistiese metode om te bepaal of twee veranderlikes in 'n kruistabellering gekorreleerd is. 'n Chi-kwadraatverdeling wissel vanaf 'n normale verspreiding gebaseer op die vryheidsgrade wat gebruik word om dit te bereken.
+    def: '''n Statistiese metode om te bepaal of twee veranderlikes in ''n kruistabellering
+      gekorreleerd is. ''n Chi-kwadraatverdeling wissel vanaf ''n normale verspreiding
+      gebaseer op die vryheidsgrade wat gebruik word om dit te bereken.
+
+      '
   am:
     term: ቺ-እስኬር ፈተና
-    def: >
-      በመስቀል ጠረፍ ውስጥ ሁለት ተለዋዋጭ ዎችን ለመገመት የሚያስችል አሃዛዊ ዘዴ (#correlation) ናቸው።  የቺ-ካሬ ስርጭት ከ[የተለመደ) የስርጭት ](#normal_distribution) ይለያያል በ[ዲግሪ)  ነፃነት](#degrees_of_freedom) መሰረት ለማስላት ይጠቀሙበት ነበር።
+    def: 'በመስቀል ጠረፍ ውስጥ ሁለት ተለዋዋጭ ዎችን ለመገመት የሚያስችል አሃዛዊ ዘዴ (#correlation) ናቸው።  የቺ-ካሬ
+      ስርጭት ከ[የተለመደ) የስርጭት ](#normal_distribution) ይለያያል በ[ዲግሪ)  ነፃነት](#degrees_of_freedom)
+      መሰረት ለማስላት ይጠቀሙበት ነበር።
 
+      '
 - slug: child_class
   en:
     term: child class
-    def: >
-      In [object-oriented programming](#oop), a [class](#class) derived from another class (called the [parent class](#parent_class)).
+    def: 'In [object-oriented programming](#oop), a [class](#class) derived from another
+      class (called the [parent class](#parent_class)).
+
+      '
   es:
     term: subclase
-    def: >
-      En [programación orientada a objetos](#oop), es la extensión de otra clase (denominada [superclase](#parent_class)).
+    def: 'En [programación orientada a objetos](#oop), es la extensión de otra clase
+      (denominada [superclase](#parent_class)).
+
+      '
   pt:
     term: classe derivada
-    def: >
-      Em [programação orientada a objetos](#oop), a classe derivada de uma outra classe (chamada de [classe base](#parent_class)).
+    def: 'Em [programação orientada a objetos](#oop), a classe derivada de uma outra
+      classe (chamada de [classe base](#parent_class)).
+
+      '
   am:
     term: ልጅ መደብ
-    def: >
-      በዕቃ ተኮር ፕሮግራም(#oop) ውስጥ ከሌላ መደብ የተገኘ [መደብ](#class) ([የወላጅ ክፍል](#parent_class)።
+    def: 'በዕቃ ተኮር ፕሮግራም(#oop) ውስጥ ከሌላ መደብ የተገኘ [መደብ](#class) ([የወላጅ ክፍል](#parent_class)።
+
+      '
   uk:
     term: дочірній клас
-    def: >
-      У [об'єктно-орієнтованому програмуванні](#oop) клас, що успадковується від іншого класу, який називається [базовим класом](#parent_class).
+    def: 'У [об''єктно-орієнтованому програмуванні](#oop) клас, що успадковується
+      від іншого класу, який називається [базовим класом](#parent_class).
 
+      '
 - slug: child_tree
   en:
     term: child (in a tree)
-    def: >
-      A [node](#node) in a [tree](#node) that is below another node (call the [parent](#parent_tree)).
+    def: 'A [node](#node) in a [tree](#node) that is below another node (call the
+      [parent](#parent_tree)).
+
+      '
   am:
     term: child (in a tree)
-    def: >
-      [ኖድ](#node) በ [ዛፍ](#node) ውስጥ ከሌላው ቁልቁል በታች ([ወላጁን](#parent_tree) ይሉታል።)
+    def: '[ኖድ](#node) በ [ዛፍ](#node) ውስጥ ከሌላው ቁልቁል በታች ([ወላጁን](#parent_tree) ይሉታል።)
 
+      '
 - slug: class
   en:
     term: class
-    def: >
-      In [object-oriented programming](#oop), a structure that combines data and operations (called [methods](#method)). The program then uses a [constructor](#constructor) to create an [object](#object) with those properties and methods. Programmers generally put generic or reusable behavior in [parent classes](#parent_class), and more detailed or specific behavior in [child classes](#child_class).
+    def: 'In [object-oriented programming](#oop), a structure that combines data and
+      operations (called [methods](#method)). The program then uses a [constructor](#constructor)
+      to create an [object](#object) with those properties and methods. Programmers
+      generally put generic or reusable behavior in [parent classes](#parent_class),
+      and more detailed or specific behavior in [child classes](#child_class).
+
+      '
   es:
     term: clase
-    def: >
-      En [programación orientada a objetos](#oop), es una estructura que combina datos y operaciones (denominadas [métodos](#method)). El programa emplea un [constructor](#constructor) para crear un [objeto](#object) con esas propiedades y métodos. Los programadores generalmente definen comportamientos genéricos o reutilizables en [superclases](#parent_class) y comportamientos más específicos o detallados en [subclases](#child_class).
+    def: 'En [programación orientada a objetos](#oop), es una estructura que combina
+      datos y operaciones (denominadas [métodos](#method)). El programa emplea un
+      [constructor](#constructor) para crear un [objeto](#object) con esas propiedades
+      y métodos. Los programadores generalmente definen comportamientos genéricos
+      o reutilizables en [superclases](#parent_class) y comportamientos más específicos
+      o detallados en [subclases](#child_class).
+
+      '
   am:
     term: ክፍል
-    def: >
-      በዕቃ ተኮር ፕሮግራም (#oop) ውስጥ, መረጃዎችን እና ክንውኖች ([ዘዴዎች](#method)። ፕሮግራሙ ከዚያ ምክኒያት የሚጠቀምበት [ኮንሰርተር](#constructor) ከነዚህ ጋር [አካል](#object) ለመፍጠር ባህሪያት እና ዘዴዎች. ፕሮግራም አዘጋጆች በአብዛኛው ጀነሬክ ወይም እንደገና ሊጠቀሙ የሚችሉ ናቸው ባህሪ በ[ወላጅ መደብ](#parent_class)፣ እና በዝርዝር ወይም በግልጽ ጠባይ በ[ልጆች መደብ](#child_class).
-  uk:  
-    term: клас
-    def: >
-      У [об'єктно-орієнтованому програмуванні](#oop) класи є шаблонами, за якими створюються об’єкти. 
-      Вони допомагають групувати разом пов’язані змінні та функції (названі [методами](#method)). 
-      Програмісти зазвичай визначають загальну або спільну функціональність в [базових класах](#parent_class), 
-      а більш детальну або специфічну функціональність в [дочірніх класах](#child_class).
+    def: 'በዕቃ ተኮር ፕሮግራም (#oop) ውስጥ, መረጃዎችን እና ክንውኖች ([ዘዴዎች](#method)። ፕሮግራሙ ከዚያ ምክኒያት
+      የሚጠቀምበት [ኮንሰርተር](#constructor) ከነዚህ ጋር [አካል](#object) ለመፍጠር ባህሪያት እና ዘዴዎች. ፕሮግራም
+      አዘጋጆች በአብዛኛው ጀነሬክ ወይም እንደገና ሊጠቀሙ የሚችሉ ናቸው ባህሪ በ[ወላጅ መደብ](#parent_class)፣ እና
+      በዝርዝር ወይም በግልጽ ጠባይ በ[ልጆች መደብ](#child_class).
 
+      '
+  uk:
+    term: клас
+    def: 'У [об''єктно-орієнтованому програмуванні](#oop) класи є шаблонами, за якими
+      створюються об’єкти.  Вони допомагають групувати разом пов’язані змінні та функції
+      (названі [методами](#method)).  Програмісти зазвичай визначають загальну або
+      спільну функціональність в [базових класах](#parent_class),  а більш детальну
+      або специфічну функціональність в [дочірніх класах](#child_class).
+
+      '
+- slug: class_imbalance
+  ref:
+  - machine_learning
+  en:
+    term: class imbalance
+    def: 'Class imbalance refers to the problem in [machine learning](machine_learning)
+      where there is an unequal distribution of classes in the dataset.
+
+      '
 - slug: classification
   ref:
-    - supervised_learning
-    - clustering
+  - supervised_learning
+  - clustering
   en:
     term: classification
-    def: >
-      The process of identifying which predefined category an item belongs to, such as deciding whether an email message is spam or not. Many [machine learning](#machine_learning) algorithms perform classification.
+    def: 'The process of identifying which predefined category an item belongs to,
+      such as deciding whether an email message is spam or not. Many [machine learning](#machine_learning)
+      algorithms perform classification.
+
+      '
   am:
     term: መደብ
-    def: >
-      አንድ ዕቃ ከየትኛው ቅድመ ምድብ ጋር እንደሆነ የመለየት ሂደት, ለምሳሌ የኢሜይል መልዕክት የመልዕክት መልዕክት እስፓም ወይም አይደለም መወሰን. ብዙ [ማሽን መማር](#machine_learning) አልጎሪቶች የመደብ ልዩነትን ያከናውናሉ።
+    def: 'አንድ ዕቃ ከየትኛው ቅድመ ምድብ ጋር እንደሆነ የመለየት ሂደት, ለምሳሌ የኢሜይል መልዕክት የመልዕክት መልዕክት እስፓም
+      ወይም አይደለም መወሰን. ብዙ [ማሽን መማር](#machine_learning) አልጎሪቶች የመደብ ልዩነትን ያከናውናሉ።
+
+      '
   es:
-    term: "clasificación"
-    def: >
-      El proceso de identificar a que categoría predefinida pertenece un objeto, como, por ejemplo, decidir si un mensaje de correo electrónico es spam o no.
+    term: clasificación
+    def: 'El proceso de identificar a que categoría predefinida pertenece un objeto,
+      como, por ejemplo, decidir si un mensaje de correo electrónico es spam o no.
       Muchos algoritmos de [machine learning](#machine_learning) realizan clasificación.
 
+      '
 - slug: cli
   en:
     term: command-line interface
-    def: >
-      A user interface that relies solely on text for commands and output, typically running in a [shell](#shell).
+    def: 'A user interface that relies solely on text for commands and output, typically
+      running in a [shell](#shell).
+
+      '
   am:
     term: ትዕዛዝ-መስመር አገናኝ
-    def: >
-      ኢንተርፌት በ[ዛጎል](#shell) ውስጥ ለመሮጥ ትዕዛዞች እና ውጤቶች ለማግኘት በጽሁፍ ላይ ብቻ የሚደገፍ  ።
+    def: 'ኢንተርፌት በ[ዛጎል](#shell) ውስጥ ለመሮጥ ትዕዛዞች እና ውጤቶች ለማግኘት በጽሁፍ ላይ ብቻ የሚደገፍ  ።
+
+      '
   uk:
     term: інтерфейс командного рядка
-    def: >
-      Інтерфейс користувача, який повністю покладається на текст
-      для введення команд та виведення результатів їх виконання.
-      Зазвичай використовується у [командній оболонці](#shell).
+    def: 'Інтерфейс користувача, який повністю покладається на текст для введення
+      команд та виведення результатів їх виконання. Зазвичай використовується у [командній
+      оболонці](#shell).
 
+      '
 - slug: client
   en:
     term: client
-    def: >
-      Typically, a program such as a web browser that gets data from a [server](#server) and displays it to, or interacts with, users. The term is used more generally to refer to any program A that makes requests of another program B. A single program can be both a client and a server.
+    def: 'Typically, a program such as a web browser that gets data from a [server](#server)
+      and displays it to, or interacts with, users. The term is used more generally
+      to refer to any program A that makes requests of another program B. A single
+      program can be both a client and a server.
+
+      '
   am:
     term: ደንበኛ
-    def: >
-      አብዛኛውን ጊዜ መረጃን ከአንድ ድረ ገጽ የሚያገኝ እንደ ዌብ ብራውዘር ያለ ፕሮግራም [ሰርቨር](#server) እና ለተጠቃሚዎች, ወይም ግንኙነት ለማሳየት. ቃሉ ጥቅም ላይ ይውላል የበለጠ በአጠቃላይ ሌላ ፕሮግራም ጥያቄዎችን የሚያደርግ ማንኛውም ፕሮግራም ሀ ለማመልከት ለ. አንድ ፕሮግራም ደንበኛም ሆነ ሰርቨር ሊሆን ይችላል።
+    def: 'አብዛኛውን ጊዜ መረጃን ከአንድ ድረ ገጽ የሚያገኝ እንደ ዌብ ብራውዘር ያለ ፕሮግራም [ሰርቨር](#server) እና
+      ለተጠቃሚዎች, ወይም ግንኙነት ለማሳየት. ቃሉ ጥቅም ላይ ይውላል የበለጠ በአጠቃላይ ሌላ ፕሮግራም ጥያቄዎችን የሚያደርግ
+      ማንኛውም ፕሮግራም ሀ ለማመልከት ለ. አንድ ፕሮግራም ደንበኛም ሆነ ሰርቨር ሊሆን ይችላል።
 
+      '
 - slug: closure
   en:
     term: closure
-    def: >
-      A set of variables defined in the same [scope](#scope) whose existence has been preserved after that scope has ended.
+    def: 'A set of variables defined in the same [scope](#scope) whose existence has
+      been preserved after that scope has ended.
+
+      '
   am:
     term: መዘጋት
-    def: >
-      ህልውናቸው በዚሁ [ስፋት](#scope) የተገለፁ ተለዋዋጭዎች ይህ ስፋት ካበቃ በኋላ ተጠብቆ እንዲቆይ ተደርጓል ።
+    def: 'ህልውናቸው በዚሁ [ስፋት](#scope) የተገለፁ ተለዋዋጭዎች ይህ ስፋት ካበቃ በኋላ ተጠብቆ እንዲቆይ ተደርጓል ።
 
+      '
 - slug: clustering
   ref:
-    - centroid
-    - classification
-    - supervised_learning
-    - unsupervised_learning
+  - centroid
+  - classification
+  - supervised_learning
+  - unsupervised_learning
   en:
-    term: "clustering"
-    def: >
-      The process of dividing data into groups when the groups themselves are not
-      known in advance.
+    term: clustering
+    def: 'The process of dividing data into groups when the groups themselves are
+      not known in advance.
+
+      '
   pt:
-    term: "agrupamento"
-    def: >
-      O processo de dividir os dados em grupos quando os grupos em si não são conhecidos
-      antecipadamente.
+    term: agrupamento
+    def: 'O processo de dividir os dados em grupos quando os grupos em si não são
+      conhecidos antecipadamente.
+
+      '
   ja:
-    term: "クラスタリング"
-    def: >
-      データをどのように分類するかは不明のまま、グループに分割するプロセスのこと。
+    term: クラスタリング
+    def: 'データをどのように分類するかは不明のまま、グループに分割するプロセスのこと。
+
+      '
   am:
     term: መከፋፈል
-    def: >
-      ቡድኖቹ ራሳቸው በማይሆንበት ጊዜ መረጃዎችን በቡድን የመከፋፈል ሂደት አስቀድሞ የታወቀ ነው ።
-  sw:
-    term: "kugawanya"
-    def: >
-      Mchakato wa kugawanya data katika vikundi wakati vikundi vyenyewe bado havijagunduliwa mapema.
+    def: 'ቡድኖቹ ራሳቸው በማይሆንበት ጊዜ መረጃዎችን በቡድን የመከፋፈል ሂደት አስቀድሞ የታወቀ ነው ።
 
+      '
+  sw:
+    term: kugawanya
+    def: 'Mchakato wa kugawanya data katika vikundi wakati vikundi vyenyewe bado havijagunduliwa
+      mapema.
+
+      '
+- slug: cnn
+  ref:
+  - deep_learning
+  - backpropagation
+  - perceptron
+  - neural_network
+  - machine_learning
+  en:
+    term: convolutional neural network (cnn)
+    def: 'A class of artificial neural network that is primarily used to analyze images.
+      A CNN has layers that perform convolutions, where a filter is shifted over the
+      data, instead of the general matrix multiplications that we see in fully connected
+      neural network layers.
+
+      '
 - slug: code_coverage
   en:
-    term: "code coverage (in testing)"
-    def: >
-      How much of a [library](#library) or program is executed when tests run. This is normally
-      reported as a percentage of lines of code: for example, if 40 out of 50 lines in
-      a file are run during testing, those tests have 80% code coverage.
+    term: code coverage (in testing)
+    def: 'How much of a [library](#library) or program is executed when tests run.
+      This is normally reported as a percentage of lines of code: for example, if
+      40 out of 50 lines in a file are run during testing, those tests have 80% code
+      coverage.
+
+      '
   am:
     term: ኮድ ሽፋን (በፈተና)
-    def: >
-      ፈተና ሲከናውን ምን ያህል [ቤተ መጻሕፍት](#library) ወይም ፕሮግራም ይፈፀም።  ይህ የተለመደ ነው እንደ አንድ በመቶ የኮድ መስመሮች ሪፖርት ተደርጓል ለምሳሌ, ከ 50 መስመሮች ውስጥ 40 ከሆነ አንድ ፋይል በፈተና ወቅት ይሰራል, እነዚያ ምርመራዎች 80% ኮድ ሽፋን አላቸው::
-  sw:
-    term: "kuasisi msimbo (majaribuni)"
-    def: >
-       Ni kiasi gani [maktaba](#library) au programu imetekelezwa wakati wa majaribio.
-       kwa mfano, ikiwa mistari 40 kati ya 50 ndani faili imetekelezwa wakati wa majaribio,
-       majaribio hayo yana kiwango cha asilimia 80%.
-  uk:
-    term: "покриття коду (в тестуванні)"
-    def: >
-      Показник, який визначає, наскільки велика частина бібліотеки або програми виконується
-      під час виконання тестів. Зазвичай виражається у відсотках від кількості рядків коду: наприклад,
-      якщо під час тестування виконується 40 з 50 рядків у файлі, то покриття коду становить 80%.
+    def: 'ፈተና ሲከናውን ምን ያህል [ቤተ መጻሕፍት](#library) ወይም ፕሮግራም ይፈፀም።  ይህ የተለመደ ነው እንደ አንድ
+      በመቶ የኮድ መስመሮች ሪፖርት ተደርጓል ለምሳሌ, ከ 50 መስመሮች ውስጥ 40 ከሆነ አንድ ፋይል በፈተና ወቅት ይሰራል,
+      እነዚያ ምርመራዎች 80% ኮድ ሽፋን አላቸው::
 
+      '
+  sw:
+    term: kuasisi msimbo (majaribuni)
+    def: 'Ni kiasi gani [maktaba](#library) au programu imetekelezwa wakati wa majaribio.
+      kwa mfano, ikiwa mistari 40 kati ya 50 ndani faili imetekelezwa wakati wa majaribio,
+      majaribio hayo yana kiwango cha asilimia 80%.
+
+      '
+  uk:
+    term: покриття коду (в тестуванні)
+    def: 'Показник, який визначає, наскільки велика частина бібліотеки або програми
+      виконується під час виконання тестів. Зазвичай виражається у відсотках від кількості
+      рядків коду: наприклад, якщо під час тестування виконується 40 з 50 рядків у
+      файлі, то покриття коду становить 80%.
+
+      '
 - slug: code_review
   en:
-    term: "code review"
-    def: >
-      To check a program or a change to a program by inspecting its source code.
+    term: code review
+    def: 'To check a program or a change to a program by inspecting its source code.
+
+      '
   es:
-    term: "revisión de código"
-    def: >
-      Revisar un programa o un cambio a un programa inspeccionando su código fuente.
+    term: revisión de código
+    def: 'Revisar un programa o un cambio a un programa inspeccionando su código fuente.
+
+      '
   am:
     term: የኮድ ክለሳ
-    def: >
-      ከምንጭ ኮዱ በመፈተሽ የአንድን ፕሮግራም ማጣራት ወይም አንድን ፕሮግራም መለወጥ ::
-  uk:
-    term: "перегляд коду"
-    def: >
-      Перевірка програми або змін у ній шляхом дослідження її вихідного коду.
+    def: 'ከምንጭ ኮዱ በመፈተሽ የአንድን ፕሮግራም ማጣራት ወይም አንድን ፕሮግራም መለወጥ ::
 
+      '
+  uk:
+    term: перегляд коду
+    def: 'Перевірка програми або змін у ній шляхом дослідження її вихідного коду.
+
+      '
 - slug: coercion
   en:
-    term: "coercion"
-    def: >
-      See [type coercion](#type_coercion).
+    term: coercion
+    def: 'See [type coercion](#type_coercion).
+
+      '
   am:
     term: ማስገደድ
-    def: >
-      [ዓይነት አስገዳጅነትን](#type_coercion) ተመልከት።
+    def: '[ዓይነት አስገዳጅነትን](#type_coercion) ተመልከት።
 
+      '
 - slug: cognitive_load
   en:
-    term: "cognitive load"
-    def: >
-      The amount of working memory needed to accomplish a set of simultaneous tasks.
+    term: cognitive load
+    def: 'The amount of working memory needed to accomplish a set of simultaneous
+      tasks.
+
+      '
   af:
-    term: "kognitiewe lading"
-    def: >
-      Die hoeveelheid werkgeheue wat nodig is om 'n stel gelyktydige take te verrig.
+    term: kognitiewe lading
+    def: 'Die hoeveelheid werkgeheue wat nodig is om ''n stel gelyktydige take te
+      verrig.
+
+      '
   am:
     term: የማሰብ ችሎታ ጭነት
-    def: >
-      አንድ አይነት ስራዎችን ለማከናወን የሚያስፈልገው የስራ ትውስታ መጠን.
-  uk:
-    term: "когнітивне навантаження"
-    def: >
-      Обсяг робочої памʼяті людини, необхідний для виконання набору одночасних завдань.
+    def: 'አንድ አይነት ስራዎችን ለማከናወን የሚያስፈልገው የስራ ትውስታ መጠን.
 
+      '
+  uk:
+    term: когнітивне навантаження
+    def: 'Обсяг робочої памʼяті людини, необхідний для виконання набору одночасних
+      завдань.
+
+      '
 - slug: collection
   ref:
-    - list
-    - vector
-    - tuple
+  - list
+  - vector
+  - tuple
   en:
-    term: "collection"
-    def: >
-      An abstract data type that groups an arbitrary, variable number of data items (possibly zero), to allow
-      processing them in a uniform fashion. Common examples of collections are lists, variable-size arrays and sets. Fixed-size arrays
-      are usually not considered collections.
+    term: collection
+    def: 'An abstract data type that groups an arbitrary, variable number of data
+      items (possibly zero), to allow processing them in a uniform fashion. Common
+      examples of collections are lists, variable-size arrays and sets. Fixed-size
+      arrays are usually not considered collections.
 
+      '
 - slug: command
   en:
-    term: "command"
-    def: >
-      An instruction telling a computer program to perform a specific task.
+    term: command
+    def: 'An instruction telling a computer program to perform a specific task.
+
+      '
   af:
     term: bevel
-    def: >
-      'n Instruksie wat 'n rekenaarprogram opdrag gee om 'n spesifieke taak uit te voer.
+    def: '''n Instruksie wat ''n rekenaarprogram opdrag gee om ''n spesifieke taak
+      uit te voer.
 
+      '
   am:
     term: ትዕዛዝ
-    def: >
-      አንድ የኮምፒውተር ፕሮግራም አንድ የተወሰነ ሥራን እንዲሠራ የሚነግረው መመሪያ።
-  sw:
-    term: "amri"
-    def: >
-      Agizo la kuiambia programu ya kompyuta kufanya kazi maalum.
-  uk:
-    term: "команда"
-    def: >
-      Інструкція, яка наказує комп'ютерній програмі виконати певне завдання.
+    def: 'አንድ የኮምፒውተር ፕሮግራም አንድ የተወሰነ ሥራን እንዲሠራ የሚነግረው መመሪያ።
 
+      '
+  sw:
+    term: amri
+    def: 'Agizo la kuiambia programu ya kompyuta kufanya kazi maalum.
+
+      '
+  uk:
+    term: команда
+    def: 'Інструкція, яка наказує комп''ютерній програмі виконати певне завдання.
+
+      '
 - slug: command_history
   en:
-    term: "command history"
-    def: >
-      An automatically created list of previously executed commands. Most read-eval-print loops
-      ([REPLs](#repl)), including the [Unix shell](#shell), record history and allow
-      users to play back recent commands.
+    term: command history
+    def: 'An automatically created list of previously executed commands. Most read-eval-print
+      loops ([REPLs](#repl)), including the [Unix shell](#shell), record history and
+      allow users to play back recent commands.
+
+      '
   am:
     term: ትዕዛዝ ታሪክ
-    def: >
-      ቀደም ሲል ተፈጻሚ የነበሩ ትዕዛዞች በራሱ የተፈጠሩ ዝርዝር. አብዛኛዎቹ የንባብ-eቫል-የህትመት ልጥፎች ([REPLs](#repl)፣ የ[ዩኒክስ ዛጎልን](#shell)፣ ታሪክን መዝግበው እንዲፈቅዱ ተጠቃሚዎች የቅርብ ጊዜ ትዕዛዞች መልሰው ለማጫወት.
+    def: 'ቀደም ሲል ተፈጻሚ የነበሩ ትዕዛዞች በራሱ የተፈጠሩ ዝርዝር. አብዛኛዎቹ የንባብ-eቫል-የህትመት ልጥፎች ([REPLs](#repl)፣
+      የ[ዩኒክስ ዛጎልን](#shell)፣ ታሪክን መዝግበው እንዲፈቅዱ ተጠቃሚዎች የቅርብ ጊዜ ትዕዛዞች መልሰው ለማጫወት.
+
+      '
   uk:
-    term: "історія команд"
-    def: >
-      Автоматично створений список раніше виконаних команд. Більшість інтерпретаторів командного рядка, 
-      у тому числі [Unix shell](#shell), зберігають історію та дозволяють користувачам відтворювати останні команди.
-  
+    term: історія команд
+    def: 'Автоматично створений список раніше виконаних команд. Більшість інтерпретаторів
+      командного рядка,  у тому числі [Unix shell](#shell), зберігають історію та
+      дозволяють користувачам відтворювати останні команди.
+
+      '
 - slug: command_line_argument
   en:
-    term: "command-line argument"
-    def: >
-      A filename or control flag given to a command-line program when it is run.
+    term: command-line argument
+    def: 'A filename or control flag given to a command-line program when it is run.
+
+      '
   am:
     term: ትዕዛዝ-መስመር ክርክር
-    def: >
-      በሚሰራበት ጊዜ ለትዕዛዝ-መስመር ፕሮግራም የተሰጠ የፋይል ስም ወይም የቁጥጥር ባንዲራ.
-  uk:
-    term: "аргумент командного рядка"
-    def: >
-      Назва файлу, опція або інша інформація, яку передають програмі під час її запуску через інтерфейс командного рядка.
+    def: 'በሚሰራበት ጊዜ ለትዕዛዝ-መስመር ፕሮግራም የተሰጠ የፋይል ስም ወይም የቁጥጥር ባንዲራ.
 
+      '
+  uk:
+    term: аргумент командного рядка
+    def: 'Назва файлу, опція або інша інформація, яку передають програмі під час її
+      запуску через інтерфейс командного рядка.
+
+      '
 - slug: comment
   en:
-    term: "comment"
-    def: >
-      Text written in a script that is not treated as code to be run, but rather as
-      text that describes what the code is doing. These are usually short notes, often
-      beginning with a `#` (in many programming languages).
+    term: comment
+    def: 'Text written in a script that is not treated as code to be run, but rather
+      as text that describes what the code is doing. These are usually short notes,
+      often beginning with a `#` (in many programming languages).
+
+      '
   fr:
-    term: "commentaire"
-    def: >
-      Texte écrit dans un script, qui n'est pas évalué lors de l'exécution du code. Il
-      est utilisé pour décrire ce qui se passe lorsque le code est évalué. Les
-      commentaires sont en général des notes brèves, qui commencent après un `#` (dans
-      plusieurs langages de programmation)
+    term: commentaire
+    def: 'Texte écrit dans un script, qui n''est pas évalué lors de l''exécution du
+      code. Il est utilisé pour décrire ce qui se passe lorsque le code est évalué.
+      Les commentaires sont en général des notes brèves, qui commencent après un `#`
+      (dans plusieurs langages de programmation)
+
+      '
   pt:
-    term: "comentário"
-    def: >
-      Texto escrito em um script que não é tratado como código a ser executado, e sim
-      como texto que descreve o que o código está fazendo. Normalmente é formado por
-      notas curtas, frequentemente começando com um `#` (em várias linguagens de programação).
+    term: comentário
+    def: 'Texto escrito em um script que não é tratado como código a ser executado,
+      e sim como texto que descreve o que o código está fazendo. Normalmente é formado
+      por notas curtas, frequentemente começando com um `#` (em várias linguagens
+      de programação).
+
+      '
   de:
-    term: "Kommentar"
-    def: >
-      Anmerkungen in einem Programmcode oder Skript, die nicht vom Computer interpretiert oder ausgeführt werden. Kommentare dienen der Leserlichkeit und Dokumentation für Nutzer des Skripts. In vielen Programmiersprache werden Kommentare mit '#' am Zeilenanfang eingeleitet.
+    term: Kommentar
+    def: 'Anmerkungen in einem Programmcode oder Skript, die nicht vom Computer interpretiert
+      oder ausgeführt werden. Kommentare dienen der Leserlichkeit und Dokumentation
+      für Nutzer des Skripts. In vielen Programmiersprache werden Kommentare mit ''#''
+      am Zeilenanfang eingeleitet.
+
+      '
   am:
     term: አስተያየት
-    def: >
-      እንደ ኮድ ተደርጎ በማይታይ ጽሁፍ የተፃፈ ጽሑፍ ይልቁንስ ኮዱን ምን እያደረገ እንዳለ የሚገልጽ ጽሑፍ።  እነዚህ ብዙውን ጊዜ አጫጭር ማስታወሻዎች ናቸው፣ ብዙ ጊዜ በ '፩' (በብዙ የፕሮግራም ቋንቋዎች) መጀመር።
-  sw:
-    term: "maoni"
-    def: >
-      Maandishi yaliyoandikwa kwa hati ambayo hayachukuliwi kama kanuni ya kutekelezwa, lakini kama
-      maandishi ambayo yanaelezea kile kanuni hufanya nini. Mara nyingi, hati hizi huwa na maelezo mafupi,
-      yanayoanza na `#` (katika lugha nyingi za programu).
-  af:
-    term: "kommentaar"
-    def: >
-      Teks geskryf in 'n rekenaarprogram of skrif wat nie behandel word as kode wat uitgevoer moet word nie.
-      Die kommentaar beskryf eerder wat die kode doen. Kommentaar is gewoonlik kort notas, wat dikwels begin met 'n `#`
-      (in baie programmeertale).
-  uk:
-    term: "коментар"
-    def: >
-      Текст, написаний у вихідному коді, який не вважається кодом для виконання, а описує що цей код робить.
-      Зазвичай цей текст - короткі нотатки, які часто починаються з символу `#` (у багатьох мовах програмування).
+    def: 'እንደ ኮድ ተደርጎ በማይታይ ጽሁፍ የተፃፈ ጽሑፍ ይልቁንስ ኮዱን ምን እያደረገ እንዳለ የሚገልጽ ጽሑፍ።  እነዚህ
+      ብዙውን ጊዜ አጫጭር ማስታወሻዎች ናቸው፣ ብዙ ጊዜ በ ''፩'' (በብዙ የፕሮግራም ቋንቋዎች) መጀመር።
 
+      '
+  sw:
+    term: maoni
+    def: 'Maandishi yaliyoandikwa kwa hati ambayo hayachukuliwi kama kanuni ya kutekelezwa,
+      lakini kama maandishi ambayo yanaelezea kile kanuni hufanya nini. Mara nyingi,
+      hati hizi huwa na maelezo mafupi, yanayoanza na `#` (katika lugha nyingi za
+      programu).
+
+      '
+  af:
+    term: kommentaar
+    def: 'Teks geskryf in ''n rekenaarprogram of skrif wat nie behandel word as kode
+      wat uitgevoer moet word nie. Die kommentaar beskryf eerder wat die kode doen.
+      Kommentaar is gewoonlik kort notas, wat dikwels begin met ''n `#` (in baie programmeertale).
+
+      '
+  uk:
+    term: коментар
+    def: 'Текст, написаний у вихідному коді, який не вважається кодом для виконання,
+      а описує що цей код робить. Зазвичай цей текст - короткі нотатки, які часто
+      починаються з символу `#` (у багатьох мовах програмування).
+
+      '
 - slug: commit
   en:
-    term: "commit"
-    def: >
-      As a verb, the act of saving a set of changes to a database or [version control](#version_control_system)
-      [repository](#repository). As a noun, the changes saved.
+    term: commit
+    def: 'As a verb, the act of saving a set of changes to a database or [version
+      control](#version_control_system) [repository](#repository). As a noun, the
+      changes saved.
+
+      '
   am:
     term: ቃል
-    def: >
-      እንደ ግስ፣ በዳታቤዝ ወይም በ[ቨርዥን መቆጣጠሪያ](#version_control_system) ላይ የተወሰኑ ለውጦችን የማስቀመጥ ተግባር [መዝገበ](#repository) ::እነዚህ ለውጦች እንደ ስም ተቀምጠዋል ።
-  uk:
-    term: "коміт"
-    def: >
-      Зробити коміт - зберегти набір змін до бази даних або [репозиторію](#repository)
-      [системи контролю версій](#version_control_system).
-      У цьому випадку, збережені зміни називаються комітом.
+    def: 'እንደ ግስ፣ በዳታቤዝ ወይም በ[ቨርዥን መቆጣጠሪያ](#version_control_system) ላይ የተወሰኑ ለውጦችን
+      የማስቀመጥ ተግባር [መዝገበ](#repository) ::እነዚህ ለውጦች እንደ ስም ተቀምጠዋል ።
 
+      '
+  uk:
+    term: коміт
+    def: 'Зробити коміт - зберегти набір змін до бази даних або [репозиторію](#repository)
+      [системи контролю версій](#version_control_system). У цьому випадку, збережені
+      зміни називаються комітом.
+
+      '
 - slug: commit_message
   en:
-    term: "commit message"
-    def: >
-      A comment attached to a [commit](#commit) that explains what was done and why.
+    term: commit message
+    def: 'A comment attached to a [commit](#commit) that explains what was done and
+      why.
+
+      '
   am:
     term: ቃል መልዕክት
-    def: >
-      ምን እንደተከናወነና ለምን እንደሆነ የሚያብራራ [commit](#commit) ላይ የተጠቀሰ ሐሳብ።
-  uk:
-    term: "повідомлення коміту"
-    def: >
-      Коментар, доданий до [коміту](#commit), який пояснює, які зміни було зроблено та чому.
+    def: 'ምን እንደተከናወነና ለምን እንደሆነ የሚያብራራ [commit](#commit) ላይ የተጠቀሰ ሐሳብ።
 
+      '
+  uk:
+    term: повідомлення коміту
+    def: 'Коментар, доданий до [коміту](#commit), який пояснює, які зміни було зроблено
+      та чому.
+
+      '
 - slug: compile
   en:
-    term: "compile"
-    def: >
-      To translate textual source into another form. Programs in [compiled
-      languages](#compiled_language) are translated into machine instructions for a
-      computer to run, and [Markdown](#markdown) is usually translated into
-      [HTML](#html) for display.
+    term: compile
+    def: 'To translate textual source into another form. Programs in [compiled languages](#compiled_language)
+      are translated into machine instructions for a computer to run, and [Markdown](#markdown)
+      is usually translated into [HTML](#html) for display.
+
+      '
   am:
     term: ያቀናበረው ንረት
-    def: >
-      የጽሁፍ ምንጭን ወደ ሌላ መልክ ለመተርጎም። ፕሮግራሞች በ[የተጠናቀረ] ቋንቋዎች](#compiled_language) ለa ማሽን መመሪያዎች ይተረጎማሉ ኮምፒዩተር ሊሰራ ና [Markdown](#markdown) ብዙ ጊዜ ይተረጎማል [HTML](#html) ለእይታ።
-  uk:
-    term: "компілювати"
-    def: >
-      Перетворювати текст або програмний код в іншу форму. Програми у
-      [компільованих мовах](#compiled_language) перетворюються на машинні
-      інструкції для виконання комп'ютером, а текст у форматі [Markdown](#markdown)
-      зазвичай перетворюється у [HTML](#html) для відображення на вебсторінках.
+    def: 'የጽሁፍ ምንጭን ወደ ሌላ መልክ ለመተርጎም። ፕሮግራሞች በ[የተጠናቀረ] ቋንቋዎች](#compiled_language)
+      ለa ማሽን መመሪያዎች ይተረጎማሉ ኮምፒዩተር ሊሰራ ና [Markdown](#markdown) ብዙ ጊዜ ይተረጎማል [HTML](#html)
+      ለእይታ።
 
+      '
+  uk:
+    term: компілювати
+    def: 'Перетворювати текст або програмний код в іншу форму. Програми у [компільованих
+      мовах](#compiled_language) перетворюються на машинні інструкції для виконання
+      комп''ютером, а текст у форматі [Markdown](#markdown) зазвичай перетворюється
+      у [HTML](#html) для відображення на вебсторінках.
+
+      '
 - slug: compiled_language
   en:
-    term: "compiled language"
-    def: >
-      Originally, a language such as C or Fortran that is translated into machine
+    term: compiled language
+    def: 'Originally, a language such as C or Fortran that is translated into machine
       instructions for execution. Languages such as Java are also compiled before
       execution, but into [byte code](#byte_code) instead of machine instructions,
       while [interpreted languages](#interpreted_language) like [Python](#python)
       are compiled to byte code on the fly.
+
+      '
   am:
     term: የተጠናቀረ ቋንቋ
-    def: >
-      መጀመርያ ወደ ማሽን የሚተረጎም እንደ ሲ ወይም ፎርትራን ያለ ቋንቋ የሞት ቅጣትን የሚወነጅሉ መመሪያዎች። እንደ ጃቫ ያሉ ቋንቋዎችም ከዚህ በፊት የተጠናቀሩ ናቸው አፈፃፀም, ነገር ግን በማሽን መመሪያ ይልቅ ወደ [ባይት ኮድ](#byte_code), ሲኾን [የተረጎሙት ቋንቋዎች](#interpreted_language) እንደ [ፓጥተን](#python) በራሪ ኮድ የተጠናቀሩ ናቸው።
-  uk:
-    term: "компільована мова"
-    def: >
-      Мова програмування, яка компілюється у машинний код (як, наприклад, C та Fortran)
-      або [байт-код](#byte_code) (як, наприклад, Java) перед виконанням програми.
-      На відміну від компільованих мов, [інтерпретовані мови](#interpreted_language), 
-      такі як [Python](#python), компілюються у машинний код безпосередньо під час виконання.
+    def: 'መጀመርያ ወደ ማሽን የሚተረጎም እንደ ሲ ወይም ፎርትራን ያለ ቋንቋ የሞት ቅጣትን የሚወነጅሉ መመሪያዎች። እንደ ጃቫ
+      ያሉ ቋንቋዎችም ከዚህ በፊት የተጠናቀሩ ናቸው አፈፃፀም, ነገር ግን በማሽን መመሪያ ይልቅ ወደ [ባይት ኮድ](#byte_code),
+      ሲኾን [የተረጎሙት ቋንቋዎች](#interpreted_language) እንደ [ፓጥተን](#python) በራሪ ኮድ የተጠናቀሩ
+      ናቸው።
 
+      '
+  uk:
+    term: компільована мова
+    def: 'Мова програмування, яка компілюється у машинний код (як, наприклад, C та
+      Fortran) або [байт-код](#byte_code) (як, наприклад, Java) перед виконанням програми.
+      На відміну від компільованих мов, [інтерпретовані мови](#interpreted_language),  такі
+      як [Python](#python), компілюються у машинний код безпосередньо під час виконання.
+
+      '
 - slug: compiler
   en:
-    term: "compiler"
-    def: >
-      An application that translates programs written in some languages into machine
+    term: compiler
+    def: 'An application that translates programs written in some languages into machine
       instructions or [byte code](#byte_code).
+
+      '
   ar:
-    term: "مُترجِم"
-    def: >
-      هو برنامج يقوم بترجمة النصوص المصدرية إلى أوامر ومعلومات يفهمها الحاسب لذلك
+    term: مُترجِم
+    def: 'هو برنامج يقوم بترجمة النصوص المصدرية إلى أوامر ومعلومات يفهمها الحاسب لذلك
       يُمكن للكمبيوتر فهم البرنامج وتشغيله دون استخدام برنامج البرمجة المستخدم لإنشائه
-      أو مايُسمى
-      [رموز البايت](#byte_code).
+      أو مايُسمى [رموز البايت](#byte_code).
+
+      '
   am:
     term: አጠናቃሪ
-    def: >
-      በአንዳንድ ቋንቋዎች የተጻፉ ፕሮግራሞችን ወደ ማሽን የሚተረጉም መተግበሪያ መመሪያዎች ወይም [ባይት ኮድ](#byte_code).
+    def: 'በአንዳንድ ቋንቋዎች የተጻፉ ፕሮግራሞችን ወደ ማሽን የሚተረጉም መተግበሪያ መመሪያዎች ወይም [ባይት ኮድ](#byte_code).
 
+      '
 - slug: computational_linguistics
   ref:
-    - nlp
+  - nlp
   en:
-    term: "computational linguistics"
-    def: >
-      The study or application of computational methods for [parsing](#parse) or understanding
-      human languages. Early approaches were algorithmic; most modern approaches are statistical.
+    term: computational linguistics
+    def: 'The study or application of computational methods for [parsing](#parse)
+      or understanding human languages. Early approaches were algorithmic; most modern
+      approaches are statistical.
+
+      '
   es:
-    term: "lingüística computacional"
-    def: >
-      El estudio o aplicación de métodos computacionales para procesamiento o entendimiento
-      de lenguajes humanos. Los primeros acercamientos fueron algorítmicos; la mayoría
-      de los acercamientos modernos son estadísticos.
+    term: lingüística computacional
+    def: 'El estudio o aplicación de métodos computacionales para procesamiento o
+      entendimiento de lenguajes humanos. Los primeros acercamientos fueron algorítmicos;
+      la mayoría de los acercamientos modernos son estadísticos.
+
+      '
   am:
     term: የሒሳብ ልሳነ-ቋንቋ
-    def: >
-      ለ[ፓርስቲንግ](#parse) ወይም ለመረዳት የሂሳብ ዘዴዎች ጥናት ወይም ተግባራዊነት የሰው ልጆች ቋንቋዎች ። የመጀመሪያ አቀራረቦች አልጎሪዝሚክ ነበሩ; አብዛኞቹ ዘመናዊ አቀራረቦች አኃዛዊ መረጃዎች ናቸው.
+    def: 'ለ[ፓርስቲንግ](#parse) ወይም ለመረዳት የሂሳብ ዘዴዎች ጥናት ወይም ተግባራዊነት የሰው ልጆች ቋንቋዎች ። የመጀመሪያ
+      አቀራረቦች አልጎሪዝሚክ ነበሩ; አብዛኞቹ ዘመናዊ አቀራረቦች አኃዛዊ መረጃዎች ናቸው.
+
+      '
   sw:
-    term: "isimu ya hesabu"
-    def: >
-      Utafiti au utumiaji wa mbinu za kukokotoa na [kuchanganua](#parse) au kuelewa lugha za binadamu. Mbinu za awali zilikuwa za algorithmic; mbinu nyingi za kisasa ni za takwimu.
+    term: isimu ya hesabu
+    def: 'Utafiti au utumiaji wa mbinu za kukokotoa na [kuchanganua](#parse) au kuelewa
+      lugha za binadamu. Mbinu za awali zilikuwa za algorithmic; mbinu nyingi za kisasa
+      ni za takwimu.
 
-
+      '
 - slug: computational_notebook
   en:
-    term: "computational notebook"
-    def: >
-      A combination of a document format that allows users to mix prose and code in a
-      single file, and an application that executes that code interactively and in
-      place. The [Jupyter Notebook](#jupyter_notebook) and [R Markdown](#r_markdown)
+    term: computational notebook
+    def: 'A combination of a document format that allows users to mix prose and code
+      in a single file, and an application that executes that code interactively and
+      in place. The [Jupyter Notebook](#jupyter_notebook) and [R Markdown](#r_markdown)
       files are both examples of computational notebooks.
+
+      '
   am:
     term: የሒሳብ ማስታወሻ ደብተር
-    def: >
-      ተጠቃሚዎች የጽሁፍ እና ኮድን በአንድ ውስጥ ለማቀላቀፍ የሚያስችል የሰነድ ቅርጸት ድምር ነጠላ ፋይል, እና ያንን ኮድ በተሳታፊነት እና ውስጥ የሚፈፅም መተግበሪያ ቦታ ።  የ[Jupyter Notebook](#jupyter_notebook) እና [R Markdown](#r_markdown) ፋይሎች ሁለቱም የሒሳብ ማስታወሻ ደብተሮች ምሳሌዎች ናቸው።
+    def: 'ተጠቃሚዎች የጽሁፍ እና ኮድን በአንድ ውስጥ ለማቀላቀፍ የሚያስችል የሰነድ ቅርጸት ድምር ነጠላ ፋይል, እና ያንን
+      ኮድ በተሳታፊነት እና ውስጥ የሚፈፅም መተግበሪያ ቦታ ።  የ[Jupyter Notebook](#jupyter_notebook)
+      እና [R Markdown](#r_markdown) ፋይሎች ሁለቱም የሒሳብ ማስታወሻ ደብተሮች ምሳሌዎች ናቸው።
 
+      '
 - slug: compute_shader
   ref:
-    - gpu
-    - shader
+  - gpu
+  - shader
   en:
-    term: "compute shader"
-    def: >
-      A general purpose [shader](#shader) program for use in parallel processing. Often used
-      for [machine learning](#machine_learning), simulations, and other fields which benifit
-      from parallel computation.
-  uk:
-    term: "обчислювальні шейдери"
-    def: >
-      [Шейдер](#shader) загального призначення для використання у паралельній обробці. Часто використовується
-      для [машинного навчання](#machine_learning), симуляцій та інших галузей, які отримують вигоду
-      від паралельних обчислень.
+    term: compute shader
+    def: 'A general purpose [shader](#shader) program for use in parallel processing.
+      Often used for [machine learning](#machine_learning), simulations, and other
+      fields which benifit from parallel computation.
 
+      '
+  uk:
+    term: обчислювальні шейдери
+    def: '[Шейдер](#shader) загального призначення для використання у паралельній
+      обробці. Часто використовується для [машинного навчання](#machine_learning),
+      симуляцій та інших галузей, які отримують вигоду від паралельних обчислень.
+
+      '
 - slug: concatenate
   ref:
-    - aggregation
-    - left_join
-    - right_join
+  - aggregation
+  - left_join
+  - right_join
   en:
-    term: "Concatenate"
-    acronym: "concat"
-    def: >
-      In general programming, to join two [strings](#string) or [collections](#collection) together.
-      In terms of data tables (for example, a [python](#python) pandas DataFrame or R tibble), append/stack
-      two tables by either columns (axis=1) or rows (axis=0) by end-to-end joining of data.
-  af:
-    term: "aaneenskakel"
-    def: >
-      Die aaneenskakeling van kolomme, rye of karakterstringe deur die samevoeging van data.
-  es:
-    term: "concatenar"
-    def: >
-      Añadir/apilar ya sea columnas (eje=1) o filas (eje=0) mediante la unión de datos de extremo a extremo. [Python](#python).
+    term: Concatenate
+    acronym: concat
+    def: 'In general programming, to join two [strings](#string) or [collections](#collection)
+      together. In terms of data tables (for example, a [python](#python) pandas DataFrame
+      or R tibble), append/stack two tables by either columns (axis=1) or rows (axis=0)
+      by end-to-end joining of data.
 
+      '
+  af:
+    term: aaneenskakel
+    def: 'Die aaneenskakeling van kolomme, rye of karakterstringe deur die samevoeging
+      van data.
+
+      '
+  es:
+    term: concatenar
+    def: 'Añadir/apilar ya sea columnas (eje=1) o filas (eje=0) mediante la unión
+      de datos de extremo a extremo. [Python](#python).
+
+      '
 - slug: conda
   ref:
-    - pip
-    - anaconda
+  - pip
+  - anaconda
   en:
-    term: "conda"
-    def: >
-      A [package manager](#package_manager) and environment management system, particularly popular for Python programs.
+    term: conda
+    def: 'A [package manager](#package_manager) and environment management system,
+      particularly popular for Python programs.
 
-
+      '
 - slug: condition
   ref:
-    - handle_condition
+  - handle_condition
   en:
-    term: "condition"
-    def: >
-      An error or other unexpected event that disrupts the normal flow of control.
+    term: condition
+    def: 'An error or other unexpected event that disrupts the normal flow of control.
+
+      '
   af:
-    term: "toestand"
-    def: >
-      'n Fout of ander onverwagte gebeurtenis wat die normale vloei van beheer ontwrig.
+    term: toestand
+    def: '''n Fout of ander onverwagte gebeurtenis wat die normale vloei van beheer
+      ontwrig.
+
+      '
   sw:
-    term: "hali"
-    def: >
-      Hitilafu au tukio lingine lisilotarajiwa ambalo linatatiza mtiririko wa kawaida wa udhibiti.
+    term: hali
+    def: 'Hitilafu au tukio lingine lisilotarajiwa ambalo linatatiza mtiririko wa
+      kawaida wa udhibiti.
+
+      '
   am:
     term: ሁኔታ
-    def: >
-      የተለመደውን የመቆጣጠሪያ ፍሰት የሚያደናቅፍ ስህተት ወይም ሌላ ያልተጠበቀ ክስተት።
+    def: 'የተለመደውን የመቆጣጠሪያ ፍሰት የሚያደናቅፍ ስህተት ወይም ሌላ ያልተጠበቀ ክስተት።
 
+      '
 - slug: conditional_expression
   en:
-    term: "conditional expression"
-    def: >
-      A [ternary expression](#ternary_expression) that serves the role of an if/else
-      statement. For example, C and similar languages use the syntax `test : ifTrue ?
-      ifFalse` to mean "choose the value `ifTrue` if `test` is true, or the value
+    term: conditional expression
+    def: 'A [ternary expression](#ternary_expression) that serves the role of an if/else
+      statement. For example, C and similar languages use the syntax `test : ifTrue
+      ? ifFalse` to mean "choose the value `ifTrue` if `test` is true, or the value
       `ifFalse` if it is not."
+
+      '
   am:
     term: የሁኔታዎች አገላለጽ
-    def: >
-      የአንድን /ሌላ) ሚና የሚያገለግል [ተርናሪ መግለጫ](#ternary_expression) መግለጫ።  ለምሳሌ C እና ተመሳሳይ ቋንቋዎች የsyntax 'ፈተና ይጠቀሙ እውነትከሆነ ? ውሸትከሆነ ' ማለት"'ፈተና' እውነት ከሆነ 'ifTrue' የሚለውን ዋጋ ምረጥ ወይም ዋጋው ካልሆነ 'የውሸት' ነው".
+    def: 'የአንድን /ሌላ) ሚና የሚያገለግል [ተርናሪ መግለጫ](#ternary_expression) መግለጫ።  ለምሳሌ C እና
+      ተመሳሳይ ቋንቋዎች የsyntax ''ፈተና ይጠቀሙ እውነትከሆነ ? ውሸትከሆነ '' ማለት"''ፈተና'' እውነት ከሆነ ''ifTrue''
+      የሚለውን ዋጋ ምረጥ ወይም ዋጋው ካልሆነ ''የውሸት'' ነው".
 
+      '
 - slug: confidence_interval
   en:
-    term: "confidence interval"
-    def: >
-      A range around an estimate that indicates the margin of error, combined with a
-      probability that the actual value falls in that range.
+    term: confidence interval
+    def: 'A range around an estimate that indicates the margin of error, combined
+      with a probability that the actual value falls in that range.
+
+      '
   af:
-    term: "vertrouensinterval"
-    def: >
-      'n Variasiewydte rondom 'n beraming wat'n foutgrens aandui, gekombineerd met die waarskynlikheid
-       dat die werklike getal binne die skatting val.
+    term: vertrouensinterval
+    def: "'n Variasiewydte rondom 'n beraming wat'n foutgrens aandui, gekombineerd\
+      \ met die waarskynlikheid\n dat die werklike getal binne die skatting val.\n"
   am:
     term: በራስ የመተማመን ጊዜ
-    def: >
-      የስህተቱን ኅዳግ ከሚጠቁም ግምት ዙሪያ የሚገኝ ክልል፣ ከa ጋር ተደምሮ ትክክለኛው ዋጋ በዚህ ክልል ውስጥ የመውደቁ አጋጣሚ ሰፊ ነው።
+    def: 'የስህተቱን ኅዳግ ከሚጠቁም ግምት ዙሪያ የሚገኝ ክልል፣ ከa ጋር ተደምሮ ትክክለኛው ዋጋ በዚህ ክልል ውስጥ የመውደቁ
+      አጋጣሚ ሰፊ ነው።
+
+      '
   ar:
-    term: "فترة الثقة"
-    def: >
-      فترة الثقة تتكون من التقدير المعلمة وهامش الخطأ, وهي الفترة التي نثق بأن قيمة التقدير تكون داخل هذه الفترة
+    term: فترة الثقة
+    def: 'فترة الثقة تتكون من التقدير المعلمة وهامش الخطأ, وهي الفترة التي نثق بأن
+      قيمة التقدير تكون داخل هذه الفترة
+
+      '
   uk:
-    term: "довірчий інтервал"
-    def: >
-      Діапазон, в якому з заданою ймовірністю знаходиться реальне значення оцінки.
-  
+    term: довірчий інтервал
+    def: 'Діапазон, в якому з заданою ймовірністю знаходиться реальне значення оцінки.
+
+      '
 - slug: configuration_file
   en:
-    term: "configuration file"
-    def: >
-      A file that specifies the parameters and initial settings of a software program.
-      Configuration, or config, files are often used for information subject to changes,
-      such as environment-specific settings.
+    term: configuration file
+    def: 'A file that specifies the parameters and initial settings of a software
+      program. Configuration, or config, files are often used for information subject
+      to changes, such as environment-specific settings.
+
+      '
   am:
     term: የቅንብር ፋይል
-    def: >
-      የሶፍትዌሩን ፕሮግራም መስፈሪያዎች እና የመጀመሪያ አቀማመዶች የሚወስን ፋይል. ቅንብር ወይም config, ፋይሎች ብዙውን ጊዜ ለውጦች ለሚታዩበት መረጃ ጥቅም ላይ ይውላሉ, እንደ አካባቢ-የተለየ አቀማመጥ.
+    def: 'የሶፍትዌሩን ፕሮግራም መስፈሪያዎች እና የመጀመሪያ አቀማመዶች የሚወስን ፋይል. ቅንብር ወይም config, ፋይሎች
+      ብዙውን ጊዜ ለውጦች ለሚታዩበት መረጃ ጥቅም ላይ ይውላሉ, እንደ አካባቢ-የተለየ አቀማመጥ.
+
+      '
   sw:
-    term: "faili ya usanidi"
-    def: >
-      Faili inayobainisha vigezo na mipangilio ya awali ya programu. Faili ya usanidi hutumiwa kwa habari  zinazobadilika mara nyingi,
-      kama vile mipangilio iambatanayo ya mazingira.
+    term: faili ya usanidi
+    def: 'Faili inayobainisha vigezo na mipangilio ya awali ya programu. Faili ya
+      usanidi hutumiwa kwa habari  zinazobadilika mara nyingi, kama vile mipangilio
+      iambatanayo ya mazingira.
 
-
-- slug: console
-  en:
-    term: "console"
-    def: >
-      A computer terminal where a user may enter commands, or a program, such as a shell
-      that simulates such a device.
-  am:
-    term: ኮንሶል
-    def: >
-      አንድ ተጠቃሚ ትዕዛዞች ሊገባበት የሚችልበት የኮምፒውተር ተርሚናል ወይም እንደ ዛጎል ያለ ፕሮግራም እንዲህ ያለውን መሣሪያ የሚኮርጅ ነው።
-  sw:
-    term: "koni ya kompyuta"
-    def: >
-      Kituo cha kompyuta ambapo mtumiaji anaweza kuingiza amri, au programu, kama vile shell
-      ambayo huiga kifaa kama hicho.
-  uk:
-    term: "консоль"
-    def: >
-      Комп'ютерний термінал, де користувач може вводити команди, або програма,
-      яка імітує такий пристрій, наприклад, [командна оболонка](#shell).
-
+      '
 - slug: confusion_matrix
   en:
-    term: "confusion matrix"
-    def: >
-      A NxN matrix that describes the performance of a classification model, where N is the number
-      of classes or outputs. Each row in the matrix represents the instances of actual classes and each column
-      represents the predicted classes. For a binary classification model the confusion matrix
-      gives the True Positives (TP), False Negatives (FN), False Positives (FP) and True Negatives
-      (TN) in the 1st, 2nd, 3rd and 4th quadrants, respectively. The table can be used to calculate
-      [Accuracy](#accuracy), [Sensitivity](#sensitivity) and [Specificity](#specificity) amongst other measures of the model.
+    term: confusion matrix
+    def: 'A NxN matrix that describes the performance of a classification model, where
+      N is the number of classes or outputs. Each row in the matrix represents the
+      instances of actual classes and each column represents the predicted classes.
+      For a binary classification model the confusion matrix gives the True Positives
+      (TP), False Negatives (FN), False Positives (FP) and True Negatives (TN) in
+      the 1st, 2nd, 3rd and 4th quadrants, respectively. The table can be used to
+      calculate [Accuracy](#accuracy), [Sensitivity](#sensitivity) and [Specificity](#specificity)
+      amongst other measures of the model.
 
+      '
+- slug: console
+  en:
+    term: console
+    def: 'A computer terminal where a user may enter commands, or a program, such
+      as a shell that simulates such a device.
+
+      '
+  am:
+    term: ኮንሶል
+    def: 'አንድ ተጠቃሚ ትዕዛዞች ሊገባበት የሚችልበት የኮምፒውተር ተርሚናል ወይም እንደ ዛጎል ያለ ፕሮግራም እንዲህ ያለውን
+      መሣሪያ የሚኮርጅ ነው።
+
+      '
+  sw:
+    term: koni ya kompyuta
+    def: 'Kituo cha kompyuta ambapo mtumiaji anaweza kuingiza amri, au programu, kama
+      vile shell ambayo huiga kifaa kama hicho.
+
+      '
+  uk:
+    term: консоль
+    def: 'Комп''ютерний термінал, де користувач може вводити команди, або програма,
+      яка імітує такий пристрій, наприклад, [командна оболонка](#shell).
+
+      '
 - slug: constant
   en:
-    term: "constant"
-    def: >
-      A constant in programming is a name associated with a value that never changes during the execution of a program. You can only access the constant’s value but not change it over time, as opposed to a [variable](#variable_program)
+    term: constant
+    def: 'A constant in programming is a name associated with a value that never changes
+      during the execution of a program. You can only access the constant’s value
+      but not change it over time, as opposed to a [variable](#variable_program)
+
+      '
   fr:
-    term: "constante"
-    def: >
-      Une valeur qui ne peut pas être modifiée après avoir été définie, par opposition à une [variable](#variable_program).
+    term: constante
+    def: 'Une valeur qui ne peut pas être modifiée après avoir été définie, par opposition
+      à une [variable](#variable_program).
+
+      '
   ar:
-    term: "الثابت"
-    def: >
-      قيمة عددية ثابتة لا يمكن أن تتغير وهي عكس المتغير الذي يمكن أن يأخذ أكثر من قيمة.
+    term: الثابت
+    def: 'قيمة عددية ثابتة لا يمكن أن تتغير وهي عكس المتغير الذي يمكن أن يأخذ أكثر
+      من قيمة.
+
+      '
   sw:
-    term: "thabiti"
-    def: >
-      Thamani ambayo haiwezi kubadilishwa baada ya kubainishwa,
-      ukilinganisha na [kigeu](#variable_program) ambayo hubadilika.
+    term: thabiti
+    def: 'Thamani ambayo haiwezi kubadilishwa baada ya kubainishwa, ukilinganisha
+      na [kigeu](#variable_program) ambayo hubadilika.
+
+      '
   es:
-    term: "constante"
-    def: >
-      Una constante en programación es un nombre asociado con un valor que nunca cambia durante la ejecución de un programa. Solo se puede acceder al valor de la constante, pero no cambiarlo con el tiempo. En oposición a una [variable](#variable_program).
-      # Un valor que no puede ser cambiado después de haber sido definido, opuesto a lo que es una [variable](#variable_program).
+    term: constante
+    def: 'Una constante en programación es un nombre asociado con un valor que nunca
+      cambia durante la ejecución de un programa. Solo se puede acceder al valor de
+      la constante, pero no cambiarlo con el tiempo. En oposición a una [variable](#variable_program).
+      # Un valor que no puede ser cambiado después de haber sido definido, opuesto
+      a lo que es una [variable](#variable_program).
 
-
+      '
 - slug: constructor
   en:
-    term: "constructor"
-    def: >
-      A function that creates an [object](#object) of a particular
-      [class](#class). In the [S3](#s3) object system, constructors are a
-      convention rather than a requirement.
+    term: constructor
+    def: 'A function that creates an [object](#object) of a particular [class](#class).
+      In the [S3](#s3) object system, constructors are a convention rather than a
+      requirement.
+
+      '
   es:
-    term: "constructor"
-    def: >
-      Una función que crea un [objeto](#object) de una [clase](#class)
-      particular. En el sistema de objetos de [S3](#s3), los constructores
-      son más una convención que un requisito.
+    term: constructor
+    def: 'Una función que crea un [objeto](#object) de una [clase](#class) particular.
+      En el sistema de objetos de [S3](#s3), los constructores son más una convención
+      que un requisito.
+
+      '
   am:
     term: ገንቢ
-    def: >
-      የአንድ የተለየ [ዕቃ](#object) የሚፈጥር ተግባር [ክፍል](#class)::  በ[S3](#s3) ከግዴታ ይልቅ የአውራጃ ስብሰባ የእቃ ስርዓት ውስጥ ገንቢዎች ናቸው ::
+    def: 'የአንድ የተለየ [ዕቃ](#object) የሚፈጥር ተግባር [ክፍል](#class)::  በ[S3](#s3) ከግዴታ ይልቅ
+      የአውራጃ ስብሰባ የእቃ ስርዓት ውስጥ ገንቢዎች ናቸው ::
 
+      '
 - slug: continuation_prompt
   en:
-    term: "continuation prompt"
-    def: >
-      A [prompt](#prompt) that indicates that the command currently being typed is not
-      yet complete, and will not be run until it is.
+    term: continuation prompt
+    def: 'A [prompt](#prompt) that indicates that the command currently being typed
+      is not yet complete, and will not be run until it is.
+
+      '
   am:
     term: ቀጣይነት ያለው እርምጃ
-    def: >
-      በአሁኑ ጊዜ እየተለፈፈ ያለው ትዕዛዝ አለመሆኑን የሚያመለክት [አፋጣኝ](#prompt) ገና ሙሉ እስከሆነ ድረስ አይሮጥም
-  sw:
-    term: "kishawishi endelevu"
-    def: >
-       [kishawishi](#prompt) kinachoashiria kwamba amri inayochapwa kwa sasa bado haijakamilika,
-       na itaendeshwa mara tu itakapokamilika.
+    def: 'በአሁኑ ጊዜ እየተለፈፈ ያለው ትዕዛዝ አለመሆኑን የሚያመለክት [አፋጣኝ](#prompt) ገና ሙሉ እስከሆነ ድረስ አይሮጥም
 
+      '
+  sw:
+    term: kishawishi endelevu
+    def: '[kishawishi](#prompt) kinachoashiria kwamba amri inayochapwa kwa sasa bado
+      haijakamilika, na itaendeshwa mara tu itakapokamilika.
+
+      '
 - slug: continuous_integration
   en:
-    term: "continuous integration"
-    def: >
-      A software development practice in which changes are automatically merged as
-      soon as they become available.
+    term: continuous integration
+    def: 'A software development practice in which changes are automatically merged
+      as soon as they become available.
 
-
+      '
 - slug: continuous_random_variable
   ref:
-    - discrete_random_variable
+  - discrete_random_variable
   en:
-    term: "continuous random variable"
-    def: >
-      A [variable](#variable_data) whose value can be any real value, either
-      within a range, or unbounded, such as age or distance.
+    term: continuous random variable
+    def: 'A [variable](#variable_data) whose value can be any real value, either within
+      a range, or unbounded, such as age or distance.
+
+      '
   am:
     term: ቀጣይ ድንገተኛ ተለዋዋጭ
-    def: >
-      ዋጋው ማንኛውም እውነተኛ ዋጋ ሊኖረው የሚችል [ተለዋዋጭ](#variable_data) ሁለቱም እንደ ዕድሜ ወይም ርቀት ባሉ የተለያዩ ወይም ገደብ የሌላቸው ነገሮች ውስጥ ነው።
+    def: 'ዋጋው ማንኛውም እውነተኛ ዋጋ ሊኖረው የሚችል [ተለዋዋጭ](#variable_data) ሁለቱም እንደ ዕድሜ ወይም ርቀት
+      ባሉ የተለያዩ ወይም ገደብ የሌላቸው ነገሮች ውስጥ ነው።
 
+      '
 - slug: control_flow
   en:
-    term: "control flow"
-    def: >
-      The logical flow through a program's code. May be linear (i.e. just a series of
-      commands), but may also include [loops](#loop) or conditional execution (i.e. if
-      a condition is met).
+    term: control flow
+    def: 'The logical flow through a program''s code. May be linear (i.e. just a series
+      of commands), but may also include [loops](#loop) or conditional execution (i.e.
+      if a condition is met).
 
-
+      '
 - slug: copy_on_modify
   ref:
-    - aliasing
+  - aliasing
   en:
-    term: "copy-on-modify"
-    def: >
-      The practice of creating a new copy of aliased data whenever there is an attempt
-      to modify it so that each reference will believe theirs is the only one.
+    term: copy-on-modify
+    def: 'The practice of creating a new copy of aliased data whenever there is an
+      attempt to modify it so that each reference will believe theirs is the only
+      one.
+
+      '
   am:
     term: ኮፒ በ ማስተካከያ
-    def: >
-      ሙከራ በሚኖርበት ጊዜ ሁሉ አዲስ የተሰሩ መረጃዎችን የመፍጠር ልማድ እያንዳንዱ ማመሳከሪያ የእነርሱ ብቻ መሆኑን እንዲያምን የማስተካከል ሂደት ነዉ።
+    def: 'ሙከራ በሚኖርበት ጊዜ ሁሉ አዲስ የተሰሩ መረጃዎችን የመፍጠር ልማድ እያንዳንዱ ማመሳከሪያ የእነርሱ ብቻ መሆኑን እንዲያምን
+      የማስተካከል ሂደት ነዉ።
 
+      '
 - slug: correlation
   en:
-    term: "correlation"
-    def: >
-      A measure of how well two variables agree with each other. Correlation is usually measured by
-      calculating a [correlation coefficient](#correlation_coefficient), and does not
-      imply [causation](#causation).
+    term: correlation
+    def: 'A measure of how well two variables agree with each other. Correlation is
+      usually measured by calculating a [correlation coefficient](#correlation_coefficient),
+      and does not imply [causation](#causation).
+
+      '
   pt:
-    term: "correlação"
-    def: >
-      O quão bem duas variáveis concordam uma com a outra. A correlação é normalmente
+    term: correlação
+    def: 'O quão bem duas variáveis concordam uma com a outra. A correlação é normalmente
       medida pelo cálculo de um [coeficiente de correlação](#correlation_coefficient),
       e não significa que precise existir causalidade.
+
+      '
   af:
-    term: "korrelasie"
-    def: >
-      Hoe sterk twee veranderlikes met mekaar ooreenstem. Korrelasie word gewoonlik gemeet aan
-      die berekening van 'n [korrelasiekoëffisiënt](#correlation_coefficient), maar
-      impliseer nie oorsaaklikheid.
+    term: korrelasie
+    def: 'Hoe sterk twee veranderlikes met mekaar ooreenstem. Korrelasie word gewoonlik
+      gemeet aan die berekening van ''n [korrelasiekoëffisiënt](#correlation_coefficient),
+      maar impliseer nie oorsaaklikheid.
+
+      '
   fr:
-    term: "corrélation"
-    def: >
-      Mesure à quel point deux variables sont en accord l'une avec l'autre. La corrélation
-      est habituellement mesurée en calculant un [coefficient de corrélation](#correlation_coefficient)
-      et n'implique pas nécessairement un lien de [causalité](#causation).
+    term: corrélation
+    def: 'Mesure à quel point deux variables sont en accord l''une avec l''autre.
+      La corrélation est habituellement mesurée en calculant un [coefficient de corrélation](#correlation_coefficient)
+      et n''implique pas nécessairement un lien de [causalité](#causation).
+
+      '
   am:
     term: ተዛማጅነት
-    def: >
-      ሁለት መለዋወጫዎች እርስ በርስ ምን ያህል እንደሚስማሙ የሚያሳይ ልኬት ነዉ። ተዛማጅነት አብዛኛውን ጊዜ የሚለካው አንድን [የዝምድና ቅንጅት](#correlation_coefficient) ማስላት፣ እናም አይደለም [#ምክንያት](#causation) ማለት ነው።
+    def: 'ሁለት መለዋወጫዎች እርስ በርስ ምን ያህል እንደሚስማሙ የሚያሳይ ልኬት ነዉ። ተዛማጅነት አብዛኛውን ጊዜ የሚለካው
+      አንድን [የዝምድና ቅንጅት](#correlation_coefficient) ማስላት፣ እናም አይደለም [#ምክንያት](#causation)
+      ማለት ነው።
+
+      '
   ar:
-    term: "constant"
-    def: >
-      مقياس يوضح مدى ارتباط وقوةالعلاقة بين متغيرين ويتم حسابه بايجاد قيمة معامل الارتباط الذي تترواح قيمته بين 1-و +1.
+    term: constant
+    def: 'مقياس يوضح مدى ارتباط وقوةالعلاقة بين متغيرين ويتم حسابه بايجاد قيمة معامل
+      الارتباط الذي تترواح قيمته بين 1-و +1.
+
+      '
   es:
-    term: "correlación"
-    def: >
-      Una medida de cuán bien dos variables están de acuerdo una con la otra. La correlación usualmente se mide
-      calculando un [coeficiente de correlación](#correlation_coefficient), y no implica
-      [causalidad](#causation).
+    term: correlación
+    def: 'Una medida de cuán bien dos variables están de acuerdo una con la otra.
+      La correlación usualmente se mide calculando un [coeficiente de correlación](#correlation_coefficient),
+      y no implica [causalidad](#causation).
+
+      '
   uk:
-    term: "кореляція"
-    def: >
-      Статистична взаємозалежність або співвідношення між двома випадковами змінними.
-      Кореляція зазвичай вимірюється за допомогою [коефіцієнта кореляції](#correlation_coefficient), 
-      і не передбачає [причинно-наслідкового зв'язку](#causation).
-      
+    term: кореляція
+    def: 'Статистична взаємозалежність або співвідношення між двома випадковами змінними.
+      Кореляція зазвичай вимірюється за допомогою [коефіцієнта кореляції](#correlation_coefficient),  і
+      не передбачає [причинно-наслідкового зв''язку](#causation).
+
+      '
 - slug: correlation_coefficient
   en:
-    term: "correlation coefficient"
-    def: >
-      A measure of how well-[correlated](#correlation) two variables are. If the
+    term: correlation coefficient
+    def: 'A measure of how well-[correlated](#correlation) two variables are. If the
       [correlation coefficient](#correlation_coefficient) between X and Y is 1.0,
-      knowing X allows perfect prediction of Y. If the correlation coefficient is 0.0,
-      knowing X tells you nothing about Y, and if it is -1.0, then X predicts Y, but
-      a change in X causes an opposite change in Y.
+      knowing X allows perfect prediction of Y. If the correlation coefficient is
+      0.0, knowing X tells you nothing about Y, and if it is -1.0, then X predicts
+      Y, but a change in X causes an opposite change in Y.
+
+      '
   pt:
-    term: "coeficiente de correlação"
-    def: >
-      Uma medida do quão bem duas variáveis estão [correlacionadas](#correlation). Se
-      o [coeficiente de correlação](#correlation_coefficient) entre X e Y for 1.0,
+    term: coeficiente de correlação
+    def: 'Uma medida do quão bem duas variáveis estão [correlacionadas](#correlation).
+      Se o [coeficiente de correlação](#correlation_coefficient) entre X e Y for 1.0,
       conhecer X permite uma previsão perfeita de Y. Se o coeficiente de correlação
       for 0.0, conhecer X não diz nada a respeito de Y, e se for -1.0, então X prevê
       Y, mas mudanças no valor de X gera uma mudança oposta em Y.
+
+      '
   af:
-    term: "korrelasiekoëffisiënt"
-    def: >
-      'n Maatstaf van hoe sterk [gekorreleer](#correlation) twee veranderlikes is. As die
-      korrelasiekoëffisiënt tussen X en Y gelyk is aan 1.0,
-      dui dit aan dat X die perfekte voorspelling van Y is. As die korrelasiekoëffisiënt
-      0,0 is, dui dit aan dat X nie verwant is aan Y nie. As dit -1,0 is, dan voorspel
-      X vir Y, maar verandering in X veroorsaak 'n teenoorgestelde verandering in Y.
+    term: korrelasiekoëffisiënt
+    def: '''n Maatstaf van hoe sterk [gekorreleer](#correlation) twee veranderlikes
+      is. As die korrelasiekoëffisiënt tussen X en Y gelyk is aan 1.0, dui dit aan
+      dat X die perfekte voorspelling van Y is. As die korrelasiekoëffisiënt 0,0 is,
+      dui dit aan dat X nie verwant is aan Y nie. As dit -1,0 is, dan voorspel X vir
+      Y, maar verandering in X veroorsaak ''n teenoorgestelde verandering in Y.
+
+      '
   am:
     term: የግንኙነት መጠን
-    def: >
-      ሁለት ተለዋዋጮች ምን ያህል በጥሩ ሁኔታ [[ተዛማጅ](#correlation) ልኬት ናቸው። ከሆነ እ.ኤ.አ. በ ኤክስ እና በ ዋይ መካከል [ትስስር Coefficient](#correlation_coefficient) 1.0 ፣ ኤክስን ማወቅ የ ዋይ ን ፍጹም ትንበያ ይፈቅዳል ፡፡ የግንኙነቱ መጠን 0.0 ከሆነ ፣ ኤክስ ን ማወቅ ስለ ዋይ ምንም አይነግርዎትም ፣ እና -1.0 ከሆነ ፣ ከዚያ ኤክስ ይተነብያል ፣ ግን የ ኤክስ ለውጥ በ ‹ዋይ› ተቃራኒ ለውጥ ያስከትላል ፡፡
+    def: 'ሁለት ተለዋዋጮች ምን ያህል በጥሩ ሁኔታ [[ተዛማጅ](#correlation) ልኬት ናቸው። ከሆነ እ.ኤ.አ. በ ኤክስ
+      እና በ ዋይ መካከል [ትስስር Coefficient](#correlation_coefficient) 1.0 ፣ ኤክስን ማወቅ የ ዋይ
+      ን ፍጹም ትንበያ ይፈቅዳል ፡፡ የግንኙነቱ መጠን 0.0 ከሆነ ፣ ኤክስ ን ማወቅ ስለ ዋይ ምንም አይነግርዎትም ፣ እና -1.0
+      ከሆነ ፣ ከዚያ ኤክስ ይተነብያል ፣ ግን የ ኤክስ ለውጥ በ ‹ዋይ› ተቃራኒ ለውጥ ያስከትላል ፡፡
+
+      '
   fr:
-    term: "coefficient de corrélation"
-    def: >
-      Une mesure de la [corrélation](#correlation) entre deux variables.
-      Si le [coefficient de corrélation](#correlation_coefficient) entre X et Y vaut 1.0,
-      alors connaître X permet de connaître parfaitement Y.
-      Si le [coefficient de corrélation](#correlation_coefficient) vaut 0.0,
-      alors connaître X ne nous dit rien sur Y.
-      Enfin, si le [coefficient de corrélation](#correlation_coefficient) vaut -1.0,
-      alors X permet de prédire Y, mais un changement en X cause un changement opposé sur Y.
+    term: coefficient de corrélation
+    def: 'Une mesure de la [corrélation](#correlation) entre deux variables. Si le
+      [coefficient de corrélation](#correlation_coefficient) entre X et Y vaut 1.0,
+      alors connaître X permet de connaître parfaitement Y. Si le [coefficient de
+      corrélation](#correlation_coefficient) vaut 0.0, alors connaître X ne nous dit
+      rien sur Y. Enfin, si le [coefficient de corrélation](#correlation_coefficient)
+      vaut -1.0, alors X permet de prédire Y, mais un changement en X cause un changement
+      opposé sur Y.
+
+      '
   uk:
-    term: "коефіцієнт кореляції"
-    def: >
-     Показник статистичного зв'язку [кореляції](#correlation) між двома змінними.
-     Якщо [коефіцієнт кореляції](#correlation_coefficient) між X та Y дорівнює 1.0,
-     то знання значення X дає змогу точно передбачити Y. 
-     За коефіцієнта кореляції 0.0 знання X не надає жодної інформації про Y. 
-     Якщо ж коефіцієнт дорівнює -1.0, то X прогнозує Y, але зміна X дозволяє передбачити протилежну зміну Y
-     (наприклад, якщо X збільшується, то Y зменшується, і навпаки).
-      
+    term: коефіцієнт кореляції
+    def: "Показник статистичного зв'язку [кореляції](#correlation) між двома змінними.\
+      \ Якщо [коефіцієнт кореляції](#correlation_coefficient) між X та Y дорівнює\
+      \ 1.0, то знання значення X дає змогу точно передбачити Y.  За коефіцієнта кореляції\
+      \ 0.0 знання X не надає жодної інформації про Y.  Якщо ж коефіцієнт дорівнює\
+      \ -1.0, то X прогнозує Y, але зміна X дозволяє передбачити протилежну зміну\
+      \ Y (наприклад, якщо X збільшується, то Y зменшується, і навпаки).\n \n"
 - slug: covariance
   en:
-    term: "covariance"
-    def: >
-      How well two variables agree with each other. The [correlation
-      coefficient](#correlation_coefficient) is a normalized measure of covariance.
+    term: covariance
+    def: 'How well two variables agree with each other. The [correlation coefficient](#correlation_coefficient)
+      is a normalized measure of covariance.
+
+      '
   pt:
-    term: "covariância"
-    def: >
-      O quão bem duas variáveis concordam uma com a outra. O [coeficiente de
-      correlação](#correlation_coefficient) é uma medida normalizada da covariância.
+    term: covariância
+    def: 'O quão bem duas variáveis concordam uma com a outra. O [coeficiente de correlação](#correlation_coefficient)
+      é uma medida normalizada da covariância.
+
+      '
   af:
-    term: "kovariansie"
-    def: >
-      Hoe goed twee veranderlikes met mekaar ooreenstem. Die
-      [korrelasiekoëffisiënt](#correlation_coefficient)
-      is 'n genormaliseerde maatstaf vir kovariansie.
+    term: kovariansie
+    def: 'Hoe goed twee veranderlikes met mekaar ooreenstem. Die [korrelasiekoëffisiënt](#correlation_coefficient)
+      is ''n genormaliseerde maatstaf vir kovariansie.
+
+      '
   am:
     term: መለዋወጥ
-    def: >
-      ሁለት ተለዋዋጮች እርስ በእርሳቸው እንዴት እንደተስማሙ ። ግንኙነቱ ትስስር](#correlation_coefficient) መደበኛ የሆነ የመለዋወጥ ልኬት ነው።
+    def: 'ሁለት ተለዋዋጮች እርስ በእርሳቸው እንዴት እንደተስማሙ ። ግንኙነቱ ትስስር](#correlation_coefficient)
+      መደበኛ የሆነ የመለዋወጥ ልኬት ነው።
+
+      '
   fr:
-    term: "covariance"
-    def: >
-      Mesure à quel point deux variables sont en accord l'une avec l'autre.
-      Le [coefficient de corrélation](#correlation_coefficient) est une mesure
-      normalisée de la covariance.
+    term: covariance
+    def: 'Mesure à quel point deux variables sont en accord l''une avec l''autre.
+      Le [coefficient de corrélation](#correlation_coefficient) est une mesure normalisée
+      de la covariance.
+
+      '
   uk:
-    term: "коваріація"
-    def: >
-      Cтатистичний показник, що відображає, як змінюються дві величини одночасно.
-      Якщо обидві зростають чи зменшуються разом - коваріація додатна, якщо одна
-      зростає, а інша зменшується - від’ємна.
-      Коваріація використовується для виявлення зв’язку між змінними, але не
-      нормується, тому не дозволяє точно оцінити силу цього зв’язку без
-      додаткових перетворень, наприклад, розрахунку
-      [коефіцієнта кореляції](#correlation_coefficient),
+    term: коваріація
+    def: 'Cтатистичний показник, що відображає, як змінюються дві величини одночасно.
+      Якщо обидві зростають чи зменшуються разом - коваріація додатна, якщо одна зростає,
+      а інша зменшується - від’ємна. Коваріація використовується для виявлення зв’язку
+      між змінними, але не нормується, тому не дозволяє точно оцінити силу цього зв’язку
+      без додаткових перетворень, наприклад, розрахунку [коефіцієнта кореляції](#correlation_coefficient),
       який є нормалізованим показником коваріації.
+
+      '
 - slug: cpu
   ref:
-    - gpu
+  - gpu
   en:
-    term: "Central Processing Unit"
-    acronym: "CPU"
-    def: >
-      The principal hardware of any digital computer. The CPU constitutes the
-      essential electronic circuitry that interprets and executes instructions
-      from the software or other hardware. Also called a central processor,
-      main processor, or microprocessor.
+    term: Central Processing Unit
+    acronym: CPU
+    def: 'The principal hardware of any digital computer. The CPU constitutes the
+      essential electronic circuitry that interprets and executes instructions from
+      the software or other hardware. Also called a central processor, main processor,
+      or microprocessor.
+
+      '
   af:
     term: Sentrale verwerkingseenheid
-    def: >
-      Dit is die primêre hardeware van enige rekenaar. Dit vorm die essensiële elektroniese stroombaan wat instruksies van die sagteware of ander hardeware interpreteer en uitvoer. Ook genoem 'n sentrale verwerker, hoofverwerker, of mikroverwerker.
-  de:
-    term: "Prozessor"
-    def: >
-      Die zentrale Recheneinheit eines jeden digitalen Computers. Der Prozessor ist eine elektronische Schaltung, die anhand von übergebenen Befehlen andere Maschinen oder elektrische Schaltungen steuert und Rechenoperationen ausführt. Wird auch als Hauptprozessor, Zentrale Recheneinheit, Zentraleinheit oder Zentrale Verarbeitungseinheit (kurz ZVE, englisch central processing unit, kurz CPU) bezeichnet.
+    def: 'Dit is die primêre hardeware van enige rekenaar. Dit vorm die essensiële
+      elektroniese stroombaan wat instruksies van die sagteware of ander hardeware
+      interpreteer en uitvoer. Ook genoem ''n sentrale verwerker, hoofverwerker, of
+      mikroverwerker.
 
+      '
+  de:
+    term: Prozessor
+    def: 'Die zentrale Recheneinheit eines jeden digitalen Computers. Der Prozessor
+      ist eine elektronische Schaltung, die anhand von übergebenen Befehlen andere
+      Maschinen oder elektrische Schaltungen steuert und Rechenoperationen ausführt.
+      Wird auch als Hauptprozessor, Zentrale Recheneinheit, Zentraleinheit oder Zentrale
+      Verarbeitungseinheit (kurz ZVE, englisch central processing unit, kurz CPU)
+      bezeichnet.
+
+      '
   am:
     term: ማዕከላዊ ማቀነባበሪያ ክፍል
-    def: >
-      የማንኛውም ዲጂታል ኮምፒውተር ዋና ሃርድዌር. ሲፒዩ ነው::  መመሪያዎችን የሚተረጉም እና የሚፈፅም አስፈላጊ የኤሌክትሮኒክ ስረሰር ከሶፍትዌሩ ወይም ከሌላ ሃርድዌር የተወሰደ።በተጨማሪም ማዕከላዊ ፕሮሲሰር ተብሎ ይጠራል፤ ዋና ፕሮሲሰር ወይም ማይክሮፕሮሰሰር ::
+    def: 'የማንኛውም ዲጂታል ኮምፒውተር ዋና ሃርድዌር. ሲፒዩ ነው::  መመሪያዎችን የሚተረጉም እና የሚፈፅም አስፈላጊ የኤሌክትሮኒክ
+      ስረሰር ከሶፍትዌሩ ወይም ከሌላ ሃርድዌር የተወሰደ።በተጨማሪም ማዕከላዊ ፕሮሲሰር ተብሎ ይጠራል፤ ዋና ፕሮሲሰር ወይም ማይክሮፕሮሰሰር
+      ::
 
+      '
   sw:
-    term: "Central Processing Unit"
-    def: >
-      Vifaa vikuu vya kompyuta yoyote ya dijitali inayojumuisha
-      sakiti muhimu za kielektroniki zinazotafsiri na kutekeleza maagizo
-      kutoka kwa programu au maunzi mengine.
+    term: Central Processing Unit
+    def: 'Vifaa vikuu vya kompyuta yoyote ya dijitali inayojumuisha sakiti muhimu
+      za kielektroniki zinazotafsiri na kutekeleza maagizo kutoka kwa programu au
+      maunzi mengine.
+
+      '
   uk:
-    term: "центральний процесор"
-    acronym: "ЦП"
-    def: >
-      Основний апаратний компонент будь-якого цифрового комп'ютера. Центральний процесор 
-      складається з базових електронних схем, які інтерпретують і виконують інструкції з 
-      програмного або іншого апаратного забезпечення. Також називається
+    term: центральний процесор
+    acronym: ЦП
+    def: 'Основний апаратний компонент будь-якого цифрового комп''ютера. Центральний
+      процесор  складається з базових електронних схем, які інтерпретують і виконують
+      інструкції з  програмного або іншого апаратного забезпечення. Також називається
       головним процесором або мікропроцесором.
 
+      '
 - slug: cran
   ref:
-    - base_r
-    - tidyverse
+  - base_r
+  - tidyverse
   en:
-    term: "Comprehensive R Archive Network"
-    acronym: "CRAN"
-    def: >
-      A public repository of [R](#r_language) packages.
+    term: Comprehensive R Archive Network
+    acronym: CRAN
+    def: 'A public repository of [R](#r_language) packages.
 
+      '
   am:
     term: ሁሉን አቀፍ R መዝገብ ቤት አውታረ መረብ
     def: የ [R](#r_language) ጥቅሎች የህዝብ ማከማቻ።
   uk:
-    term: "CRAN (Comprehensive R Archive Network)"
-    acronym: "CRAN"
-    def: >
-      Публічний репозиторій для пакетів мовою програмування [R](#r_language).
+    term: CRAN (Comprehensive R Archive Network)
+    acronym: CRAN
+    def: 'Публічний репозиторій для пакетів мовою програмування [R](#r_language).
 
+      '
 - slug: cross_join
   ref:
-    - anti_join
-    - cross_join
-    - full_join
-    - inner_join
-    - left_join
-    - right_join
-    - self_join
+  - anti_join
+  - cross_join
+  - full_join
+  - inner_join
+  - left_join
+  - right_join
+  - self_join
   en:
-    term: "cross join"
-    def: >
-      A [join](#join) that produces all possible combinations of rows from two tables.
+    term: cross join
+    def: 'A [join](#join) that produces all possible combinations of rows from two
+      tables.
 
+      '
   am:
     term: ማቀናጀት
     def: ሁሉንም ሊሆኑ የሚችሉ የረድፎች ጥምረት የሚያመጣ አንድ [ተቀላቀል](#join) ከ ሁለት ጠረጴዛዎች፡፡
-
   af:
-    term: "kruiskoppeling"
-    def: >
-      'n [Koppeling](#join) wat alle moontlike kombinasies van rye uit twee tabelle A en B oplewer.
+    term: kruiskoppeling
+    def: '''n [Koppeling](#join) wat alle moontlike kombinasies van rye uit twee tabelle
+      A en B oplewer.
 
-
+      '
 - slug: cross_validation
   ref:
-    - machine_learning
+  - machine_learning
   en:
-    term: "cross-validation"
-    def: >
-      A technique that divides data into [training data](t#raining_data) and [test
-      data](#test_data). The training data and correct answers are used to find
-      [parameters](#parameter), and the algorithm's effectiveness is then measured by examining the
-      answers it gives on the test data.
+    term: cross-validation
+    def: 'A technique that divides data into [training data](t#raining_data) and [test
+      data](#test_data). The training data and correct answers are used to find [parameters](#parameter),
+      and the algorithm''s effectiveness is then measured by examining the answers
+      it gives on the test data.
 
+      '
   am:
     term: መስቀል-ማረጋገጫ ማሽን መማር
-    def: >
-      መረጃን ወደ [የሥልጠና ውሂብ](#training_data) እና [የሙከራ ውሂብ](#test_data) የሚከፍል ዘዴ ፡፡ የሥልጠናው መረጃ እና ትክክለኛ መልሶች [መለኪያዎች](#parameter) ለማግኘት ጥቅም ላይ ይውላሉ ፣ እና የአልጎሪዝም እና #39 ውጤታማነት የሚለካው በፈተናው መረጃ ላይ የሚሰጡትን መልሶች በመመርመር ነው።
+    def: 'መረጃን ወደ [የሥልጠና ውሂብ](#training_data) እና [የሙከራ ውሂብ](#test_data) የሚከፍል ዘዴ ፡፡
+      የሥልጠናው መረጃ እና ትክክለኛ መልሶች [መለኪያዎች](#parameter) ለማግኘት ጥቅም ላይ ይውላሉ ፣ እና የአልጎሪዝም
+      እና #39 ውጤታማነት የሚለካው በፈተናው መረጃ ላይ የሚሰጡትን መልሶች በመመርመር ነው።
 
+      '
 - slug: cryptographic_hash_function
   en:
-    term: "cryptographic hash function"
-    def: >
-      A [hash function](#hash_function) that produces a random value for
-      any input.
+    term: cryptographic hash function
+    def: 'A [hash function](#hash_function) that produces a random value for any input.
 
+      '
   am:
     term: ምስጠራ ሃሽ ተግባር
-    def: >
-      ለማንኛውም ግብዓት የዘፈቀደ እሴት የሚያመጣ ተግባር ::
+    def: 'ለማንኛውም ግብዓት የዘፈቀደ እሴት የሚያመጣ ተግባር ::
 
+      '
 - slug: css
   en:
-    term: "Cascading Style Sheets"
-    acronym: "CSS"
-    def: >
-      A way to control the appearance of HTML. CSS is typically used to specify fonts,
-      colors, and layout.
-  fr:
-    term: "Feuilles de Style en Cascade"
-    acronym: "CSS"
-    def: >
-      Une manière de contrôler l'apparence du rendu HTML. Le CSS est généralement
-      utilisé dans le but de spécifier les polices, les couleurs ainsi que la
-      structure d'une page web.
+    term: Cascading Style Sheets
+    acronym: CSS
+    def: 'A way to control the appearance of HTML. CSS is typically used to specify
+      fonts, colors, and layout.
 
+      '
+  fr:
+    term: Feuilles de Style en Cascade
+    acronym: CSS
+    def: 'Une manière de contrôler l''apparence du rendu HTML. Le CSS est généralement
+      utilisé dans le but de spécifier les polices, les couleurs ainsi que la structure
+      d''une page web.
+
+      '
   am:
     term: ሲ.ኤስ.ኤስ.
-    def: >
-      የኤችቲኤምኤልን ገጽታ የሚቆጣጠርበት መንገድ። ሲ.ኤስ.ኤስ በተለምዶ ጥቅም ላይ ይውላል ቅርጸ-ቁምፊዎችን ፣ ቀለሞችን እና አቀማመጥን ይጥቀሱ ፡፡
+    def: 'የኤችቲኤምኤልን ገጽታ የሚቆጣጠርበት መንገድ። ሲ.ኤስ.ኤስ በተለምዶ ጥቅም ላይ ይውላል ቅርጸ-ቁምፊዎችን ፣ ቀለሞችን
+      እና አቀማመጥን ይጥቀሱ ፡፡
 
+      '
 - slug: csv
   en:
-    term: "comma-separated values"
-    acronym: "CSV"
-    def: >
-      A text format for tabular data in which each [record](#record) is one row and [fields](#field) are
-      separated by commas. There are many minor variations, particularly around
-      quoting of [strings](#string).
+    term: comma-separated values
+    acronym: CSV
+    def: 'A text format for tabular data in which each [record](#record) is one row
+      and [fields](#field) are separated by commas. There are many minor variations,
+      particularly around quoting of [strings](#string).
 
+      '
   am:
     term: ሲ.ኤስ.ቪ.
-    def: >
-      እያንዳንዱ [መዝገብ](#record) የሚገኝበት ለሠንጠረዥ መረጃ የጽሑፍ ቅርጸት አንድ ረድፍ እና የመስክ ሳራ በኮማዎች ተለያይተዋል ፡፡ ብዙ ጥቃቅን ልዩነቶች አሉ ፣ በተለይም ሕብረቁምፊዎችን በመጥቀስ ፡፡
-  uk:
-    term: "значення, розділені комами"
-    acronym: "CSV"
-    def: >
-      Текстовий формат для табличних даних, в якому кожен [запис](#record) - один рядок, а [поля](#field)
-      розділені комами. Має багато незначних варіацій, особливо щодо використання лапок навколо
-      [рядків](#string).
+    def: 'እያንዳንዱ [መዝገብ](#record) የሚገኝበት ለሠንጠረዥ መረጃ የጽሑፍ ቅርጸት አንድ ረድፍ እና የመስክ ሳራ በኮማዎች
+      ተለያይተዋል ፡፡ ብዙ ጥቃቅን ልዩነቶች አሉ ፣ በተለይም ሕብረቁምፊዎችን በመጥቀስ ፡፡
 
+      '
+  uk:
+    term: значення, розділені комами
+    acronym: CSV
+    def: 'Текстовий формат для табличних даних, в якому кожен [запис](#record) - один
+      рядок, а [поля](#field) розділені комами. Має багато незначних варіацій, особливо
+      щодо використання лапок навколо [рядків](#string).
+
+      '
 - slug: current_working_directory
   en:
-    term: "current working directory"
-    def: >
-      The [folder](#folder) or [directory](#directory) location in which the program operates. Any action
-      taken by the program occurs relative to this directory.
-  pt:
-    term: "diretório de trabalho"
-    def: >
-      O local, pasta ou diretório, em que o programa está operando. Qualquer ação do
-      programa acontece relativa a esse diretório.
-  fr:
-    term: "répertoire de travail"
-    def: >
-      L'emplacement du système de fichiers dans lequel le programme en cours est en train d'opérer.
-      Chaque opération effectuée par le programme se fait relativement à cet emplacement.
+    term: current working directory
+    def: 'The [folder](#folder) or [directory](#directory) location in which the program
+      operates. Any action taken by the program occurs relative to this directory.
 
+      '
+  pt:
+    term: diretório de trabalho
+    def: 'O local, pasta ou diretório, em que o programa está operando. Qualquer ação
+      do programa acontece relativa a esse diretório.
+
+      '
+  fr:
+    term: répertoire de travail
+    def: 'L''emplacement du système de fichiers dans lequel le programme en cours
+      est en train d''opérer. Chaque opération effectuée par le programme se fait
+      relativement à cet emplacement.
+
+      '
   am:
     term: የአሁኑ የሥራ ማውጫ
-    def: >
-      ፕሮግራሙ የሚሠራበትን [አቃፊ](#folder) ወይም ማውጫ ቦታ። ማንኛውም እርምጃ የተወሰደው በፕሮግራሙ የተወሰደው ከዚህ ማውጫ አንጻር ነው ፡፡
+    def: 'ፕሮግራሙ የሚሠራበትን [አቃፊ](#folder) ወይም ማውጫ ቦታ። ማንኛውም እርምጃ የተወሰደው በፕሮግራሙ የተወሰደው
+      ከዚህ ማውጫ አንጻር ነው ፡፡
 
+      '
+- slug: data_analysis
+  en:
+    term: data analysis
+    def: 'The process of inspecting, cleaning, transforming, and modeling data to
+      discover useful information, draw conclusions, and support decision-making.
+
+      '
+- slug: data_analytics
+  ref:
+  - data_analysis
+  - data_science
+  en:
+    term: data analytics
+    def: 'The science of analyzing raw data to make conclusions and identify patterns.
+      Often used interchangeably with [data analysis](#data_analysis), though sometimes
+      refers more specifically to business applications.
+
+      '
+- slug: data_cleaning
+  ref:
+  - missing_data
+  - data_preprocessing
+  en:
+    term: data cleaning
+    def: 'The process of detecting and correcting (or removing) corrupt, inaccurate,
+      or irrelevant records from a dataset. This includes handling [missing values](#missing_data),
+      removing duplicates, and fixing inconsistencies.
+
+      '
 - slug: data_collison
   en:
-    term: "data collison"
-    def: >
-      Occurs when  when two or more devices or nodes try to transmit signals at the same time on
-      the same network. Similarly a data collision can also occur when [hashing](#hash_function)
-      if two distinct pieces of data have the same hash value.
+    term: data collison
+    def: 'Occurs when  when two or more devices or nodes try to transmit signals at
+      the same time on the same network. Similarly a data collision can also occur
+      when [hashing](#hash_function) if two distinct pieces of data have the same
+      hash value.
 
+      '
 - slug: data_engineer
   ref:
-    - data_scientist
-    - data_wrangling
+  - data_scientist
+  - data_wrangling
   en:
-    term: "data engineer"
-    def: >
-      Someone who sets up and runs data analyses. Data engineers are often responsible
-      for installing software, managing databases, generating reports, and archiving results.
+    term: data engineer
+    def: 'Someone who sets up and runs data analyses. Data engineers are often responsible
+      for installing software, managing databases, generating reports, and archiving
+      results.
 
+      '
   am:
     term: የውሂብ መሐንዲስ
-    def: >
-      መረጃ ትንታኔዎችን የሚያዘጋጅ እና የሚያከናውን ሰው ፡፡ የመረጃ መሐንዲሶች ብዙውን ጊዜ ናቸው ሶፍትዌርን ለመጫን ፣ የውሂብ ጎታዎችን ለማስተዳደር ፣ ሪፖርቶችን ለማመንጨት እና ውጤቶችን በማህደር ማስቀመጥ።
+    def: 'መረጃ ትንታኔዎችን የሚያዘጋጅ እና የሚያከናውን ሰው ፡፡ የመረጃ መሐንዲሶች ብዙውን ጊዜ ናቸው ሶፍትዌርን ለመጫን
+      ፣ የውሂብ ጎታዎችን ለማስተዳደር ፣ ሪፖርቶችን ለማመንጨት እና ውጤቶችን በማህደር ማስቀመጥ።
 
+      '
 - slug: data_engineering
   ref:
-    - data_science
+  - data_science
   en:
-    term: "data engineering"
-    def: >
-      The pragmatic steps taken to make data usable, such as writing short programs to
-      put mailing addresses in a uniform format.
+    term: data engineering
+    def: 'The pragmatic steps taken to make data usable, such as writing short programs
+      to put mailing addresses in a uniform format.
+
+      '
   el:
-    term: "μηχανικός δεδομένων"
-    def: >
-      Ένα άτομο που υλοποιεί και τρέχει αναλύσεις δεδομένων. Οι μηχανικοί δεδομένων
+    term: μηχανικός δεδομένων
+    def: 'Ένα άτομο που υλοποιεί και τρέχει αναλύσεις δεδομένων. Οι μηχανικοί δεδομένων
       είναι συνήθως υπεύθυνοι για την εγκατάσταση λογισμικού, τη διαχείριση βάσεων
       δεδομένων, τη δημιουργία αναφορών και την αρχειοθέτηση των αποτελεσμάτων.
 
+      '
   am:
     term: የውሂብ ምህንድስና
-    def: >
-      እንደ አጭር መጻፍ ያሉ መረጃዎችን ለመጠቀም እንዲችሉ የተደረጉ ተግባራዊ ተግባራት የመልእክት አድራሻዎችን በአንድ ወጥ ቅርጸት ለማስቀመጥ ፕሮግራሞች ፡፡
+    def: 'እንደ አጭር መጻፍ ያሉ መረጃዎችን ለመጠቀም እንዲችሉ የተደረጉ ተግባራዊ ተግባራት የመልእክት አድራሻዎችን በአንድ
+      ወጥ ቅርጸት ለማስቀመጥ ፕሮግራሞች ፡፡
 
+      '
 - slug: data_frame
   ref:
-    - tidy_data
+  - tidy_data
   en:
-    term: "data frame"
-    def: >
-      A two-dimensional data structure for storing tabular data in memory. Rows
+    term: data frame
+    def: 'A two-dimensional data structure for storing tabular data in memory. Rows
       represent [records](#record) and columns represent [variables](#variable_data).
+
+      '
   fr:
-    term: "trame de données"
-    def: >
-      Une structure bi-dimensionnelle pour enregistrer des données tabulaires. Les
-      lignes représentent les [entrées](#record) et les colonnes représentent les
-      [variables](#variable_data).
+    term: trame de données
+    def: 'Une structure bi-dimensionnelle pour enregistrer des données tabulaires.
+      Les lignes représentent les [entrées](#record) et les colonnes représentent
+      les [variables](#variable_data).
+
+      '
   es:
-    term: "marco de datos"
-    def: >
-      Una estructura de datos bi-dimensional para guardar datos tabulares en memoria.
+    term: marco de datos
+    def: 'Una estructura de datos bi-dimensional para guardar datos tabulares en memoria.
       Líneas representan [entradas](#record) y columnas representan [variables](#variable_data).
+
+      '
   sw:
-    term: "Data Fremu"
-    def: >
-      Muundo wa data wa pande mbili wa kuhifadhi data ya tabular katika kumbukumbu. Safu zinawakilisha rekodi na nguzo zinawakilisha vigezo.
+    term: Data Fremu
+    def: 'Muundo wa data wa pande mbili wa kuhifadhi data ya tabular katika kumbukumbu.
+      Safu zinawakilisha rekodi na nguzo zinawakilisha vigezo.
 
-
+      '
 - slug: data_masking
   en:
-    term: "data masking"
-    def: >
-      Altering data in a dataset to anonymize or otherwise remove identifying information.
-      For example, real names might be swapped out with fictional names to provide name-based data
-      without referencing actual people.
+    term: data masking
+    def: 'Altering data in a dataset to anonymize or otherwise remove identifying
+      information. For example, real names might be swapped out with fictional names
+      to provide name-based data without referencing actual people.
 
+      '
   am:
     term: የውሂብ ክፈፍ
-    def: >
-      በትር ውስጥ ሰንጠረዥ መረጃዎችን ለማከማቸት ባለ ሁለት አቅጣጫዊ የውሂብ መዋቅር። ረድፎች [መዝገቦችን](#record) ይወክላሉ  እና አምዶች ይወክላሉ [variables](#variable_data)።
+    def: 'በትር ውስጥ ሰንጠረዥ መረጃዎችን ለማከማቸት ባለ ሁለት አቅጣጫዊ የውሂብ መዋቅር። ረድፎች [መዝገቦችን](#record)
+      ይወክላሉ  እና አምዶች ይወክላሉ [variables](#variable_data)።
 
-
+      '
 - slug: data_mining
   en:
-    term: "data mining"
-    def: >
-      The use of computers to search for patterns in large datasets. The term [data
-      science](#data_science) is now more commonly used.
+    term: data mining
+    def: 'The use of computers to search for patterns in large datasets. The term
+      [data science](#data_science) is now more commonly used.
+
+      '
   af:
-    term: "data-ontgining"
-    def: >
-      Die gebruik van 'n rekendaar om te soek na patrone in groot datastelle. Die term [data wetenskap](#data_science)
-      word tans meer gebruik.
+    term: data-ontgining
+    def: 'Die gebruik van ''n rekendaar om te soek na patrone in groot datastelle.
+      Die term [data wetenskap](#data_science) word tans meer gebruik.
+
+      '
   zu:
-    term: "ukumbiwa kwedatha"
-    def: >
-      The use of computers to search for patterns in large datasets. The term [data
-      science](#data_science) is now more commonly used.
+    term: ukumbiwa kwedatha
+    def: 'The use of computers to search for patterns in large datasets. The term
+      [data science](#data_science) is now more commonly used.
+
+      '
   sw:
-    term: "Uchimbaji data"
-    def: >
-      Mchakato wa kuchimba na kugundua mifumo katika seti kubwa za data kwa kutumia tarakilishi.
+    term: Uchimbaji data
+    def: 'Mchakato wa kuchimba na kugundua mifumo katika seti kubwa za data kwa kutumia
+      tarakilishi.
+
+      '
   am:
     term: መረጃ ማውጣት
-    def: >
-      በትላልቅ የውሂብ ስብስቦች ውስጥ ቅጦችን ለመፈለግ የኮምፒተር አጠቃቀም። ዘ ቃል [ዳታ ሳይንስ](#data_science) አሁን በብዛት ጥቅም ላይ ውሏል ፡፡
+    def: 'በትላልቅ የውሂብ ስብስቦች ውስጥ ቅጦችን ለመፈለግ የኮምፒተር አጠቃቀም። ዘ ቃል [ዳታ ሳይንስ](#data_science)
+      አሁን በብዛት ጥቅም ላይ ውሏል ፡፡
 
+      '
 - slug: data_package
   en:
-    term: "data package"
-    def: >
-      A software package that, mostly, contains only data. Is used to make it simpler
-      to disseminate data for easier use.
+    term: data package
+    def: 'A software package that, mostly, contains only data. Is used to make it
+      simpler to disseminate data for easier use.
+
+      '
   af:
-    term: "data pakket"
-    def: >
-      'n Sagtewarepakket wat meestal net data bevat. Word gebruik om dit eenvoudiger te maak
-      om data te versprei vir makliker gebruik.
+    term: data pakket
+    def: '''n Sagtewarepakket wat meestal net data bevat. Word gebruik om dit eenvoudiger
+      te maak om data te versprei vir makliker gebruik.
+
+      '
   am:
     term: የውሂብ ጥቅል
-    def: >
-      የሶፍትዌር ፓኬጅ ፣ በአብዛኛው ፣ መረጃዎችን ብቻ የያዘ። ለመሥራት ያገለገለ ነው ለቀላል አጠቃቀም መረጃን ለማሰራጨት የበለጠ ቀላል ነው።
-  sw:
-    term: "Kifurushi cha data"
-    def: >
-      Kifurushi cha programu ambacho, mara nyingi, kina data pekee. Hutumika kurahisisha kusambaza data kwa matumizi rahisi.
+    def: 'የሶፍትዌር ፓኬጅ ፣ በአብዛኛው ፣ መረጃዎችን ብቻ የያዘ። ለመሥራት ያገለገለ ነው ለቀላል አጠቃቀም መረጃን ለማሰራጨት
+      የበለጠ ቀላል ነው።
 
+      '
+  sw:
+    term: Kifurushi cha data
+    def: 'Kifurushi cha programu ambacho, mara nyingi, kina data pekee. Hutumika kurahisisha
+      kusambaza data kwa matumizi rahisi.
+
+      '
+- slug: data_preprocessing
+  ref:
+  - data_cleaning
+  - feature_selection
+  en:
+    term: data preprocessing
+    def: 'The process of transforming raw data into a format suitable for analysis
+      or [machine learning](#machine_learning). This includes [data cleaning](#data_cleaning),
+      normalization, encoding categorical variables, and [feature selection](#feature_selection).
+
+      '
 - slug: data_science
   en:
-    term: "data science"
-    def: >
-      The combination of statistics, programming, and hard work used to extract
+    term: data science
+    def: 'The combination of statistics, programming, and hard work used to extract
       knowledge from data.
+
+      '
   pt:
-    term: "ciência de dados"
-    def: >
-      A combinação de estatística, programação e trabalho duro usados para extrair
+    term: ciência de dados
+    def: 'A combinação de estatística, programação e trabalho duro usados para extrair
       conhecimento a partir de dados.
+
+      '
   af:
-    term: "datawetenskap"
-    def: >
-      Die kombinasie van statistiek en programmering wat gebruik word om kennis vanuit data te ontgin.
+    term: datawetenskap
+    def: 'Die kombinasie van statistiek en programmering wat gebruik word om kennis
+      vanuit data te ontgin.
+
+      '
   sw:
-    term: "sayansi ya data"
-    def: >
-      mchanganyiko wa takwimu, programu na kazi ngumu inayotumika kupata maarifa kutoka kwa data.
+    term: sayansi ya data
+    def: 'mchanganyiko wa takwimu, programu na kazi ngumu inayotumika kupata maarifa
+      kutoka kwa data.
+
+      '
   es:
-    term: "ciencia de datos"
-    def: >
-      La combinación de estadísticas, programación y trabajo duro que se utiliza para extraer información de los datos.
+    term: ciencia de datos
+    def: 'La combinación de estadísticas, programación y trabajo duro que se utiliza
+      para extraer información de los datos.
+
+      '
   el:
-    term: "επιστήμη δεδομένων"
-    def: >
-      Ο συνδυασμός στατιστικής, προγραμματισμού και σκληρής δουλειάς που χρειάζεται για να εξαχθούν συμπεράσματα από δεδομένα.
+    term: επιστήμη δεδομένων
+    def: 'Ο συνδυασμός στατιστικής, προγραμματισμού και σκληρής δουλειάς που χρειάζεται
+      για να εξαχθούν συμπεράσματα από δεδομένα.
+
+      '
   am:
     term: የውሂብ ሳይንስ
-    def: >
-      ጥቅም ላይ የዋለው የስታቲስቲክስ ፣ የፕሮግራም እና ከባድ ሥራ ጥምረት ከመረጃ ዕውቀትን ያውጡ።
-  uk:
-    term: "наука про дані"
-    def: >
-      Міждисциплінарна галузь, що поєднує статистику, математику, програмування, машинне навчання та інші методи
-      для розуміння даних і виявлення прихованих закономірностей.
+    def: 'ጥቅም ላይ የዋለው የስታቲስቲክስ ፣ የፕሮግራም እና ከባድ ሥራ ጥምረት ከመረጃ ዕውቀትን ያውጡ።
 
+      '
+  uk:
+    term: наука про дані
+    def: 'Міждисциплінарна галузь, що поєднує статистику, математику, програмування,
+      машинне навчання та інші методи для розуміння даних і виявлення прихованих закономірностей.
+
+      '
 - slug: data_scientist
   en:
-    term: "data scientist"
-    def: >
-      Someone who uses programming skills to solve statistical problems.
+    term: data scientist
+    def: 'Someone who uses programming skills to solve statistical problems.
+
+      '
   sw:
-    term: "mwanasayansi wa data"
-    def: >
-      mtu anayetumia ujuzi wa programu kutafuta suluhu/kusuluhisha matatizo ya takwimu.
+    term: mwanasayansi wa data
+    def: 'mtu anayetumia ujuzi wa programu kutafuta suluhu/kusuluhisha matatizo ya
+      takwimu.
+
+      '
   pt:
-    term: "cientista de dados"
-    def: >
-      Alguém que usa habilidades de programação para resolver problemas estatísticos.
+    term: cientista de dados
+    def: 'Alguém que usa habilidades de programação para resolver problemas estatísticos.
+
+      '
   af:
-    term: "datawetenskaplike"
-    def: >
-      Iemand wat programmeringsvaardighede gebruik om statistiese probleme op te los.
+    term: datawetenskaplike
+    def: 'Iemand wat programmeringsvaardighede gebruik om statistiese probleme op
+      te los.
+
+      '
   es:
-    term: "cientifico/cientifica de datos"
-    def: >
-      Alguien que usa habilidades de programación para resolver problemas de estadísticas.
+    term: cientifico/cientifica de datos
+    def: 'Alguien que usa habilidades de programación para resolver problemas de estadísticas.
+
+      '
   el:
-    term: "επιστήμονας δεδομένων"
-    def: >
-      Ένα άτομο που χρησιμοποιεί προγραμματισμό για να λύσει προβλήματα στατιστικής.
+    term: επιστήμονας δεδομένων
+    def: 'Ένα άτομο που χρησιμοποιεί προγραμματισμό για να λύσει προβλήματα στατιστικής.
+
+      '
   am:
     term: የውሂብ ሳይንቲስት
-    def: >
-      የስታቲስቲክስ ችግሮችን ለመፍታት የፕሮግራም ችሎታን የሚጠቀም ሰው ፡፡
-  uk:
-    term: "спеціаліст з обробки даних"
-    def: >
-      Фахівець, який поєднує знання з програмування, статистики та машинного навчання для аналізу даних,
-      виявлення закономірностей і формулювання висновків, що допомагають приймати обґрунтовані рішення.
+    def: 'የስታቲስቲክስ ችግሮችን ለመፍታት የፕሮግራም ችሎታን የሚጠቀም ሰው ፡፡
 
+      '
+  uk:
+    term: спеціаліст з обробки даних
+    def: 'Фахівець, який поєднує знання з програмування, статистики та машинного навчання
+      для аналізу даних, виявлення закономірностей і формулювання висновків, що допомагають
+      приймати обґрунтовані рішення.
+
+      '
 - slug: data_structure
   en:
-    term: "data structure"
-    def: >
-      A format for the organisation, management, and efficient access of data. Typically it will
-      characterise a set of data values and their representation (or [encoding](#character_encoding)),
-      the relationships between values, and ways to access or manipulate those data, such as
-      reading, altering, or writing.
+    term: data structure
+    def: 'A format for the organisation, management, and efficient access of data.
+      Typically it will characterise a set of data values and their representation
+      (or [encoding](#character_encoding)), the relationships between values, and
+      ways to access or manipulate those data, such as reading, altering, or writing.
+
+      '
   sw:
-    term: "muundo wa data"
-    def: >
-      Muundo wa ushirikashi, usimamizi na ufikiaji bora wa data. Kwa kawaida itakuwa
+    term: muundo wa data
+    def: 'Muundo wa ushirikashi, usimamizi na ufikiaji bora wa data. Kwa kawaida itakuwa
       kubainisha thamani ya seti za data na uwakilishi wao (au [encoding](#character_encoding)),
       uhusiano kati ya thamana, na njia za kufikia au kuendesha data hizo, kama vile
       kusoma, kubadilisha, au kuandika.
-  uk:
-    term: "структура даних"
-    def: >
-      Спосіб організації та зберігання даних у комп’ютері, який забезпечує ефективний доступ і зміну цих даних.
 
+      '
+  uk:
+    term: структура даних
+    def: 'Спосіб організації та зберігання даних у комп’ютері, який забезпечує ефективний
+      доступ і зміну цих даних.
+
+      '
 - slug: data_visualization
   en:
-    term: "data visualization"
-    def: >
-      The creation of charts, maps, graphs, or infographics to translate datasets into something visual.
-      Sometimes called "dataviz" or "data viz."
+    term: data visualization
+    def: 'The creation of charts, maps, graphs, or infographics to translate datasets
+      into something visual. Sometimes called "dataviz" or "data viz."
+
+      '
   am:
     term: የውሂብ መዋቅር
-    def: >
-      ለድርጅቱ ቅርጸት ፣ አስተዳደር እና ቀልጣፋ ተደራሽነት መረጃ በተለምዶ ያደርገዋል የውሂብ እሴቶችን ስብስብ እና የእነሱ ውክልና (ወይም።) [ኢንኮዲንግ](#character_encoding)) ፣ በእሴቶች መካከል ያሉ ግንኙነቶች እና ለመድረስ ወይም ለማታለል መንገዶች እነዚያ መረጃዎች ፣ እንደ ማንበብ ፣ መለወጥ ወይም መጻፍ ፡፡
-  sw:
-    term: "taswira ya data"
-    def: >
-      Uundaji wa chati, ramani, grafu, au infographics ili kutafsiri seti za data kuwa kitu kinachoonekana.
-      Wakati mwingine huitwa "dataviz" au "data viz."
-  uk:
-    term: "візуалізація даних"
-    def: >
-      Процес представлення даних у вигляді графіків, діаграм, карт або інших візуальних форм, що дозволяє легше сприймати та аналізувати інформацію.
+    def: 'ለድርጅቱ ቅርጸት ፣ አስተዳደር እና ቀልጣፋ ተደራሽነት መረጃ በተለምዶ ያደርገዋል የውሂብ እሴቶችን ስብስብ እና የእነሱ
+      ውክልና (ወይም።) [ኢንኮዲንግ](#character_encoding)) ፣ በእሴቶች መካከል ያሉ ግንኙነቶች እና ለመድረስ ወይም
+      ለማታለል መንገዶች እነዚያ መረጃዎች ፣ እንደ ማንበብ ፣ መለወጥ ወይም መጻፍ ፡፡
 
+      '
+  sw:
+    term: taswira ya data
+    def: 'Uundaji wa chati, ramani, grafu, au infographics ili kutafsiri seti za data
+      kuwa kitu kinachoonekana. Wakati mwingine huitwa "dataviz" au "data viz."
+
+      '
+  uk:
+    term: візуалізація даних
+    def: 'Процес представлення даних у вигляді графіків, діаграм, карт або інших візуальних
+      форм, що дозволяє легше сприймати та аналізувати інформацію.
+
+      '
 - slug: data_wrangling
   en:
-    term: "data wrangling"
-    def: >
-      A colloquial name for small-scale [data engineering](#data_engineering).
+    term: data wrangling
+    def: 'A colloquial name for small-scale [data engineering](#data_engineering).
 
+      '
   am:
     term: የውሂብ ክርክር
-    def: >
-      ለአነስተኛ መጠን [የመረጃ ምህንድስና](#data_engineering) የትብብር ስም።
+    def: 'ለአነስተኛ መጠን [የመረጃ ምህንድስና](#data_engineering) የትብብር ስም።
 
+      '
   sw:
-    term: "mchakato wa data"
-    def: >
-      Jina la mazungumzo kwa kiwango kidogo cha [data engineering](#data_engineering).
+    term: mchakato wa data
+    def: 'Jina la mazungumzo kwa kiwango kidogo cha [data engineering](#data_engineering).
 
+      '
+- slug: dataset
+  ref:
+  - data_frame
+  - table
+  en:
+    term: dataset
+    def: 'A collection of related data, typically organized in a structured format
+      such as a [table](#table) or [data frame](#data_frame), where rows represent
+      observations and columns represent variables or features.
+
+      '
 - slug: debug
   en:
-    term: "debug"
-    def: >
-      In a computer environment 'debug' refers to the process of finding and resolving errors (also known as 'bugs') within computer programs or systems.
+    term: debug
+    def: 'In a computer environment ''debug'' refers to the process of finding and
+      resolving errors (also known as ''bugs'') within computer programs or systems.
 
+      '
   pt:
-    term: "depurar"
-    def: >
-      Em um ambiente de computador, 'debug' refere-se ao processo de encontrar e resolver erros (também conhecidos como 'bugs') em programas ou sistemas de computador.
+    term: depurar
+    def: 'Em um ambiente de computador, ''debug'' refere-se ao processo de encontrar
+      e resolver erros (também conhecidos como ''bugs'') em programas ou sistemas
+      de computador.
 
+      '
   sw:
-    term: "utatuzi"
-    def: >
-      Katika mazingira ya kompyuta 'utatuzi' inarejelea mchakato wa kutafuta na kutatua makosa (pia hujulikana kama hitilafu) ndani ya programu au mifumo ya kompyuta.
-  uk:
-    term: "налагодження"
-    def: >
-      В комп'ютерному середовищі "налагодження" відноситься до процесу пошуку та виправлення помилок
-      (також відомих як [дефекти](#bug), або, неформально, "баги") в комп'ютерних програмах або системах.
+    term: utatuzi
+    def: 'Katika mazingira ya kompyuta ''utatuzi'' inarejelea mchakato wa kutafuta
+      na kutatua makosa (pia hujulikana kama hitilafu) ndani ya programu au mifumo
+      ya kompyuta.
 
+      '
+  uk:
+    term: налагодження
+    def: 'В комп''ютерному середовищі "налагодження" відноситься до процесу пошуку
+      та виправлення помилок (також відомих як [дефекти](#bug), або, неформально,
+      "баги") в комп''ютерних програмах або системах.
+
+      '
 - slug: decision_tree
   ref:
-    - random_forests
+  - random_forests
   en:
-    term: "decision tree"
-    def: >
-      A tree whose [nodes](#node) are questions and whose [branches](#branch) eventually lead to a
-      decision or [classification](#classification).
+    term: decision tree
+    def: 'A tree whose [nodes](#node) are questions and whose [branches](#branch)
+      eventually lead to a decision or [classification](#classification).
 
+      '
   am:
     term: የውሳኔ ዛፍ
-    def: >
-      [አንጓዎቹ](#node) ጥያቄዎቹ እና [ቅርንጫፎቹ](#branch) ውሎ አድሮ ወደ ውሳኔ ወይም [ምደባ](#classification) የሚወስድ ዛፍ።
+    def: '[አንጓዎቹ](#node) ጥያቄዎቹ እና [ቅርንጫፎቹ](#branch) ውሎ አድሮ ወደ ውሳኔ ወይም [ምደባ](#classification)
+      የሚወስድ ዛፍ።
 
+      '
 - slug: decorator_pattern
   en:
-    term: "Decorator pattern"
-    def: >
-      A [design pattern](#design_pattern) in which a function adds additional features
-      to another function or a [class](#class) after its initial definition.
+    term: Decorator pattern
+    def: 'A [design pattern](#design_pattern) in which a function adds additional
+      features to another function or a [class](#class) after its initial definition.
       Decorators are a feature of [Python](#python) and can be implemented in most
       other languages as well.
 
+      '
   am:
     term: የማስዋቢያ ንድፍ
-    def: >
-      አንድ ተግባር የሚጨምርበት የ [ዲዛይን ንድፍ](#design_pattern) ተጨማሪ ባህሪያትን ለሌላ ተግባር ወይም ከመጀመሪያው (ክፍል)(#class) ትርጉም ማስዋቢያዎች የ [Python](#python) ገጽታ ናቸው እና ሊተገበሩ ይችላሉ በአብዛኞቹ ሌሎች ቋንቋዎችም እንዲሁ ፡፡
+    def: 'አንድ ተግባር የሚጨምርበት የ [ዲዛይን ንድፍ](#design_pattern) ተጨማሪ ባህሪያትን ለሌላ ተግባር ወይም
+      ከመጀመሪያው (ክፍል)(#class) ትርጉም ማስዋቢያዎች የ [Python](#python) ገጽታ ናቸው እና ሊተገበሩ ይችላሉ
+      በአብዛኞቹ ሌሎች ቋንቋዎችም እንዲሁ ፡፡
 
+      '
 - slug: decrement
   ref:
-    - increment
+  - increment
   en:
-    term: "decrement"
-    def: >
-      A unary operation that decreases the value of a variable, usually by 1.
+    term: decrement
+    def: 'A unary operation that decreases the value of a variable, usually by 1.
+
+      '
   es:
-    term: "decrementar"
-    def: >
-      Una operación unaria que disminuye el valor de una variable, generalmente en 1.
+    term: decrementar
+    def: 'Una operación unaria que disminuye el valor de una variable, generalmente
+      en 1.
+
+      '
   pt:
-    term: "decrementar"
-    def: >
-      Uma operação unária que diminui o valor de uma variável, geralmente em um.
+    term: decrementar
+    def: 'Uma operação unária que diminui o valor de uma variável, geralmente em um.
 
+      '
   sw:
-    term: "kupunguza"
-    def: >
-      Operesheni isiyo ya kawaida ambayo hupunguza thamani ya kigezo, kwa kawaida kwa 1.
+    term: kupunguza
+    def: 'Operesheni isiyo ya kawaida ambayo hupunguza thamani ya kigezo, kwa kawaida
+      kwa 1.
 
-
+      '
 - slug: deep_learning
   en:
-    term: "deep learning"
-    def: >
-      A family of [neural network](#neural_network) algorithms that use multiple
+    term: deep learning
+    def: 'A family of [neural network](#neural_network) algorithms that use multiple
       layers to extract features at successively higher levels.
+
+      '
   de:
-    term: "Deep Learning"
-    def: >
-      Eine Familie von Algorithmen für künstliche neuronale Netzwerke, die mehrere Schichten verwenden, um schrittweise Eigenschaften auf immer höheren Ebenen zu extrahieren.
+    term: Deep Learning
+    def: 'Eine Familie von Algorithmen für künstliche neuronale Netzwerke, die mehrere
+      Schichten verwenden, um schrittweise Eigenschaften auf immer höheren Ebenen
+      zu extrahieren.
+
+      '
   am:
     term: ጥልቅ ትምህርት
-    def: >
-      የሚጠቀሙባቸው [neural network](#neural_network) ስልተ ቀመሮች በተከታታይ በከፍተኛ ደረጃዎች ባህሪያትን ለማውጣት ብዙ ንብርብሮች።
+    def: 'የሚጠቀሙባቸው [neural network](#neural_network) ስልተ ቀመሮች በተከታታይ በከፍተኛ ደረጃዎች ባህሪያትን
+      ለማውጣት ብዙ ንብርብሮች።
 
+      '
   es:
-    term: "Aprendizaje profundo"
-    def: >
-      Una familia de algoritmos de redes neuronales que utilizan múltiples capas 
-      para extraer atributos de los datos a niveles de abstracción sucesivamente más altos.
-      
+    term: Aprendizaje profundo
+    def: 'Una familia de algoritmos de redes neuronales que utilizan múltiples capas  para
+      extraer atributos de los datos a niveles de abstracción sucesivamente más altos.
+
+      '
   sw:
-    term: "kujifunza kwa kina"
-    def: >
-      Familia ya algoriti za mtandao wa neva [neural network](#neural_network) ambazo hutumia tabaka nyingi
-      ili kutoa vipengele katika viwango vya juu.
+    term: kujifunza kwa kina
+    def: 'Familia ya algoriti za mtandao wa neva [neural network](#neural_network)
+      ambazo hutumia tabaka nyingi ili kutoa vipengele katika viwango vya juu.
 
-
+      '
 - slug: default_target
   en:
-    term: "default target"
-    def: >
-      The [build target](#build_target) that is used when none is specified explicitly.
+    term: default target
+    def: 'The [build target](#build_target) that is used when none is specified explicitly.
 
+      '
   am:
     term: ነባሪ ዒላማ
-    def: >
-      ምንም በማይሆንበት ጊዜ ጥቅም ላይ የሚውለው [የግንባታ ዒላማ](#build_target) በግልፅ ተገልጻል ፡፡
+    def: 'ምንም በማይሆንበት ጊዜ ጥቅም ላይ የሚውለው [የግንባታ ዒላማ](#build_target) በግልፅ ተገልጻል ፡፡
 
+      '
 - slug: default_value
   en:
-    term: "default value"
-    def: >
-      A value assigned to a function [parameter](#parameter) when the caller does not specify a
-      value. Default values are specified as part of the function's definition.
+    term: default value
+    def: 'A value assigned to a function [parameter](#parameter) when the caller does
+      not specify a value. Default values are specified as part of the function''s
+      definition.
 
+      '
   am:
     term: ነባሪ እሴት
-    def: >
-      መቼ ለአንድ ተግባር [ልኬት](#parameter) የተመደበ እሴት ደዋዩ ዋጋ አይገልጽም። ነባሪ እሴቶች እንደ የተግባሩ አካል ሆነው ተገልፀዋል ትርጉም
+    def: 'መቼ ለአንድ ተግባር [ልኬት](#parameter) የተመደበ እሴት ደዋዩ ዋጋ አይገልጽም። ነባሪ እሴቶች እንደ የተግባሩ
+      አካል ሆነው ተገልፀዋል ትርጉም
 
+      '
   pt:
-    term: "valor por defeito"
-    def: >
-      Valor associado ao [parâmetro](#parameter) de uma função quando o operador não especifica um
-      valor. Valores por defeito fazem parte da definição de uma função.
+    term: valor por defeito
+    def: 'Valor associado ao [parâmetro](#parameter) de uma função quando o operador
+      não especifica um valor. Valores por defeito fazem parte da definição de uma
+      função.
 
+      '
 - slug: defensive_programming
   en:
-    term: "defensive programming"
-    def: >
-      A set of programming practices that assumes mistakes will happen and either
+    term: defensive programming
+    def: 'A set of programming practices that assumes mistakes will happen and either
       reports or corrects them, such as inserting [assertions](#assertion) to report
       situations that are not ever supposed to occur.
 
+      '
   am:
     term: የመከላከል  መርሃግብር
-    def: >
-      ስህተቶችን የሚወስድ የፕሮግራም አሰራሮች ስብስብ ይከሰታል እና እንደ ሪፖርት (እንደ ማረጋገጫ) ማስገባት (#assertion) ወይ ሪፖርት ያድርጉ ወይም ያስተካክሉዋቸው መከሰት ፈጽሞ የማይታሰቡ ሁኔታዎችን ሪፖርት ለማድረግ ፡፡
+    def: 'ስህተቶችን የሚወስድ የፕሮግራም አሰራሮች ስብስብ ይከሰታል እና እንደ ሪፖርት (እንደ ማረጋገጫ) ማስገባት (#assertion)
+      ወይ ሪፖርት ያድርጉ ወይም ያስተካክሉዋቸው መከሰት ፈጽሞ የማይታሰቡ ሁኔታዎችን ሪፖርት ለማድረግ ፡፡
 
+      '
 - slug: degrees_of_freedom
   en:
-    term: "degrees of freedom"
-    def: >
-      In statistics, the degrees of freedom (often "DF") is a measure of how much independent
-      information, in the form data and calculations, has been combined to produce a given
-      statistical parameter. Put another way, the DF is the number of values that are free to
-      vary in the calculation of a given statistical parameter. For a statistic calculated
-      from data which are indepdendent (i.e., the values are uncorrelated), the DF can be
-      generally estimated as the sample size minus the number of individual parameters
-      calculated to obtain the final statistic.
+    term: degrees of freedom
+    def: 'In statistics, the degrees of freedom (often "DF") is a measure of how much
+      independent information, in the form data and calculations, has been combined
+      to produce a given statistical parameter. Put another way, the DF is the number
+      of values that are free to vary in the calculation of a given statistical parameter.
+      For a statistic calculated from data which are indepdendent (i.e., the values
+      are uncorrelated), the DF can be generally estimated as the sample size minus
+      the number of individual parameters calculated to obtain the final statistic.
 
-
+      '
 - slug: delegate_pattern
   en:
-    term: "Delegate pattern"
-    def: >
-      A [design pattern](#design_pattern) in which an [object](#object) does most of the work to
-      complete a task, but uses one of a set of other objects to complete some
-      specific parts of the work. Delegation is often used instead of inheritance to
-      customize objects' behavior.
+    term: Delegate pattern
+    def: 'A [design pattern](#design_pattern) in which an [object](#object) does most
+      of the work to complete a task, but uses one of a set of other objects to complete
+      some specific parts of the work. Delegation is often used instead of inheritance
+      to customize objects'' behavior.
 
+      '
   am:
     term: የውክልና ንድፍ
-    def: >
-      \ አንድ [ንድፍ ንድፍ](#design_pattern) በውስጡ አንድ [ነገር](#object) አብዛኛውን ሥራ ይሠራልሥራን ማጠናቀቅ ፣ ግን ለማጠናቀቅ ከሌሎች ነገሮች ስብስብ ውስጥ አንዱን ይጠቀማል የተወሰኑ የተወሰኑ የሥራ ክፍሎች. ውክልና ብዙውን ጊዜ ጥቅም ላይ ይውላል ዕቃዎችን ለማበጀት ውርስ ባህሪ ::
+    def: '\ አንድ [ንድፍ ንድፍ](#design_pattern) በውስጡ አንድ [ነገር](#object) አብዛኛውን ሥራ ይሠራልሥራን
+      ማጠናቀቅ ፣ ግን ለማጠናቀቅ ከሌሎች ነገሮች ስብስብ ውስጥ አንዱን ይጠቀማል የተወሰኑ የተወሰኑ የሥራ ክፍሎች. ውክልና ብዙውን
+      ጊዜ ጥቅም ላይ ይውላል ዕቃዎችን ለማበጀት ውርስ ባህሪ ::
 
+      '
 - slug: dependency
   en:
-    term: "dependency"
-    def: >
-      See [prerequisite](#prerequisite).
-  sw:
-    term: "utegemezi"
-    def: >
-      hali ya kutegemea jambo ama kitu fulani
+    term: dependency
+    def: 'See [prerequisite](#prerequisite).
 
+      '
+  sw:
+    term: utegemezi
+    def: 'hali ya kutegemea jambo ama kitu fulani
+
+      '
   am:
     term: ጥገኝነት
     def: "[ቅድመ ሁኔታ](#prerequisite) ን ይመልከቱ \n"
   uk:
-    term: "залежність"
-    def: >
-      Див. [передумова](#prerequisite).
+    term: залежність
+    def: 'Див. [передумова](#prerequisite).
 
+      '
 - slug: dependent_variable
   en:
-    term: "dependent variable"
-    def: >
-      A variable whose value depends on the value of another variable, which is called
-      the [independent variable](#independent_variable).
-  pt:
-    term: "variável dependente"
-    def: >
-      Uma variável cujo valor dependa do valor de outra variável, que é chamada de
-      [variável independente](#independent_variable).
+    term: dependent variable
+    def: 'A variable whose value depends on the value of another variable, which is
+      called the [independent variable](#independent_variable).
 
+      '
+  pt:
+    term: variável dependente
+    def: 'Uma variável cujo valor dependa do valor de outra variável, que é chamada
+      de [variável independente](#independent_variable).
+
+      '
   am:
     term: ጥገኛ ተለዋዋጭ
-    def: >
-      ዋጋው በሌላ ተለዋዋጭ እሴት ላይ የሚመረኮዝ ተለዋዋጭ ፣ [ገለልተኛ ተለዋዋጭ](#independent_variable) ተብሎ የሚጠራው።
-  de:
-    term: "Abhängige Variable"
-    def: >
-      Eine Variable, dessen Werte von denen einer anderen Variablen abhängig sind, welche 
-      als [unabhängige Variable](#independent_variable) bezeichnet wird.
+    def: 'ዋጋው በሌላ ተለዋዋጭ እሴት ላይ የሚመረኮዝ ተለዋዋጭ ፣ [ገለልተኛ ተለዋዋጭ](#independent_variable)
+      ተብሎ የሚጠራው።
 
+      '
+  de:
+    term: Abhängige Variable
+    def: 'Eine Variable, dessen Werte von denen einer anderen Variablen abhängig sind,
+      welche  als [unabhängige Variable](#independent_variable) bezeichnet wird.
+
+      '
 - slug: depth_first
   en:
-    term: "depth first"
-    def: >
-      To go through a nested data structure such as a [tree](#tree) by going as far as
-      possible down one path, then as far as possible down the next and so on, or to
-      explore a problem by following one solution to its conclusion and then trying
-      the next.
+    term: depth first
+    def: 'To go through a nested data structure such as a [tree](#tree) by going as
+      far as possible down one path, then as far as possible down the next and so
+      on, or to explore a problem by following one solution to its conclusion and
+      then trying the next.
 
+      '
   am:
     term: ጥልቀት በመጀመሪያ
-    def: >
-      እንደ [tree](#tree)ያሉ ጎጆዎች በተዘረጋው የውሂብ መዋቅር ውስጥ ለማለፍ  በተቻለ መጠን በአንድ ጎዳና መሄድ ፣ ከዚያ በተቻለ መጠን በሚቀጥለው እና በመሳሰሉት መንገዶች ላይ ፣ ወይም ለመደምደሚያው አንድ መፍትሄን በመከተል እና ቀጣዩን በመሞከር አንድ ችግርን ለመመርመር ፡፡
+    def: 'እንደ [tree](#tree)ያሉ ጎጆዎች በተዘረጋው የውሂብ መዋቅር ውስጥ ለማለፍ  በተቻለ መጠን በአንድ ጎዳና መሄድ
+      ፣ ከዚያ በተቻለ መጠን በሚቀጥለው እና በመሳሰሉት መንገዶች ላይ ፣ ወይም ለመደምደሚያው አንድ መፍትሄን በመከተል እና ቀጣዩን
+      በመሞከር አንድ ችግርን ለመመርመር ፡፡
 
+      '
 - slug: design_pattern
   ref:
-    - iterator_pattern
-    - singleton_pattern
-    - template_method_pattern
-    - visitor_pattern
+  - iterator_pattern
+  - singleton_pattern
+  - template_method_pattern
+  - visitor_pattern
   en:
-    term: "design pattern"
-    def: >
-      A recurring pattern in software design that is specific enough to be worth
-      naming, but not so specific that a single best implementation can be provided by
-      a [library](#library). For example, [data frames](#data_frame) and database
+    term: design pattern
+    def: 'A recurring pattern in software design that is specific enough to be worth
+      naming, but not so specific that a single best implementation can be provided
+      by a [library](#library). For example, [data frames](#data_frame) and database
       [tables](#table) are instances of the same pattern.
 
+      '
   am:
     term: የንድፍ ንድፍ
-    def: >
-      የንድፍ ንድፍ  ለሶስተኛ ደረጃ መሰየሚያ ተብሎ በተጠቀሰው የሶፍትዌር ዲዛይን ውስጥ ተደጋጋሚ ንድፍ ፣ ግን በጣም የተለየ አይደለም ፣ አንድ ምርጥ አተገባበር በ [ቤተ-መጽሐፍት](#library) ሊቀርብ ይችላል ፡፡ ለምሳሌ ፣ [የውሂብ ክፈፎች] እና የመረጃ ቋት [ጠረጴዛዎች](#data_frame) ተመሳሳይ ንድፍ ምሳሌዎች ናቸው።
+    def: 'የንድፍ ንድፍ  ለሶስተኛ ደረጃ መሰየሚያ ተብሎ በተጠቀሰው የሶፍትዌር ዲዛይን ውስጥ ተደጋጋሚ ንድፍ ፣ ግን በጣም
+      የተለየ አይደለም ፣ አንድ ምርጥ አተገባበር በ [ቤተ-መጽሐፍት](#library) ሊቀርብ ይችላል ፡፡ ለምሳሌ ፣ [የውሂብ
+      ክፈፎች] እና የመረጃ ቋት [ጠረጴዛዎች](#data_frame) ተመሳሳይ ንድፍ ምሳሌዎች ናቸው።
 
+      '
 - slug: destructuring_assignment
   en:
-    term: "destructuring assignment"
-    def: >
-      Unpacking values from data structures and assigning them to multiple variables
+    term: destructuring assignment
+    def: 'Unpacking values from data structures and assigning them to multiple variables
       in a single statement.
 
+      '
   am:
     term: የሚያጠፋ ተግባር
-    def: >
-      እሴቶችን ከመረጃ መዋቅሮች ማራገፍ እና ለብዙዎች መመደብ ተለዋዋጮች በአንድ መግለጫ ፡፡
+    def: 'እሴቶችን ከመረጃ መዋቅሮች ማራገፍ እና ለብዙዎች መመደብ ተለዋዋጮች በአንድ መግለጫ ፡፡
 
+      '
 - slug: dictionary
   en:
-    term: "dictionary"
-    def: >
-      A data structure that allows items to be looked up by value, sometimes called an
-      [associative array](#associative_array). Dictionaries are often implemented
+    term: dictionary
+    def: 'A data structure that allows items to be looked up by value, sometimes called
+      an [associative array](#associative_array). Dictionaries are often implemented
       using [hash tables](#hash_table).
 
+      '
   am:
     term: መዝገበ-ቃላት
-    def: >
-      ዕቃዎችን በእሴት እንዲመለከቱ የሚያስችላቸው የውሂብ አወቃቀር ፣ አንዳንድ ጊዜ [associative array](#associative_array) ይባላል። መዝገበ ቃላት ብዙውን ጊዜ [hash tables](#hash_table) በመጠቀም ይተገበራሉ ፡፡
-  es:
-    term: "diccionario"
-    def: >
-      Una estructura de datos que contiene parejas llave-valor, a veces llamados [arreglos asociativos](#associative_array).
-      Los diccionarios en ocasiones son implementados usando [tablas hash](#hash_table).
-  uk:
-    term: "словник"
-    def: >
-      Структура даних, яка містить пари ключ-значення. Кожна пара у словнику зіставляє ключ із пов’язаним значенням.
-      Словники також іноді називаються асоціативними масивами, та часто реалізуються за  допомогою [геш-таблиць](#hash_table).
+    def: 'ዕቃዎችን በእሴት እንዲመለከቱ የሚያስችላቸው የውሂብ አወቃቀር ፣ አንዳንድ ጊዜ [associative array](#associative_array)
+      ይባላል። መዝገበ ቃላት ብዙውን ጊዜ [hash tables](#hash_table) በመጠቀም ይተገበራሉ ፡፡
 
+      '
+  es:
+    term: diccionario
+    def: 'Una estructura de datos que contiene parejas llave-valor, a veces llamados
+      [arreglos asociativos](#associative_array). Los diccionarios en ocasiones son
+      implementados usando [tablas hash](#hash_table).
+
+      '
+  uk:
+    term: словник
+    def: 'Структура даних, яка містить пари ключ-значення. Кожна пара у словнику зіставляє
+      ключ із пов’язаним значенням. Словники також іноді називаються асоціативними
+      масивами, та часто реалізуються за  допомогою [геш-таблиць](#hash_table).
+
+      '
 - slug: dimension_reduction
   ref:
-    - principal_component_analysis
+  - principal_component_analysis
   en:
-    term: "dimension reduction"
-    def: >
-      Reducing the number of dimensions in a dataset, typically by finding the
+    term: dimension reduction
+    def: 'Reducing the number of dimensions in a dataset, typically by finding the
       dimensions along which it varies most.
 
+      '
   am:
     term: ልኬት ቅነሳ
-    def: >
-      በውሂብ ስብስብ ውስጥ ያሉትን ልኬቶች ብዛት መቀነስ ፣ በተለምዶ በማግኘት
+    def: 'በውሂብ ስብስብ ውስጥ ያሉትን ልኬቶች ብዛት መቀነስ ፣ በተለምዶ በማግኘት
 
+      '
 - slug: directory
   en:
-    term: "directory"
-    def: >
-      An item within a [filesystem](#filesystem) that can contain files and other
+    term: directory
+    def: 'An item within a [filesystem](#filesystem) that can contain files and other
       directories. Also known as a [folder](#folder).
-  es:
-    term: "directorio"
-    def: >
-      Un objeto dentro de un [sistema de archivos](#filesystem) que contiene archivos y otros directorios.
-      También conocido como un [folder](#folder).
-  sw:
-    term: "Mpangilio orodha"
-    def: >
-      Kipengee ndani ya mfumo wa faili ambao unaweza kuwa na faili na saraka zingine. Pia inajulikana kama folda.
-  uk:
-    term: "каталог"
-    def: >
-      Елемент [файлової системи](#filesystem), який може містити файли та інші каталоги. Також відомий як [тека](#folder).
 
+      '
+  es:
+    term: directorio
+    def: 'Un objeto dentro de un [sistema de archivos](#filesystem) que contiene archivos
+      y otros directorios. También conocido como un [folder](#folder).
+
+      '
+  sw:
+    term: Mpangilio orodha
+    def: 'Kipengee ndani ya mfumo wa faili ambao unaweza kuwa na faili na saraka zingine.
+      Pia inajulikana kama folda.
+
+      '
+  uk:
+    term: каталог
+    def: 'Елемент [файлової системи](#filesystem), який може містити файли та інші
+      каталоги. Також відомий як [тека](#folder).
+
+      '
 - slug: discrete_random_variable
   ref:
-    - continuous_random_variable
+  - continuous_random_variable
   en:
-    term: "discrete random variable"
-    def: >
-      A [variable](#variable_data) whose value can take on only one of a fixed
+    term: discrete random variable
+    def: 'A [variable](#variable_data) whose value can take on only one of a fixed
       set of values, such as [true](#true) or [false](#false).
 
+      '
   am:
     term: ልዩ ራንደም ተለዋዋጭ
-    def: >
-      : እንደ [እውነተኛ](#variable_data) ወይም [ሐሰት](#true) ያሉ እሴቶቹ ከተወሰኑ የእሴቶች ስብስብ በአንዱ ላይ ብቻ ሊወስድ የሚችል አንድ [ተለዋዋጭ](#false)።
+    def: ': እንደ [እውነተኛ](#variable_data) ወይም [ሐሰት](#true) ያሉ እሴቶቹ ከተወሰኑ የእሴቶች ስብስብ
+      በአንዱ ላይ ብቻ ሊወስድ የሚችል አንድ [ተለዋዋጭ](#false)።
 
+      '
 - slug: distro
   en:
-    term: "distro"
-    def: >
-      See [software distribution](#software_distribution).
+    term: distro
+    def: 'See [software distribution](#software_distribution).
 
+      '
   am:
     term: ዲስትሮ
-    def: >
-      ይመልከቱ [የሶፍትዌር ስርጭት](#software_distribution)
+    def: 'ይመልከቱ [የሶፍትዌር ስርጭት](#software_distribution)
 
+      '
+- slug: divide_and_conquer
+  ref:
+  - recursion
+  - algorithm
+  en:
+    term: divide and conquer
+    def: 'An algorithm design paradigm that breaks a problem into smaller subproblems
+      of the same type, solves them independently (often using [recursion](#recursion)),
+      and combines their solutions. Examples include merge sort and quicksort.
+
+      '
 - slug: docstring
   en:
-    term: "docstring"
-    def: >
-      Short for "documentation string," a string appearing at the start of a module,
-      class, or function in [Python](#python) that automatically becomes that object's documentation.
+    term: docstring
+    def: 'Short for "documentation string," a string appearing at the start of a module,
+      class, or function in [Python](#python) that automatically becomes that object''s
+      documentation.
 
+      '
   am:
     term: ዶስተስተሪንግ
-    def: >
-      አጭር ለ "የሰነድ ሕብረቁምፊ", በ [Python](#python) ውስጥ ሞጁል ፣ ክፍል ወይም ተግባር ሲጀመር የሚታየው አንድ ሕብረቁምፊ በራስ-ሰር የዚያ ነገር ሰነድ ይሆናል።
+    def: 'አጭር ለ "የሰነድ ሕብረቁምፊ", በ [Python](#python) ውስጥ ሞጁል ፣ ክፍል ወይም ተግባር ሲጀመር የሚታየው
+      አንድ ሕብረቁምፊ በራስ-ሰር የዚያ ነገር ሰነድ ይሆናል።
 
+      '
 - slug: documentation_generator
   en:
-    term: "documentation generator"
-    def: >
-      A software tool that extracts specially formatted comments or
-      [dostrings](#docstring) from code and generates cross-referenced developer documentation.
+    term: documentation generator
+    def: 'A software tool that extracts specially formatted comments or [dostrings](#docstring)
+      from code and generates cross-referenced developer documentation.
 
+      '
   am:
     term: የሰነድ ማመንጫ
-    def: >
-      በልዩ ሁኔታ የተቀረጹ አስተያየቶችን የሚያወጣ የሶፍትዌር መሣሪያ ወይም [dostrings](#docstring)  ከኮድ እና በመስቀለኛ ማጣቀሻ ያመነጫል  የገንቢ ሰነድ ::
+    def: 'በልዩ ሁኔታ የተቀረጹ አስተያየቶችን የሚያወጣ የሶፍትዌር መሣሪያ ወይም [dostrings](#docstring)  ከኮድ
+      እና በመስቀለኛ ማጣቀሻ ያመነጫል  የገንቢ ሰነድ ::
 
+      '
 - slug: doi
   ref:
-    - orcid
+  - orcid
   en:
-    term: "Digital Object Identifier"
-    acronym: "DOI"
-    def: >
-      A unique persistent identifier for a book, paper, report, dataset, software release, or
-      other digital artefact.
-  ja:
-    term: "デジタルオブジェクト識別子"
-    acronym: "DOI"
-    def: >
-      本、文献、レポート、ソフトウェアリリースや他のデジタル媒体が持つ、固有かつ恒久的な識別子のこと。
+    term: Digital Object Identifier
+    acronym: DOI
+    def: 'A unique persistent identifier for a book, paper, report, dataset, software
+      release, or other digital artefact.
 
+      '
+  ja:
+    term: デジタルオブジェクト識別子
+    acronym: DOI
+    def: '本、文献、レポート、ソフトウェアリリースや他のデジタル媒体が持つ、固有かつ恒久的な識別子のこと。
+
+      '
   am:
     term: ዲጂታል የነገር መለያ
-    def: >
-      ለመጽሃፍ ፣ ወረቀት ፣ ሪፖርት ፣ የውሂብ ስብስብ ልዩ ልዩ የማያቋርጥ መለያ የሶፍትዌር መለቀቅ ወይም ሌላ ዲጂታል ቅርሶች።
-  uk:
-    term: "цифровий ідентифікатор об'єкта"
-    acronym: "DOI"
-    def: >
-      DOI, або Digital Object Identifier (цифровий ідентифікатор об'єкта) - це унікальний і постійний ідентифікатор книги, 
-      статті, звіту, набору даних, релізу програмного забезпечення або іншого цифрового носія.
+    def: 'ለመጽሃፍ ፣ ወረቀት ፣ ሪፖርት ፣ የውሂብ ስብስብ ልዩ ልዩ የማያቋርጥ መለያ የሶፍትዌር መለቀቅ ወይም ሌላ ዲጂታል
+      ቅርሶች።
 
+      '
+  uk:
+    term: цифровий ідентифікатор об'єкта
+    acronym: DOI
+    def: 'DOI, або Digital Object Identifier (цифровий ідентифікатор об''єкта) - це
+      унікальний і постійний ідентифікатор книги,  статті, звіту, набору даних, релізу
+      програмного забезпечення або іншого цифрового носія.
+
+      '
 - slug: dom
   en:
-    term: "Document Object Model"
-    acronym: "DOM"
-    def: >
-      A standard, in-memory representation of [HTML](#html) and [XML](#xml). Each
+    term: Document Object Model
+    acronym: DOM
+    def: 'A standard, in-memory representation of [HTML](#html) and [XML](#xml). Each
       [element](#element) is stored as a [node](#node) in a [tree](#tree) with a set
-      of named [attributes](#attribute); contained elements are [child
-      nodes](#child_tree). Modern programming languages provide many [libraries](#library) for
-      searching and modifying the DOM.
+      of named [attributes](#attribute); contained elements are [child nodes](#child_tree).
+      Modern programming languages provide many [libraries](#library) for searching
+      and modifying the DOM.
 
+      '
   am:
     term: ዶም
-    def: >
-      የ [HTML](#html) መደበኛ እና ማህደረ ትውስታ ውክልና እና [XML](#xml) እያንዳንዱ [ንጥረ ነገር](#element) በአንድ [ዛፍ](#tree) ውስጥ እንደ [node](#node) ይቀመጣል ከተሰየመ [ባህሪዎች](#tree) ብስብ ጋር; የተካተቱ አካላት [የህፃናት ኖዶች](#attribute) ናቸው ፡፡ DOM ን ለመፈለግ እና ለማሻሻል ዘመናዊ የፕሮግራም ቋንቋዎች ብዙ [ቤተ-መጻሕፍት](#child_tree) ይሰጣሉ ፡፡
+    def: 'የ [HTML](#html) መደበኛ እና ማህደረ ትውስታ ውክልና እና [XML](#xml) እያንዳንዱ [ንጥረ ነገር](#element)
+      በአንድ [ዛፍ](#tree) ውስጥ እንደ [node](#node) ይቀመጣል ከተሰየመ [ባህሪዎች](#tree) ብስብ ጋር; የተካተቱ
+      አካላት [የህፃናት ኖዶች](#attribute) ናቸው ፡፡ DOM ን ለመፈለግ እና ለማሻሻል ዘመናዊ የፕሮግራም ቋንቋዎች ብዙ
+      [ቤተ-መጻሕፍት](#child_tree) ይሰጣሉ ፡፡
 
+      '
 - slug: dom_selector
   ref:
-    - regular_expression
+  - regular_expression
   en:
-    term: "DOM selector"
-    def: >
-      A pattern that identifies [nodes](#node) in a [DOM](#dom) [tree](#tree). For
-      example, `#alpha` matches nodes whose `id` [attribute](#attribute) is "alpha",
+    term: DOM selector
+    def: 'A pattern that identifies [nodes](#node) in a [DOM](#dom) [tree](#tree).
+      For example, `#alpha` matches nodes whose `id` [attribute](#attribute) is "alpha",
       while `.beta` matches nodes whose `class` [attribute](#attribute) is "beta".
 
+      '
   am:
     term: የዶም  መራጭ
     def: በ [DOM](#dom) [ዛፍ] ውስጥ [nodes](#node) ን የሚለይ ንድፍ። ለምሳሌ ፣ "#አልፋ" "መታወቂያቸው"
       (አይነታ) አስፈላጊ ሆኖ ከተገኘባቸው አንጓዎች ጋር ይዛመዳል።
-
 - slug: domain_knowledge
   en:
-    term: "domain knowledge"
-    def: >
-      Understanding of a specific problem domain, e.g., knowledge of transportation logistics.
+    term: domain knowledge
+    def: 'Understanding of a specific problem domain, e.g., knowledge of transportation
+      logistics.
 
+      '
   am:
     term: የጎራ እውቀት
-    def: >
-      ስለ አንድ የተወሰነ የችግር ጎራ መረዳትን ፣ ለምሳሌ ፣ ስለ የትራንስፖርት ሎጂስቲክስ.
+    def: 'ስለ አንድ የተወሰነ የችግር ጎራ መረዳትን ፣ ለምሳሌ ፣ ስለ የትራንስፖርት ሎጂስቲክስ.
 
+      '
   sw:
-    term: "maarifa ya kikoa"
-    def: >
-      Uelewa wa kikoa maalum, kwa mfano, ujuzi wa vifaa vya usafiri.
+    term: maarifa ya kikoa
+    def: 'Uelewa wa kikoa maalum, kwa mfano, ujuzi wa vifaa vya usafiri.
 
+      '
 - slug: double
   en:
-    term: "double"
-    def: >
-      Short for "double-precision floating-point number", meaning a 64-bit numeric
+    term: double
+    def: 'Short for "double-precision floating-point number", meaning a 64-bit numeric
       value with a fractional part and an exponent.
 
+      '
   am:
     term: ድርብ
-    def: >
-      አጭር ለ & quot; ድርብ ትክክለኛነት ተንሳፋፊ-ነጥብ ቁጥር & quot ;, ማለት 64-ቢት ነው ቁጥራዊ እሴት ከፋፋይ ክፍል እና አንድ አክሲዮን ጋር።
+    def: 'አጭር ለ & quot; ድርብ ትክክለኛነት ተንሳፋፊ-ነጥብ ቁጥር & quot ;, ማለት 64-ቢት ነው ቁጥራዊ እሴት
+      ከፋፋይ ክፍል እና አንድ አክሲዮን ጋር።
 
+      '
 - slug: double_square_brackets
   ref:
-    - single_square_brackets
+  - single_square_brackets
   en:
-    term: "double square brackets"
-    def: >
-      An index enclosed in `[[...]]`, used to return a single value of the underlying type.
+    term: double square brackets
+    def: 'An index enclosed in `[[...]]`, used to return a single value of the underlying
+      type.
 
+      '
   am:
     term: ባለ ሁለት ካሬ ቅንፎች
-    def: >
-      በ [[...]] ውስጥ የተካተተ መረጃ ጠቋሚ ፣ የአንድ ነጠላ ዋጋን ለመመለስ ያገለግል ነበር የመነሻ ዓይነት::
+    def: 'በ [[...]] ውስጥ የተካተተ መረጃ ጠቋሚ ፣ የአንድ ነጠላ ዋጋን ለመመለስ ያገለግል ነበር የመነሻ ዓይነት::
 
+      '
 - slug: down_vote
   ref:
-    - up_vote
+  - up_vote
   en:
-    term: "down-vote"
-    def: >
-      A vote against something.
+    term: down-vote
+    def: 'A vote against something.
+
+      '
   af:
-    term: "afstem"
-    def: >
-      Om teen iets te stem.
+    term: afstem
+    def: 'Om teen iets te stem.
+
+      '
   am:
     term: ወደታች ድምጽ መስጠት
-    def: >
-      በአንድ ነገር ላይ የሚደረግ ድምጽ
+    def: 'በአንድ ነገር ላይ የሚደረግ ድምጽ
 
+      '
   sw:
-    term: "kura ya chini"
-    def: >
-      Kura dhidi ya kitu.
+    term: kura ya chini
+    def: 'Kura dhidi ya kitu.
 
+      '
 - slug: dry
   en:
-    term: "Don't Repeat Yourself principle"
-    acronym: "DRY"
-    def: >
-      The Don't Repeat Yourself (DRY) principle states that — Every piece of knowledge
-      must have a single, unambiguous, authoritative representation within a system.
-      The term comes from The Pragmatic Programmer, by Andrew Hunt and David Thomas.
-      Programs that follow the DRY Principle avoid duplication of definitions and logic,
-      so that a change in their behaviour only requires each modification to be made in
-      one part of the code. The goal is to create code that is easier to maintain.
+    term: Don't Repeat Yourself principle
+    acronym: DRY
+    def: 'The Don''t Repeat Yourself (DRY) principle states that — Every piece of
+      knowledge must have a single, unambiguous, authoritative representation within
+      a system. The term comes from The Pragmatic Programmer, by Andrew Hunt and David
+      Thomas. Programs that follow the DRY Principle avoid duplication of definitions
+      and logic, so that a change in their behaviour only requires each modification
+      to be made in one part of the code. The goal is to create code that is easier
+      to maintain.
 
+      '
   am:
     term: የራስዎን መርህ አይድገሙ
-    def: >
-      የራስዎን (ደረቅ) መርህ አይደገምም የሚለው - እያንዳንዱ ቁራጭ የእውቀት በውስጡ አንድ ነጠላ ፣ የማያሻማ ፣ ስልጣን ያለው ውክልና ሊኖረው ይገባል አንድ ስርዓት. ቃሉ የመጣው ከፕራግማዊ መርሃግብሩ ፣ በአንድሪው ሁንት እና ዴቪድ ቶማስ ፡፡ የ "ደረቅ" መርህን የሚከተሉ ፕሮግራሞች የ ‹ብዜትን› ያስወግዳሉ ትርጓሜዎች እና አመክንዮዎች ፣ ስለሆነም በባህሪያቸው ላይ የሚደረገው ለውጥ እያንዳንዱን ማሻሻያ ብቻ ይፈልጋል በኮዱ አንድ ክፍል ውስጥ እንዲሠራ ፡፡ ግቡ ቀለል ያለ ኮድ መፍጠር ነው ጠብቅ ::
+    def: 'የራስዎን (ደረቅ) መርህ አይደገምም የሚለው - እያንዳንዱ ቁራጭ የእውቀት በውስጡ አንድ ነጠላ ፣ የማያሻማ ፣ ስልጣን
+      ያለው ውክልና ሊኖረው ይገባል አንድ ስርዓት. ቃሉ የመጣው ከፕራግማዊ መርሃግብሩ ፣ በአንድሪው ሁንት እና ዴቪድ ቶማስ ፡፡
+      የ "ደረቅ" መርህን የሚከተሉ ፕሮግራሞች የ ‹ብዜትን› ያስወግዳሉ ትርጓሜዎች እና አመክንዮዎች ፣ ስለሆነም በባህሪያቸው
+      ላይ የሚደረገው ለውጥ እያንዳንዱን ማሻሻያ ብቻ ይፈልጋል በኮዱ አንድ ክፍል ውስጥ እንዲሠራ ፡፡ ግቡ ቀለል ያለ ኮድ መፍጠር
+      ነው ጠብቅ ::
 
+      '
 - slug: dynamic_loading
   en:
-    term: "dynamic loading"
-    def: >
-      To [import](#import) a [module](#module) into the memory of a program while it
-      is already running. Most [interpreted languages](#interpreted_language) use
+    term: dynamic loading
+    def: 'To [import](#import) a [module](#module) into the memory of a program while
+      it is already running. Most [interpreted languages](#interpreted_language) use
       dynamic loading, and provide tools so that programs can find and load modules
       dynamically to configure themselves.
 
+      '
   am:
     term: ተለዋዋጭ ጭነት
-    def: >
-      አንድን (ሞዱል)(#import)ቀድሞውኑ በሚሰራበት ጊዜ ወደ ማህደረ ትውስታ ለማስገባት (ለማስመጣት)(#module) ፡፡ አብዛኛዎቹ [የተተረጎሙ ቋንቋዎች](#interpreted_language) ተለዋዋጭ ጭነት ይጠቀማሉ ፣ እና ፕሮግራሞች ሞጁሎችን ማግኘት እና መጫን እንዲችሉ መሣሪያዎችን ያቅርቡ ተለዋዋጭ በሆነ መልኩ ራሳቸውን ለማዋቀር ፡፡
+    def: 'አንድን (ሞዱል)(#import)ቀድሞውኑ በሚሰራበት ጊዜ ወደ ማህደረ ትውስታ ለማስገባት (ለማስመጣት)(#module)
+      ፡፡ አብዛኛዎቹ [የተተረጎሙ ቋንቋዎች](#interpreted_language) ተለዋዋጭ ጭነት ይጠቀማሉ ፣ እና ፕሮግራሞች
+      ሞጁሎችን ማግኘት እና መጫን እንዲችሉ መሣሪያዎችን ያቅርቡ ተለዋዋጭ በሆነ መልኩ ራሳቸውን ለማዋቀር ፡፡
 
+      '
 - slug: dynamic_lookup
   en:
-    term: "dynamic lookup"
-    def: >
-      To find a function or a property of an [object](#object) by name while a program
-      is running. For example, instead of getting a specific property of an object
-      using `obj.name`, a program might use `obj[someVariable]`, where `someVariable`
+    term: dynamic lookup
+    def: 'To find a function or a property of an [object](#object) by name while a
+      program is running. For example, instead of getting a specific property of an
+      object using `obj.name`, a program might use `obj[someVariable]`, where `someVariable`
       could hold `"name"` or some other property name.
 
+      '
   am:
     term: ተለዋዋጭ ፍለጋ
-    def: >
-      የአንድ [ዕቃ](#object) ተግባር ወይም ንብረት በስም ለማግኘት ፕሮግራም እየሰራ እያለ ፡፡ ለምሳሌ ፣ የተወሰነ ንብረት ከማግኘት ይልቅ የ አንድ ነገር "obj.name` ን በመጠቀም አንድ ፕሮግራም" obj [someVariable] "ን ፣ የት ሊጠቀም ይችላል "someVariable`" & quot; name & quot; ወይም ሌላ ሌላ የንብረት ስም መያዝ ይችላል።
+    def: 'የአንድ [ዕቃ](#object) ተግባር ወይም ንብረት በስም ለማግኘት ፕሮግራም እየሰራ እያለ ፡፡ ለምሳሌ ፣ የተወሰነ
+      ንብረት ከማግኘት ይልቅ የ አንድ ነገር "obj.name` ን በመጠቀም አንድ ፕሮግራም" obj [someVariable] "ን
+      ፣ የት ሊጠቀም ይችላል "someVariable`" & quot; name & quot; ወይም ሌላ ሌላ የንብረት ስም መያዝ ይችላል።
 
+      '
+- slug: dynamic_programming
+  ref:
+  - memoization
+  - recursion
+  en:
+    term: dynamic programming
+    def: 'An algorithmic technique for solving complex problems by breaking them down
+      into simpler overlapping subproblems and storing their solutions to avoid redundant
+      calculations. Often uses [memoization](#memoization) or tabulation.
+
+      '
 - slug: dynamic_scoping
   en:
-    term: "dynamic scoping"
-    def: >
-      To find the value of a [variable](#variable_program) by looking at what is on
-      the [call stack](#call_stack) at the moment the lookup is done. Almost all
-      programming languages use [lexical_scoping](#lexical_scoping) instead, since it
-      is more predictable.
+    term: dynamic scoping
+    def: 'To find the value of a [variable](#variable_program) by looking at what
+      is on the [call stack](#call_stack) at the moment the lookup is done. Almost
+      all programming languages use [lexical_scoping](#lexical_scoping) instead, since
+      it is more predictable.
 
+      '
   am:
     term: ተለዋዋጭ ስኮፒንግ
-    def: >
-      ምን እንደ ሆነ በማየት የአንድ [ተለዋዋጭ](#variable_program) ዋጋ ለማግኘት ፍለጋው በተጠናቀቀበት ጊዜ [የጥሪ ቁልል](#call_stack) ፡፡ ሁሉም ማለት ይቻላል የበለጠ ሊተነበይ ስለሚችል የፕሮግራም ቋንቋዎች ይልቁንስ [lexical_scoping](#lexical_scoping) ን ይጠቀማሉ ፡፡
+    def: 'ምን እንደ ሆነ በማየት የአንድ [ተለዋዋጭ](#variable_program) ዋጋ ለማግኘት ፍለጋው በተጠናቀቀበት ጊዜ
+      [የጥሪ ቁልል](#call_stack) ፡፡ ሁሉም ማለት ይቻላል የበለጠ ሊተነበይ ስለሚችል የፕሮግራም ቋንቋዎች ይልቁንስ [lexical_scoping](#lexical_scoping)
+      ን ይጠቀማሉ ፡፡
 
+      '
 - slug: edge
   en:
-    term: "edge"
-    def: >
-      A connection between two [nodes](#node) in a [graph](#graph). An edge may have
-      data associated with it, such as a name or distance.
+    term: edge
+    def: 'A connection between two [nodes](#node) in a [graph](#graph). An edge may
+      have data associated with it, such as a name or distance.
 
+      '
   am:
     term: ጠርዝ
-    def: >
-      በ [ግራፍ](#node)ውስጥ በሁለት [ኖዶች](#graph) መካከል ያለ ግንኙነት። አንድ ጠርዝ እንደ ስም ወይም ርቀት ያለ ከዚህ ጋር የተጎዳኘ ውሂብ ሊኖረው ይችላል።
-  sw:
-    term: "kingo"
-    def: >
-      Muunganisho kati ya [nodes] mbili (#node) katika [graph](#graph).
-      Kingo yanaweza kuwa data inayohusishwa nayo, kama vile jina au umbali.
+    def: 'በ [ግራፍ](#node)ውስጥ በሁለት [ኖዶች](#graph) መካከል ያለ ግንኙነት። አንድ ጠርዝ እንደ ስም ወይም ርቀት
+      ያለ ከዚህ ጋር የተጎዳኘ ውሂብ ሊኖረው ይችላል።
 
+      '
+  sw:
+    term: kingo
+    def: 'Muunganisho kati ya [nodes] mbili (#node) katika [graph](#graph). Kingo
+      yanaweza kuwa data inayohusishwa nayo, kama vile jina au umbali.
+
+      '
 - slug: element
   ref:
-    - empty_element
+  - empty_element
   en:
-    term: "element"
-    def: >
-      A named component in an [HTML](#html) or [XML](#xml) document. Elements are
-      usually written `<name>`...`</name>`, where "..." represents the content of the
-      element. Elements often have [attributes](#attribute).
+    term: element
+    def: 'A named component in an [HTML](#html) or [XML](#xml) document. Elements
+      are usually written `<name>`...`</name>`, where "..." represents the content
+      of the element. Elements often have [attributes](#attribute).
 
+      '
   am:
     term: ንጥረ ነገር
-    def: >
-      በ [HTML](#html) ወይም [XML](#xml) ሰነድ ውስጥ የተሰየመ አካል ንጥረ ነገሮች ብዙውን ጊዜ የተጻፉት "& lt; name & gt;" ... "& lt; / name & gt;", የት & quot; ... & quot; የንጥሉን ይዘት ይወክላል። ንጥረ ነገሮች ብዙውን ጊዜ [ባህሪዎች] አላቸው (#ባህሪ)።
+    def: 'በ [HTML](#html) ወይም [XML](#xml) ሰነድ ውስጥ የተሰየመ አካል ንጥረ ነገሮች ብዙውን ጊዜ የተጻፉት
+      "& lt; name & gt;" ... "& lt; / name & gt;", የት & quot; ... & quot; የንጥሉን ይዘት
+      ይወክላል። ንጥረ ነገሮች ብዙውን ጊዜ [ባህሪዎች] አላቸው (#ባህሪ)።
 
+      '
 - slug: emacs
   en:
-    term: "Emacs (editor)"
-    def: >
-      A text editor that is popular among Unix programmers.
+    term: Emacs (editor)
+    def: 'A text editor that is popular among Unix programmers.
 
+      '
   af:
-    term: "Emacs (teksredigeerder)"
-    def: >
-      'n teksredigeerder wat gewild is onder Unix-programmeerders.
+    term: Emacs (teksredigeerder)
+    def: '''n teksredigeerder wat gewild is onder Unix-programmeerders.
 
-
+      '
 - slug: email
   en:
-    term: "Electronic mail"
-    acronym: "email"
-    def: >
-      Electronic mail is a method for delivering messages between people over a computer network.
-      Messages are sent via an [SMTP](#smtp) server and retrieved using either an [IMAP](#imap) or
-      [POP](#pop) server.
+    term: Electronic mail
+    acronym: email
+    def: 'Electronic mail is a method for delivering messages between people over
+      a computer network. Messages are sent via an [SMTP](#smtp) server and retrieved
+      using either an [IMAP](#imap) or [POP](#pop) server.
 
+      '
   af:
-    term: "Elektronisese pos"
-    acronym: "epos"
-    def: >
-      Elektroniese pos is 'n metode vir die aflewering van boodskappe tussen mense oor 'n rekenaarnetwerk.  
-      Boodskappe word via 'n [SMTP](#smtp) bediener gestuur en verkry deur gebruik te maak van óf 'n [IMAP](#imap) óf 'n [POP](#pop) bediener.
+    term: Elektronisese pos
+    acronym: epos
+    def: 'Elektroniese pos is ''n metode vir die aflewering van boodskappe tussen
+      mense oor ''n rekenaarnetwerk.   Boodskappe word via ''n [SMTP](#smtp) bediener
+      gestuur en verkry deur gebruik te maak van óf ''n [IMAP](#imap) óf ''n [POP](#pop)
+      bediener.
 
-
+      '
 - slug: empty_element
   en:
-    term: "empty element"
-    def: >
-      An [element](#element) of an [HTML](#html) or [XML](#xml) document that has no
-      [children](#child_tree). Empty elements can always be written as
-      `<name></name>`, but may also be written using the shorthand notation `<name/>`
-      (with a slash after the name inside the angle brackets).
+    term: empty element
+    def: 'An [element](#element) of an [HTML](#html) or [XML](#xml) document that
+      has no [children](#child_tree). Empty elements can always be written as `<name></name>`,
+      but may also be written using the shorthand notation `<name/>` (with a slash
+      after the name inside the angle brackets).
 
+      '
   am:
     term: ባዶ አካል
-    def: >
-      የ [ኤችቲኤምኤል](#element) ወይም የ [XML](#xml) ሰነድ [አባል](#child_tree) ምንም [ልጆች] የሌሉት (#የልጁ_ ዛፍ)። ባዶ አባሎች ሁል ጊዜ እንደ"& lt; name & gt; & lt; / name & gt;"ተብሎ ሊፃፉ ይችላሉ ፣ ነገር ግን በአጭሩ ማሳወቂያ በመጠቀም ሊፃፍ ይችላል & (lt; name / & gt;
+    def: 'የ [ኤችቲኤምኤል](#element) ወይም የ [XML](#xml) ሰነድ [አባል](#child_tree) ምንም [ልጆች]
+      የሌሉት (#የልጁ_ ዛፍ)። ባዶ አባሎች ሁል ጊዜ እንደ"& lt; name & gt; & lt; / name & gt;"ተብሎ ሊፃፉ
+      ይችላሉ ፣ ነገር ግን በአጭሩ ማሳወቂያ በመጠቀም ሊፃፍ ይችላል & (lt; name / & gt;
 
+      '
 - slug: empty_vector
   en:
-    term: "empty vector"
-    def: >
-      A vector that contains no elements. Empty vectors have a type such as logical or
-      character, and are *not* the same as [null](#null).
-  
+    term: empty vector
+    def: 'A vector that contains no elements. Empty vectors have a type such as logical
+      or character, and are *not* the same as [null](#null).
+
+      '
   af:
-    term: "leë vektor"
-    def: >
-      'n Vektor wat geen elemente bevat nie. Leë vektore het 'n tipe soos logies of karakter, en is *nie* dieselfde as [nul](#null) nie.
+    term: leë vektor
+    def: '''n Vektor wat geen elemente bevat nie. Leë vektore het ''n tipe soos logies
+      of karakter, en is *nie* dieselfde as [nul](#null) nie.
 
-
+      '
   fr:
-    term: "vecteur vide"
-    def: >
-      Un vecteur qui ne contient aucun élément. Les vecteurs vides possèdent un type, par
-      exemple entier ou caractère, et sont *différents* de [null](#null).
+    term: vecteur vide
+    def: 'Un vecteur qui ne contient aucun élément. Les vecteurs vides possèdent un
+      type, par exemple entier ou caractère, et sont *différents* de [null](#null).
 
+      '
   am:
     term: ባዶ ቬክተር
-    def: >
-      ምንም ንጥረ ነገሮችን ያልያዘ ቬክተር። ባዶ ቬክተሮች እንደ ሎጂካዊ ወይም ቁምፊ ዓይነት አላቸው ፣ እና እንደ [null](#null) * ተመሳሳይ * አይደሉም።
+    def: 'ምንም ንጥረ ነገሮችን ያልያዘ ቬክተር። ባዶ ቬክተሮች እንደ ሎጂካዊ ወይም ቁምፊ ዓይነት አላቸው ፣ እና እንደ [null](#null)
+      * ተመሳሳይ * አይደሉም።
 
+      '
 - slug: encoding
   en:
-    term: "encoding"
-    def: >
-      The process of putting a sequence of characters such as letters, numbers, punctuation,
-      and certain symbols, into a specialized format for efficient transmission or storage.
+    term: encoding
+    def: 'The process of putting a sequence of characters such as letters, numbers,
+      punctuation, and certain symbols, into a specialized format for efficient transmission
+      or storage.
 
+      '
   af:
-    term: "kodering"
-    def: >
-      Die proses waardeur 'n reeks karakters, soos letters, syfers, interpunktiewe tekens en sekere simbole, in 'n gespesialiseerde formaat geplaas word vir doeltreffende oordrag of berging
+    term: kodering
+    def: 'Die proses waardeur ''n reeks karakters, soos letters, syfers, interpunktiewe
+      tekens en sekere simbole, in ''n gespesialiseerde formaat geplaas word vir doeltreffende
+      oordrag of berging
 
+      '
   uk:
-    term: "кодування"
-    def: >
-      Процес переробки послідовності символів, таких як літери, цифри, знаки пунктуації та
-      інші спеціальні символи, у інший формат, який передбачає їх ефективну передачу чи зберігання.
+    term: кодування
+    def: 'Процес переробки послідовності символів, таких як літери, цифри, знаки пунктуації
+      та інші спеціальні символи, у інший формат, який передбачає їх ефективну передачу
+      чи зберігання.
 
+      '
 - slug: environment
   en:
-    term: "environment"
-    def: >
-      A structure that stores a set of variable names and the values they refer to.
+    term: environment
+    def: 'A structure that stores a set of variable names and the values they refer
+      to.
 
+      '
   af:
-    term: "omgewing"
-    def: >
-      'n Struktuur wat 'n stel van veranderlike name en die waardes waarna na verwys, stoor.
+    term: omgewing
+    def: '''n Struktuur wat ''n stel van veranderlike name en die waardes waarna na
+      verwys, stoor.
 
+      '
   fr:
-    term: "environnement"
-    def: >
-      Une structure qui stocke un ensemble de noms de variables et les valeurs qui leur
-      sont associées.
+    term: environnement
+    def: 'Une structure qui stocke un ensemble de noms de variables et les valeurs
+      qui leur sont associées.
 
+      '
   am:
     term: አካባቢ
-    def: >
-      ተለዋዋጭ ስሞችን እና የሚጠቅሷቸውን እሴቶች የሚያከማች መዋቅር።
+    def: 'ተለዋዋጭ ስሞችን እና የሚጠቅሷቸውን እሴቶች የሚያከማች መዋቅር።
 
-
+      '
   sw:
-    term: "mazingira"
-    def: >
-      Muundo unaohifadhi seti ya majina tofauti na thamani wanazorejelea.
+    term: mazingira
+    def: 'Muundo unaohifadhi seti ya majina tofauti na thamani wanazorejelea.
 
+      '
+- slug: epoch_dl
+  ref:
+  - deep_learning
+  - backpropagation
+  - perceptron
+  - neural_network
+  - machine_learning
+  en:
+    term: epoch (deep learning)
+    def: 'In [deep learning](#deep_learning), an epoch is one cycle in the deep learning
+      process where all the training data has been fed to the algorithm once. Training
+      a deep neural networks usually consists of multiple epochs.
+
+      '
+  es:
+    term: epoch (aprendizaje profundo)
+    def: "En [aprendizaje profundo](#deep_learning), un epoch es un ciclo completo\
+      \ en el proceso del aprendizaje profundo  en el que todos los datos de entrenamiento\
+      \ se han introducido una vez en el algoritmo.  El entrenamiento de una red neuronal\
+      \ profunda consiste en varios epoch.    \n"
 - slug: error_handling
   en:
-    term: "error handling"
-    def: >
-      What a program does to detect and correct for errors. Examples include printing
+    term: error handling
+    def: 'What a program does to detect and correct for errors. Examples include printing
       a message and using a default configuration if the user-specified configuration
       cannot be found.
 
+      '
   af:
-    term: "foutbehandeling"
-    def: >
-     Wat 'n program doen om foute op te spoor en reg te stel. Voorbeelde sluit in die afdruk van 'n boodskap en die gebruik van 'n 
-     standaardkonfigurasie as die gebruiker-gespesifiseerde konfigurasie nie gevind kan word nie.
+    term: foutbehandeling
+    def: 'Wat ''n program doen om foute op te spoor en reg te stel. Voorbeelde sluit
+      in die afdruk van ''n boodskap en die gebruik van ''n  standaardkonfigurasie
+      as die gebruiker-gespesifiseerde konfigurasie nie gevind kan word nie.
 
+      '
   am:
     term: ስህተትን  መቆጣጠር
-    def: >
-      አንድ ፕሮግራም ስህተቶችን ለመመርመር እና ለማረም ምን ያደርጋል። ምሳሌዎች በተጠቃሚ የተገለጸ ውቅር ሊገኝ የማይችል ከሆነ መልእክት ማተም እና ነባሪ ውቅረትን መጠቀምን ያካትታሉ።
+    def: 'አንድ ፕሮግራም ስህተቶችን ለመመርመር እና ለማረም ምን ያደርጋል። ምሳሌዎች በተጠቃሚ የተገለጸ ውቅር ሊገኝ የማይችል
+      ከሆነ መልእክት ማተም እና ነባሪ ውቅረትን መጠቀምን ያካትታሉ።
 
+      '
 - slug: error_test
   en:
-    term: "error (in a test)"
-    def: >
-      Signalled when something goes wrong in a [unit test](#unit_test) itself rather
-      than in the system being tested. In this case, we do not know anything about the
-      correctness of the system.
+    term: error (in a test)
+    def: 'Signalled when something goes wrong in a [unit test](#unit_test) itself
+      rather than in the system being tested. In this case, we do not know anything
+      about the correctness of the system.
 
+      '
   af:
-    term: "fout (in 'n toets)"
-    def: >
-      Aangewys wanneer iets verkeerd gaan in 'n [eenheidstoets](#unit_test) self eerder as in die stelsel wat getoets word. In hierdie geval weet ons niks van die 
-      korrekheid van die stelsel nie.
+    term: fout (in 'n toets)
+    def: 'Aangewys wanneer iets verkeerd gaan in ''n [eenheidstoets](#unit_test) self
+      eerder as in die stelsel wat getoets word. In hierdie geval weet ons niks van
+      die  korrekheid van die stelsel nie.
 
-
+      '
   am:
     term: የስህተት አያያዝ
-    def: >
-      አንድ ፕሮግራም ስህተቶችን ለመመርመር እና ለማረም ምን ያደርጋል። ምሳሌዎች በተጠቃሚ የተገለጸ ውቅር ሊገኝ የማይችል ከሆነ መልእክት ማተም እና ነባሪ ውቅረትን መጠቀምን ያካትታሉ።
+    def: 'አንድ ፕሮግራም ስህተቶችን ለመመርመር እና ለማረም ምን ያደርጋል። ምሳሌዎች በተጠቃሚ የተገለጸ ውቅር ሊገኝ የማይችል
+      ከሆነ መልእክት ማተም እና ነባሪ ውቅረትን መጠቀምን ያካትታሉ።
 
+      '
 - slug: escape_sequence
   en:
-    term: "escape sequence"
-    def: >
-      A sequence of characters added as a prefix to some other character that would
-      otherwise have a special meaning, temporarily altering the meaning of the character.
-      For example, the escape sequence `\"` is used to represent a double-quote character
-      inside a double-quoted string.
+    term: escape sequence
+    def: 'A sequence of characters added as a prefix to some other character that
+      would otherwise have a special meaning, temporarily altering the meaning of
+      the character. For example, the escape sequence `\"` is used to represent a
+      double-quote character inside a double-quoted string.
 
+      '
   am:
     term: የማምለጫ ቅደም ተከተል
-    def: >
-      ለሌላ ገጸ-ባህሪ እንደ ቅድመ-ቅጥያ የታከሉ የቁምፊዎች ቅደም ተከተል ያ ማለት ትርጉሙን ለጊዜው የሚቀይር ልዩ ትርጉም ይኖረዋል የባህሪው ለምሳሌ ፣ የማምለጫ ቅደም ተከተል "\ & quot;"በድርብ በተጠቀሰው ገመድ ውስጥ ባለ ሁለት ጥቅስ ቁምፊን ለመወከል ጥቅም ላይ ይውላል።
+    def: 'ለሌላ ገጸ-ባህሪ እንደ ቅድመ-ቅጥያ የታከሉ የቁምፊዎች ቅደም ተከተል ያ ማለት ትርጉሙን ለጊዜው የሚቀይር ልዩ ትርጉም
+      ይኖረዋል የባህሪው ለምሳሌ ፣ የማምለጫ ቅደም ተከተል "\ & quot;"በድርብ በተጠቀሰው ገመድ ውስጥ ባለ ሁለት ጥቅስ
+      ቁምፊን ለመወከል ጥቅም ላይ ይውላል።
 
+      '
 - slug: evaluation
   en:
-    term: "evaluation"
-    def: >
-      The process of taking an expression such as `1+2*3/4` and turning it into a
-      single, irreducible value.
+    term: evaluation
+    def: 'The process of taking an expression such as `1+2*3/4` and turning it into
+      a single, irreducible value.
 
+      '
   af:
-    term: "evaluering"
-    def: >
-     Die proses om 'n uitdrukking soos 1+2*3/4 te neem en dit om te skakel in 'n enkele, onherleidbare waarde.
+    term: evaluering
+    def: 'Die proses om ''n uitdrukking soos 1+2*3/4 te neem en dit om te skakel in
+      ''n enkele, onherleidbare waarde.
 
+      '
   am:
     term: ግምገማ
-    def: >
-      እንደ "1 + 2 * 3/4" ያለ አገላለጽን የመውሰድ እና የማዞር ሂደት ወደ አንድ ፣ የማይቀለበስ እሴት።
+    def: 'እንደ "1 + 2 * 3/4" ያለ አገላለጽን የመውሰድ እና የማዞር ሂደት ወደ አንድ ፣ የማይቀለበስ እሴት።
 
+      '
   sw:
-    term: "tathmini"
-    def: >
-      Mchakato wa kuchukua usemi kama vile `1+2*3/4` na kuugeuza kuwa thamani moja isiyoweza kupunguzwa.
+    term: tathmini
+    def: 'Mchakato wa kuchukua usemi kama vile `1+2*3/4` na kuugeuza kuwa thamani
+      moja isiyoweza kupunguzwa.
 
+      '
 - slug: exception
   en:
-    term: "exception"
-    def: >
-      An object that stores information about an error or other unusual event in a
-      program. One part of a program will create and [raise an
-      exception](#raise_exception) to signal that something unexpected has happened;
-      another part will [catch](#catch_exception) it.
+    term: exception
+    def: 'An object that stores information about an error or other unusual event
+      in a program. One part of a program will create and [raise an exception](#raise_exception)
+      to signal that something unexpected has happened; another part will [catch](#catch_exception)
+      it.
 
+      '
   am:
     term: በስተቀር
-    def: >
-      ስለ ስህተት ወይም ሌላ ያልተለመደ መረጃን የሚያከማች ዕቃ ክስተት በፕሮግራም ውስጥ ፡፡ አንድ የፕሮግራም አንድ ክፍል ይፈጥራል እና አንድ ያሳድጋል በስተቀር] አንድ ያልተጠበቀ ነገር እንዳለው ለማመልከት (#raise_exception) ተከስቷል; ሌላ ክፍል [ይይዛል](#catch_exception) ፡፡
+    def: 'ስለ ስህተት ወይም ሌላ ያልተለመደ መረጃን የሚያከማች ዕቃ ክስተት በፕሮግራም ውስጥ ፡፡ አንድ የፕሮግራም አንድ ክፍል
+      ይፈጥራል እና አንድ ያሳድጋል በስተቀር] አንድ ያልተጠበቀ ነገር እንዳለው ለማመልከት (#raise_exception) ተከስቷል;
+      ሌላ ክፍል [ይይዛል](#catch_exception) ፡፡
 
+      '
 - slug: exception_handler
   en:
-    term: "exception handler"
-    def: >
-      A piece of code that deals with an [exception](#exception) after it is
-      [caught](#catch_exception), e.g., by writing a [log message](#log_message),
-      retrying the operation that failed, or performing an alternate operation.
+    term: exception handler
+    def: 'A piece of code that deals with an [exception](#exception) after it is [caught](#catch_exception),
+      e.g., by writing a [log message](#log_message), retrying the operation that
+      failed, or performing an alternate operation.
 
+      '
   am:
     term: ልዩ ተቆጣጣሪ
-    def: >
-      ከእሱ በኋላ [በስተቀር](#exception) ጋር የሚዛመድ የቁጥር ቁራጭ ተይ [ል (#catch_exception) ፣ ለምሳሌ ፣ አንድ [የምዝግብ ማስታወሻ](#log_message) በመጻፍ  ፣ ያልተሳካውን ክወና እንደገና በመሞከር ወይም ተለዋጭ ክዋኔን በማከናወን ላይ።
+    def: 'ከእሱ በኋላ [በስተቀር](#exception) ጋር የሚዛመድ የቁጥር ቁራጭ ተይ [ል (#catch_exception) ፣
+      ለምሳሌ ፣ አንድ [የምዝግብ ማስታወሻ](#log_message) በመጻፍ  ፣ ያልተሳካውን ክወና እንደገና በመሞከር ወይም ተለዋጭ
+      ክዋኔን በማከናወን ላይ።
 
+      '
 - slug: expected_result
   ref:
-    - actual_result
+  - actual_result
   en:
-    term: "expected result (of test)"
-    def: >
-      The value that a piece of software is supposed to produce when tested in a
-      certain way, or the state in which it is supposed to leave the system.
+    term: expected result (of test)
+    def: 'The value that a piece of software is supposed to produce when tested in
+      a certain way, or the state in which it is supposed to leave the system.
 
+      '
   am:
     term: የተጠበቀው ውጤት (የሙከራ)
-    def: >
-      አንድ ቁራጭ ሶፍትዌር መቼ ያወጣል ተብሎ የሚታሰበው ዋጋ በ ውስጥ ተፈትኗል አንድን መንገድ ፣ ወይም መተው ያለበት ሁኔታ ስርዓት::
-  es:
-    term: "resultado esperado (de una prueba)"
-    def: >
-      El valor que se supone debe producir una sección de código cuando se prueba de una
-      manera determinada, o el estado en el que se supone debe dejar el sistema.
-  sw:
-    term: "matokeo yanayotarajiwa (ya majaribio)"
-    def: >
-      Thamani ambayo kipande cha programu kinatakiwa kutoa kinapojaribiwa kwa njia fulani, au hali ambayo kinatakiwa kuondoka kwenye mfumo.
+    def: 'አንድ ቁራጭ ሶፍትዌር መቼ ያወጣል ተብሎ የሚታሰበው ዋጋ በ ውስጥ ተፈትኗል አንድን መንገድ ፣ ወይም መተው ያለበት
+      ሁኔታ ስርዓት::
 
+      '
+  es:
+    term: resultado esperado (de una prueba)
+    def: 'El valor que se supone debe producir una sección de código cuando se prueba
+      de una manera determinada, o el estado en el que se supone debe dejar el sistema.
+
+      '
+  sw:
+    term: matokeo yanayotarajiwa (ya majaribio)
+    def: 'Thamani ambayo kipande cha programu kinatakiwa kutoa kinapojaribiwa kwa
+      njia fulani, au hali ambayo kinatakiwa kuondoka kwenye mfumo.
+
+      '
 - slug: exploratory_programming
   en:
-    term: "exploratory programming"
-    def: >
-      A software development methodology in which requirements emerge or change as the
-      software is being written, often in response to results from early runs.
-  es:
-    term: "programación exploratoria"
-    def: >
-      Un método de desarrollo de software en el cual los requerimientos emergen o cambian
-      a medida que el software es escrito, frecuentemente en respuesta a resultados de
-      corridas previas.
-  af:
-    term: "verkennende programmering"
-    def: >
-      Hierdie is 'n sagteware-ontwikkelingsmetodologie waarin vereistes ontstaan of verander terwyl die sagteware geskryf word, dikwels in reaksie op 
-      resultate van vroeë toetslopies.
+    term: exploratory programming
+    def: 'A software development methodology in which requirements emerge or change
+      as the software is being written, often in response to results from early runs.
 
+      '
+  es:
+    term: programación exploratoria
+    def: 'Un método de desarrollo de software en el cual los requerimientos emergen
+      o cambian a medida que el software es escrito, frecuentemente en respuesta a
+      resultados de corridas previas.
+
+      '
+  af:
+    term: verkennende programmering
+    def: 'Hierdie is ''n sagteware-ontwikkelingsmetodologie waarin vereistes ontstaan
+      of verander terwyl die sagteware geskryf word, dikwels in reaksie op  resultate
+      van vroeë toetslopies.
+
+      '
   am:
     term: ተመራማሪ መርሃግብር
-    def: >
-      ሶፍትዌሩ በሚጻፍበት ጊዜ መስፈርቶች ብቅ የሚሉበት ወይም የሚለወጡበት የሶፍትዌር ልማት ዘዴ ፣ ብዙውን ጊዜ ከቀደሙት ሥራዎች ለሚመጡ ውጤቶች ምላሽ ይሰጣል ፡፡
-  sw:
-    term: "programu ya uchunguzi"
-    def: >
-      Mbinu ya uundaji wa programu ambayo mahitaji huibuka au kubadilika jinsi programu inavyoandikwa, mara nyingi kwa kujibu matokeo ya uendeshaji wa mapema.
+    def: 'ሶፍትዌሩ በሚጻፍበት ጊዜ መስፈርቶች ብቅ የሚሉበት ወይም የሚለወጡበት የሶፍትዌር ልማት ዘዴ ፣ ብዙውን ጊዜ ከቀደሙት
+      ሥራዎች ለሚመጡ ውጤቶች ምላሽ ይሰጣል ፡፡
 
+      '
+  sw:
+    term: programu ya uchunguzi
+    def: 'Mbinu ya uundaji wa programu ambayo mahitaji huibuka au kubadilika jinsi
+      programu inavyoandikwa, mara nyingi kwa kujibu matokeo ya uendeshaji wa mapema.
+
+      '
 - slug: export
   en:
-    term: "export"
-    def: >
-      To make something visible outside a [module](#module) so that other parts of a
-      program can [import](#import) it. In most languages a module must export things
-      explicitly in an attempt to avoid [name collision](#name_collision).
+    term: export
+    def: 'To make something visible outside a [module](#module) so that other parts
+      of a program can [import](#import) it. In most languages a module must export
+      things explicitly in an attempt to avoid [name collision](#name_collision).
 
+      '
   am:
     term: ወደ ውጭ መላክ
-    def: >
-      ከ [ሞዱል](#module) ውጭ የሆነ ነገር እንዲታይ ለማድረግ ሌላ የፕሮግራሙ ክፍሎች (ማስመጣት)(#import) ይችላሉ። በአብዛኛዎቹ ቋንቋዎች ሞዱል መሆን አለበት [የስም ግጭት](#name_collision) ን ለማስወገድ #ነገሮችን በግልፅ ወደ ውጭ ይላኩ ።
+    def: 'ከ [ሞዱል](#module) ውጭ የሆነ ነገር እንዲታይ ለማድረግ ሌላ የፕሮግራሙ ክፍሎች (ማስመጣት)(#import)
+      ይችላሉ። በአብዛኛዎቹ ቋንቋዎች ሞዱል መሆን አለበት [የስም ግጭት](#name_collision) ን ለማስወገድ #ነገሮችን
+      በግልፅ ወደ ውጭ ይላኩ ።
 
+      '
+- slug: f1_score
+  ref:
+  - precision
+  - recall
+  - classification
+  en:
+    term: F1 score
+    def: 'The harmonic mean of [precision](#precision) and [recall](#recall), providing
+      a single metric that balances both measures. It is calculated as 2 * (precision
+      * recall) / (precision + recall) and ranges from 0 to 1, where 1 is the best
+      score.
+
+      '
 - slug: fail_test
   ref:
-    - pass_test
+  - pass_test
   en:
-    term: "fail (a test)"
-    def: >
-      A test fails if the [actual result](#actual_result) does not match the [expected result](#expected_result).
+    term: fail (a test)
+    def: 'A test fails if the [actual result](#actual_result) does not match the [expected
+      result](#expected_result).
+
+      '
   tn:
-    term: "E tlholegile (teko)"
-    def: >
-      Teko e tlholega fa dipholo tsa tlhomamisho di sa chwane le dipholo tse di ne di letetswe.
+    term: E tlholegile (teko)
+    def: 'Teko e tlholega fa dipholo tsa tlhomamisho di sa chwane le dipholo tse di
+      ne di letetswe.
+
+      '
   am:
     term: መውደቅ (ፈተና)
-    def: >
-      [ትክክለኛው ውጤት](#actual_result) የማይዛመድ ከሆነ አንድ ሙከራ አልተሳካም የተጠበቀው ውጤት (#expected_result)።
-  es:
-    term: "fallar (una prueba)"
-    def: >
-      Una prueba falla si el [resultado real](#actual_result) no coincide con el [resultado esperado](#expected_result).
-  sw:
-    term: "kushindwa (jaribio)"
-    def: >
-      Jaribio litashindikana ikiwa [matokeo_halisi](#actual_result) hayalingani na [matokeo_yanayotarajiwa](#expected_result)
+    def: '[ትክክለኛው ውጤት](#actual_result) የማይዛመድ ከሆነ አንድ ሙከራ አልተሳካም የተጠበቀው ውጤት (#expected_result)።
 
-- slug: "false"
+      '
+  es:
+    term: fallar (una prueba)
+    def: 'Una prueba falla si el [resultado real](#actual_result) no coincide con
+      el [resultado esperado](#expected_result).
+
+      '
+  sw:
+    term: kushindwa (jaribio)
+    def: 'Jaribio litashindikana ikiwa [matokeo_halisi](#actual_result) hayalingani
+      na [matokeo_yanayotarajiwa](#expected_result)
+
+      '
+- slug: 'false'
   ref:
-    - truthy
-    - falsy
+  - truthy
+  - falsy
   en:
-    term: "false"
-    def: >
-      The logical ([Boolean](#boolean)) state opposite of "[true](#true)". Used in
-      logic and programming to represent a [binary](#binary) state of something.
+    term: 'false'
+    def: 'The logical ([Boolean](#boolean)) state opposite of "[true](#true)". Used
+      in logic and programming to represent a [binary](#binary) state of something.
+
+      '
   am:
     term: ውሸት
-    def: >
-      የ ሎጂካዊ ([ቦሊያን]ሁኔታ ከ [እውነተኛ](#boolean) ውስጥ ጥቅም ላይ ውሏልየ [ሁለትዮሽ](#true) ሁኔታን ለመወከል አመክንዮ እና መርሃግብር አንድ ነገር ::
+    def: 'የ ሎጂካዊ ([ቦሊያን]ሁኔታ ከ [እውነተኛ](#boolean) ውስጥ ጥቅም ላይ ውሏልየ [ሁለትዮሽ](#true) ሁኔታን
+      ለመወከል አመክንዮ እና መርሃግብር አንድ ነገር ::
 
-
+      '
   sw:
-    term: "uongo"
-    def: >
-      Mantiki ya [Boolean](#boolean) iliyo katika hali kinyume cha [kweli](#true).
+    term: uongo
+    def: 'Mantiki ya [Boolean](#boolean) iliyo katika hali kinyume cha [kweli](#true).
       Inatumika katika mantiki na upangaji kuwakilisha hali [binary](#binary) ya kitu.
 
+      '
 - slug: false_negative
   ref:
-    - false_positive
-    - true_negative
-    - true_positive
-    - machine_learning
-    - classification
+  - false_positive
+  - true_negative
+  - true_positive
+  - machine_learning
+  - classification
   en:
-    term: "false negative"
-    def: >
-      Data points which are actually [true](#true) but incorrectly predicted as [false](#false).
+    term: false negative
+    def: 'Data points which are actually [true](#true) but incorrectly predicted as
+      [false](#false).
 
+      '
   pt:
-    term: "falso negativo"
-    def: >
-      Dados ou resultados que são realmente [verdadeiro](#true), mas são incorretamente previstos como [falso](#false).
+    term: falso negativo
+    def: 'Dados ou resultados que são realmente [verdadeiro](#true), mas são incorretamente
+      previstos como [falso](#false).
 
+      '
   sw:
-    term: "uongo hasi"
-    def: >
-      Pointi za data ambazo kwa hakika ni za [kweli](#true) lakini zimetabiriwa kimakosa kama kua za [uongo](#false).
+    term: uongo hasi
+    def: 'Pointi za data ambazo kwa hakika ni za [kweli](#true) lakini zimetabiriwa
+      kimakosa kama kua za [uongo](#false).
 
-
+      '
 - slug: false_positive
   ref:
-    - false_negative
-    - true_negative
-    - true_positive
-    - machine_learning
-    - classification
+  - false_negative
+  - true_negative
+  - true_positive
+  - machine_learning
+  - classification
   en:
-    term: "false positive"
-    def: >
-      Data points which are actually [false](#false) but incorrectly predicted as [true](#true).
+    term: false positive
+    def: 'Data points which are actually [false](#false) but incorrectly predicted
+      as [true](#true).
 
+      '
   pt:
-    term: "falso positivo"
-    def: >
-      Dados ou resultados que são realmente [falso](#false), mas são incorretamente previstos como [verdadeiro](#true) pelo algoritmo
+    term: falso positivo
+    def: 'Dados ou resultados que são realmente [falso](#false), mas são incorretamente
+      previstos como [verdadeiro](#true) pelo algoritmo
 
+      '
   sw:
-    term: "uwongo chanya"
-    def: >
-      Pointi za data ambazo kwa hakika ni za [uongo](#false) lakini zimetabiriwa kimakosa kama kua za [kweli](#true).
+    term: uwongo chanya
+    def: 'Pointi za data ambazo kwa hakika ni za [uongo](#false) lakini zimetabiriwa
+      kimakosa kama kua za [kweli](#true).
 
+      '
 - slug: falsy
   ref:
-    - truthy
+  - truthy
   en:
-    term: "falsy"
-    def: >
-      Evaluating to [false](#false) in a [Boolean](#boolean) context.
+    term: falsy
+    def: 'Evaluating to [false](#false) in a [Boolean](#boolean) context.
 
+      '
   am:
     term: ሐሰተኛ
-    def: >
-      በ [ቦሊያን](#false) አውድ ውስጥ ወደ [ሐሰት](#boolean) መገምገም።
+    def: 'በ [ቦሊያን](#false) አውድ ውስጥ ወደ [ሐሰት](#boolean) መገምገም።
 
+      '
   sw:
-    term: "uongo"
-    def: >
-      Inatathmini hadi ya [uongo](#false) katika muktadha wa [Boolean](#boolean).
+    term: uongo
+    def: 'Inatathmini hadi ya [uongo](#false) katika muktadha wa [Boolean](#boolean).
 
+      '
 - slug: faq
   en:
-    term: "Frequently Asked Questions"
-    acronym: "FAQ"
-    def: >
-      A curated list of questions commonly asked about a subject, along with answers.
+    term: Frequently Asked Questions
+    acronym: FAQ
+    def: 'A curated list of questions commonly asked about a subject, along with answers.
 
+      '
   am:
     term: ተደጋግሞ የሚነሱ ጥያቄዎች አህጽሮተ ቃል-ተደጋጋሚ ጥያቄዎች
-    def: >
-      ስለ አንድ ርዕሰ ጉዳይ በተለምዶ የሚጠየቁ የተጠናቀሩ የጥያቄዎች ዝርዝር በመልሶች ::
+    def: 'ስለ አንድ ርዕሰ ጉዳይ በተለምዶ የሚጠየቁ የተጠናቀሩ የጥያቄዎች ዝርዝር በመልሶች ::
 
+      '
   sw:
-    term: "maswali yanayoulizwa mara kwa mara"
-    def: >
-      Orodha iliyoratibiwa ya maswali yanayoulizwa kwa kawaida kuhusu mada fulani, pamoja na majibu.
+    term: maswali yanayoulizwa mara kwa mara
+    def: 'Orodha iliyoratibiwa ya maswali yanayoulizwa kwa kawaida kuhusu mada fulani,
+      pamoja na majibu.
 
+      '
 - slug: fasta
   en:
-    term: "FASTA"
-    def: >
-      A file format for storing amino acid or genomic sequence information.
-      Information for each sequence is broken up into a block of 2 lines. Line 1 contains
-      information about the sequence and begins with a greater than symbol, ‘>’. Line 2
-      contains the actual amino acid or genomic sequence using single-letter codes.
+    term: FASTA
+    def: 'A file format for storing amino acid or genomic sequence information. Information
+      for each sequence is broken up into a block of 2 lines. Line 1 contains information
+      about the sequence and begins with a greater than symbol, ‘>’. Line 2 contains
+      the actual amino acid or genomic sequence using single-letter codes.
+
+      '
   sw:
-    term: "FASTA"
-    def: >
-      Umbizo la faili la kuhifadhi amino asidi au taarifa ya mfuatano wa jeni.
-      Habari kwa kila mlolongo imegawanywa katika kizuizi cha mistari miwili(2).
-      Mstari wa kwanza (1) una taarifa kuhusu mfuatano na huanza na alama kubwa kuliko, ‘>’.
-      Mstari wa pili (2) una asidi ya amino halisi au mfuatano wa jeni kwa kutumia misimbo ya herufi moja.
+    term: FASTA
+    def: 'Umbizo la faili la kuhifadhi amino asidi au taarifa ya mfuatano wa jeni.
+      Habari kwa kila mlolongo imegawanywa katika kizuizi cha mistari miwili(2). Mstari
+      wa kwanza (1) una taarifa kuhusu mfuatano na huanza na alama kubwa kuliko, ‘>’.
+      Mstari wa pili (2) una asidi ya amino halisi au mfuatano wa jeni kwa kutumia
+      misimbo ya herufi moja.
+
+      '
   es:
-    term: "FASTA"
-    def: >
-      Formato de archivo para almacenar información de secuencias genómicas o de aminoácidos.
-      La información de cada secuencia se divide en 2 líneas. La línea 1 contiene información sobre la secuencia
-      y comienza con el símbolo '>' (mayor que). La línea 2 contiene la secuencia genómica o de aminoácidos utilizando
+    term: FASTA
+    def: 'Formato de archivo para almacenar información de secuencias genómicas o
+      de aminoácidos. La información de cada secuencia se divide en 2 líneas. La línea
+      1 contiene información sobre la secuencia y comienza con el símbolo ''>'' (mayor
+      que). La línea 2 contiene la secuencia genómica o de aminoácidos utilizando
       códigos de una sola letra.
 
+      '
 - slug: fastq
   en:
-    term: "FASTQ"
-    def: >
-      A file format for storing genomic sequence information and the corresponding quality scores.
-      Information for each sequence is broken up into a block of four lines. Line 1 contains information about
-      the sequence and begins with ‘@’. Line 2 contains the actual genomic sequence using single-letter codes to
-      represent nucleotides. Line 3 is a separator that begins with a `+`. Line 4 has a string of
-      quality characters for each base in the genomic sequence.
-  sw:
-    term: "FASTQ"
-    def: >
-      Umbizo la faili la kuhifadhi maelezo ya mfuatano wa jeni na alama za ubora zinazolingana.
-      Habari kwa kila mlolongo imegawanywa katika kizuizi cha mistari minne.
-      Mstari wa kwanza (1) una taarifa kuhusu mfuatano huo na huanza na ‘@’.
-      Mstari wa pili (2) una mfuatano halisi wa jeni kwa kutumia misimbo ya herufi moja kuwakilisha nyukleotidi.
-      Mstari wa tatu (3) ni kitenganishi kinachoanza na `+`.
-      Mstari wa nne (4) una mfuatano wa herufi za ubora kwa kila msingi katika mfuatano wa jeni.
+    term: FASTQ
+    def: 'A file format for storing genomic sequence information and the corresponding
+      quality scores. Information for each sequence is broken up into a block of four
+      lines. Line 1 contains information about the sequence and begins with ‘@’. Line
+      2 contains the actual genomic sequence using single-letter codes to represent
+      nucleotides. Line 3 is a separator that begins with a `+`. Line 4 has a string
+      of quality characters for each base in the genomic sequence.
 
+      '
+  sw:
+    term: FASTQ
+    def: 'Umbizo la faili la kuhifadhi maelezo ya mfuatano wa jeni na alama za ubora
+      zinazolingana. Habari kwa kila mlolongo imegawanywa katika kizuizi cha mistari
+      minne. Mstari wa kwanza (1) una taarifa kuhusu mfuatano huo na huanza na ‘@’.
+      Mstari wa pili (2) una mfuatano halisi wa jeni kwa kutumia misimbo ya herufi
+      moja kuwakilisha nyukleotidi. Mstari wa tatu (3) ni kitenganishi kinachoanza
+      na `+`. Mstari wa nne (4) una mfuatano wa herufi za ubora kwa kila msingi katika
+      mfuatano wa jeni.
+
+      '
 - slug: feature
   en:
-    term: "Feature"
-    def: >
-      An individual characteristic or property of a phenomenon that is measurable
-      (e.g. length, height, number of petals) and used as the input to a model.
-      Finding or selecting features that are highly independent and discriminatory
-      is a fundamental part of classification.
+    term: Feature
+    def: 'An individual characteristic or property of a phenomenon that is measurable
+      (e.g. length, height, number of petals) and used as the input to a model. Finding
+      or selecting features that are highly independent and discriminatory is a fundamental
+      part of classification.
 
+      '
   sw:
-    term: "Kigezo"
-    def: >
-      Tabia au ubinafsi wa kitu ambacho kinaweza kupimika
-      (kama vile urefu, kimo, idadi ya petali) na kutumika kama ingizo la modeli.
-      Kutafuta au kuchagua vipengele ambavyo ni huru na vibaguzi
-      ni sehemu ya msingi ya uainishaji.
+    term: Kigezo
+    def: 'Tabia au ubinafsi wa kitu ambacho kinaweza kupimika (kama vile urefu, kimo,
+      idadi ya petali) na kutumika kama ingizo la modeli. Kutafuta au kuchagua vipengele
+      ambavyo ni huru na vibaguzi ni sehemu ya msingi ya uainishaji.
 
+      '
 - slug: feature_branch
   ref:
-    - master_branch
+  - master_branch
   en:
-    term: "feature branch"
-    def: >
-      A [branch](#branch) within a [Git](#git) [repository](#repository)
-      containing [commits](#commit) dedicated to a specific feature, e.g., a
-      [bug](#bug) fix or a new function. This branch can be merged into another branch.
+    term: feature branch
+    def: 'A [branch](#branch) within a [Git](#git) [repository](#repository) containing
+      [commits](#commit) dedicated to a specific feature, e.g., a [bug](#bug) fix
+      or a new function. This branch can be merged into another branch.
 
+      '
   am:
     term: የባህሪ ቅርንጫፍ
-    def: >
-      አንድ [ቅርንጫፍ](በአንድ ቅርንጫፍ) ውስጥ በአንድ [Git](#git) [ማከማቻ](#repository) ለተለየ ባህሪ የተሰጠ [ተግባሮች](#commit) የያዘ ፣ ለምሳሌ ፣ አንድ [bug](#bug) ማስተካከል ወይም አዲስ ተግባር። ይህ ቅርንጫፍ ወደ ሌላ ቅርንጫፍ ሊዋሃድ ይችላል ፡፡
+    def: 'አንድ [ቅርንጫፍ](በአንድ ቅርንጫፍ) ውስጥ በአንድ [Git](#git) [ማከማቻ](#repository) ለተለየ ባህሪ
+      የተሰጠ [ተግባሮች](#commit) የያዘ ፣ ለምሳሌ ፣ አንድ [bug](#bug) ማስተካከል ወይም አዲስ ተግባር። ይህ ቅርንጫፍ
+      ወደ ሌላ ቅርንጫፍ ሊዋሃድ ይችላል ፡፡
 
+      '
 - slug: feature_data
   en:
-    term: "feature (in data)"
-    def: >
-      A variable or observable in a dataset.
+    term: feature (in data)
+    def: 'A variable or observable in a dataset.
 
+      '
   am:
     term: ባህሪ (በመረጃ ውስጥ)
-    def: >
-      በውሂብ ስብስብ ውስጥ ተለዋዋጭ ወይም ታዛቢ።
+    def: 'በውሂብ ስብስብ ውስጥ ተለዋዋጭ ወይም ታዛቢ።
 
+      '
 - slug: feature_engineering
   en:
-    term: "feature engineering"
-    def: >
-      The process of choosing the variables to be used as inputs to a [model](#model).
+    term: feature engineering
+    def: 'The process of choosing the variables to be used as inputs to a [model](#model).
       Choosing good features often depends on [domain knowledge](#domain_knowledge).
 
+      '
   am:
     term: የባህሪ ምህንድስና
-    def: >
-      ለ ‹ግብዓት› ጥቅም ላይ የሚውሉ ተለዋዋጮችን የመምረጥ ሂደት [ሞዴል](#model) ጥሩ ባህሪያትን መምረጥ ብዙውን ጊዜ በ [ጎራ ላይ የተመሠረተ ነው እውቀት](#domain_knowledge)።
+    def: 'ለ ‹ግብዓት› ጥቅም ላይ የሚውሉ ተለዋዋጮችን የመምረጥ ሂደት [ሞዴል](#model) ጥሩ ባህሪያትን መምረጥ ብዙውን
+      ጊዜ በ [ጎራ ላይ የተመሠረተ ነው እውቀት](#domain_knowledge)።
 
+      '
 - slug: feature_request
   en:
-    term: "feature request"
-    def: >
-      A request to the maintainers or developers of a software program to add a
-      specific functionality (a feature) to that program.
-  sw:
-    term: "Ombi la kuongeza Kigezo (au kipengele)"
-    def: >
-      Ombi kwa watunzaji au wasanidi programu wa kuongeza utendaji maalum (au kipengele) kwenye programu hiyo.
+    term: feature request
+    def: 'A request to the maintainers or developers of a software program to add
+      a specific functionality (a feature) to that program.
 
+      '
+  sw:
+    term: Ombi la kuongeza Kigezo (au kipengele)
+    def: 'Ombi kwa watunzaji au wasanidi programu wa kuongeza utendaji maalum (au
+      kipengele) kwenye programu hiyo.
+
+      '
   am:
     term: የባህሪ ጥያቄ
-    def: >
-      ለሶፍትዌር ፕሮግራም ተጠባባቂዎች ወይም ገንቢዎች የቀረበ ጥያቄ ለዚያ ፕሮግራም አንድ የተወሰነ ተግባር (ባህሪ) ያክሉ።
+    def: 'ለሶፍትዌር ፕሮግራም ተጠባባቂዎች ወይም ገንቢዎች የቀረበ ጥያቄ ለዚያ ፕሮግራም አንድ የተወሰነ ተግባር (ባህሪ) ያክሉ።
 
+      '
+- slug: feature_selection
+  ref:
+  - machine_learning
+  - dimension_reduction
+  en:
+    term: feature selection
+    def: 'The process of selecting a subset of relevant features (variables) for use
+      in model construction. This reduces [dimensionality](#dimension_reduction),
+      improves model performance, and reduces overfitting.
+
+      '
 - slug: feature_software
   en:
-    term: "feature (in software)"
-    def: >
-      Some aspect of software that was deliberately designed or built. A [bug](#bug)
+    term: feature (in software)
+    def: 'Some aspect of software that was deliberately designed or built. A [bug](#bug)
       is an undesired feature.
 
+      '
   am:
     term: ባህሪ (በሶፍትዌር ውስጥ)
-    def: >
-      ሆን ተብሎ የተቀየሰ ወይም የተገነባ የሶፍትዌር አንዳንድ ገጽታ። ሀ [bug](#bug) የማይፈለግ ባህሪ ነው።
+    def: 'ሆን ተብሎ የተቀየሰ ወይም የተገነባ የሶፍትዌር አንዳንድ ገጽታ። ሀ [bug](#bug) የማይፈለግ ባህሪ ነው።
 
+      '
   sw:
-    term: "kipengele (katika programu)"
-    def: >
-      Baadhi ya vipengele vya programu ambavyo viliundwa au kujengwa kimakusudi. [hitilafu] (#bug) ni kipengele kisichohitajika.
+    term: kipengele (katika programu)
+    def: 'Baadhi ya vipengele vya programu ambavyo viliundwa au kujengwa kimakusudi.
+      [hitilafu] (#bug) ni kipengele kisichohitajika.
 
+      '
 - slug: field
   en:
-    term: "field"
-    def: >
-      A component of a [record](#record) containing a single value. Every record in a
-      [tibble](#tibble) or database [table](#table) has the same fields.
-  fr:
-    term: "champ"
-    def: >
-      Composant d'une [entrée](#record) contenant une seule valeur. Chaque entrée dans
-      une [tibble](#tibble) ou [table](#table) de base de données contient les mêmes champs.
+    term: field
+    def: 'A component of a [record](#record) containing a single value. Every record
+      in a [tibble](#tibble) or database [table](#table) has the same fields.
 
+      '
+  fr:
+    term: champ
+    def: 'Composant d''une [entrée](#record) contenant une seule valeur. Chaque entrée
+      dans une [tibble](#tibble) ou [table](#table) de base de données contient les
+      mêmes champs.
+
+      '
   am:
     term: መስክ
-    def: >
-      አንድ ነጠላ እሴት የያዘ የ [መዝገብ](#record) አንድ አካል። እያንዳንዱ መዝገብ በ [tibble](#tibble) ወይም በመረጃ ቋት [ሰንጠረዥ](#table) ተመሳሳይ መስኮች አሉት ፡፡
+    def: 'አንድ ነጠላ እሴት የያዘ የ [መዝገብ](#record) አንድ አካል። እያንዳንዱ መዝገብ በ [tibble](#tibble)
+      ወይም በመረጃ ቋት [ሰንጠረዥ](#table) ተመሳሳይ መስኮች አሉት ፡፡
 
+      '
 - slug: filename_extension
   en:
-    term: "filename extension"
-    def: >
-      The last part of a filename, usually following the '.' symbol. Filename
+    term: filename extension
+    def: 'The last part of a filename, usually following the ''.'' symbol. Filename
       extensions are commonly used to indicate the type of content in the file, though
       there is no guarantee that this is correct.
 
+      '
   am:
     term: የፋይል ስም ቅጥያ
-    def: >
-      የፋይል ስም የመጨረሻው ክፍል ፣ ብዙውን ጊዜ & #39 ን ይከተላል & #39; ምልክት የፋይል ስም ቅጥያዎች በ ውስጥ ያለውን የይዘት አይነት ለማመልከት በተለምዶ ያገለግላሉ ምንም እንኳን ይህ ትክክል ስለመሆኑ ምንም ማረጋገጫ ባይኖርም ፋይል ያድርጉ ፡፡
+    def: 'የፋይል ስም የመጨረሻው ክፍል ፣ ብዙውን ጊዜ & #39 ን ይከተላል & #39; ምልክት የፋይል ስም ቅጥያዎች በ ውስጥ
+      ያለውን የይዘት አይነት ለማመልከት በተለምዶ ያገለግላሉ ምንም እንኳን ይህ ትክክል ስለመሆኑ ምንም ማረጋገጫ ባይኖርም ፋይል
+      ያድርጉ ፡፡
 
+      '
 - slug: filename_stem
   en:
-    term: "filename stem"
-    def: >
-      The part of the filename that does not include the [extension](#filename_extension).
+    term: filename stem
+    def: 'The part of the filename that does not include the [extension](#filename_extension).
       For example, the stem of `glossary.yml` is `glossary`.
 
+      '
   am:
     term: የፋይል ስም ግንድ
-    def: >
-      [ቅጥያውን](#filename_extension) የማያካትት የፋይል ስም ክፍል። ለምሳሌ ፣ የ "መዝገበ-ቃላት .yml` ግንድ" የቃላት መፍቻ "ነው።
+    def: '[ቅጥያውን](#filename_extension) የማያካትት የፋይል ስም ክፍል። ለምሳሌ ፣ የ "መዝገበ-ቃላት .yml`
+      ግንድ" የቃላት መፍቻ "ነው።
 
+      '
 - slug: filesystem
   en:
-    term: "filesystem"
-    def: >
-      The part of the [operating system](#operating_system) that manages how files
-      are stored and retrieved. Also used to refer to all of those files and
-      [directories](#directory) or the specific way they are stored (as in "the Unix filesystem").
+    term: filesystem
+    def: 'The part of the [operating system](#operating_system) that manages how files
+      are stored and retrieved. Also used to refer to all of those files and [directories](#directory)
+      or the specific way they are stored (as in "the Unix filesystem").
+
+      '
   de:
-    term: "Dateisystem"
-    def: >
-      Der Teil des [Betriebssystems](#operating_system), der verwaltet wie Dateien gespeichert
-      und abgerufen werden. Der Begriff wird auch als Referenz für alle Dateien und
-      [Verzeichnisse](#directory) verwendet, oder für die spezifische Art, wie Dateien
-      gespeichert werden (z.B. "das Unix-Dateisystem").
+    term: Dateisystem
+    def: 'Der Teil des [Betriebssystems](#operating_system), der verwaltet wie Dateien
+      gespeichert und abgerufen werden. Der Begriff wird auch als Referenz für alle
+      Dateien und [Verzeichnisse](#directory) verwendet, oder für die spezifische
+      Art, wie Dateien gespeichert werden (z.B. "das Unix-Dateisystem").
+
+      '
   es:
-    term: "sistema de archivos"
-    def: >
-      La parte del sistema operativo que administra cómo se almacenan y recuperan
+    term: sistema de archivos
+    def: 'La parte del sistema operativo que administra cómo se almacenan y recuperan
       los archivos. También se usa para referirse a todos esos archivos y directorios
-      o a la forma específica en que se almacenan (como en "el sistema de archivos Unix").
+      o a la forma específica en que se almacenan (como en "el sistema de archivos
+      Unix").
+
+      '
   ja:
-    term: "ファイルシステム"
-    def: >
-      [オペレーティングシステム](#operating_system)におけるファイルの保存方法と取得方法を管理する部分。
-      また、それらファイルや[ディレクトリ](#directory)を参照するのに用いられたり、
+    term: ファイルシステム
+    def: '[オペレーティングシステム](#operating_system)におけるファイルの保存方法と取得方法を管理する部分。 また、それらファイルや[ディレクトリ](#directory)を参照するのに用いられたり、
       それらが保存される特定の方法 (例えば「Unix ファイルシステム」において見られるようなもの)のこと。
+
+      '
   uk:
-    term: "файлова система"
-    def: >
-      Частина [операційної системи](#operating_system), яка відповідає за
-      зберігання та доступ до файлів. Також використовується для посилання на 
-      конкретний спосіб їх зберігання (наприклад, "файлова система Unix").
+    term: файлова система
+    def: 'Частина [операційної системи](#operating_system), яка відповідає за зберігання
+      та доступ до файлів. Також використовується для посилання на  конкретний спосіб
+      їх зберігання (наприклад, "файлова система Unix").
+
+      '
   am:
     term: የፋይል ስርዓት
-    def: >
-      የሚያስተዳድረው የ [ኦፐሬቲንግ ሲስተም](#operating_system) ክፍል filesm እንዴት እንደሚከማች እና እንደተገኘ። እነዚያን ሁሉ ፋይሎች ለማመልከትም እንዲሁ እና [ማውጫዎች](#directory) ወይም የሚቀመጡበት የተወሰነ መንገድ (እንደ ውስጥ የዩኒክስ የፋይል ስርዓት).
+    def: 'የሚያስተዳድረው የ [ኦፐሬቲንግ ሲስተም](#operating_system) ክፍል filesm እንዴት እንደሚከማች እና
+      እንደተገኘ። እነዚያን ሁሉ ፋይሎች ለማመልከትም እንዲሁ እና [ማውጫዎች](#directory) ወይም የሚቀመጡበት የተወሰነ
+      መንገድ (እንደ ውስጥ የዩኒክስ የፋይል ስርዓት).
 
+      '
 - slug: filter
   en:
-    term: "filter"
-    def: >
-      As a verb, to choose a set of [records](#record) (i.e., rows of a table) based
-      on the values they contain. As a noun, a command-line program that reads lines
-      of text from files or [standard input](#stdin), performs some operation on them
-      (such as filtering), and writes to a file or [stdout](#stdout).
-  fr:
-    term: "filtrer"
-    def: >
-      Le fait de sélectionner un ensemble d'[observations](#record) (par exemple
-      certaines lignes d'une table) en se basant sur leurs valeurs.
+    term: filter
+    def: 'As a verb, to choose a set of [records](#record) (i.e., rows of a table)
+      based on the values they contain. As a noun, a command-line program that reads
+      lines of text from files or [standard input](#stdin), performs some operation
+      on them (such as filtering), and writes to a file or [stdout](#stdout).
 
+      '
+  fr:
+    term: filtrer
+    def: 'Le fait de sélectionner un ensemble d''[observations](#record) (par exemple
+      certaines lignes d''une table) en se basant sur leurs valeurs.
+
+      '
   am:
     term: ማጣሪያ
-    def: >
-      እንደ ግስ ፣ የ [መዝገቦችን] ስብስብ ለመምረጥ (#record) (ማለትም ፣ የ ሀ ረድፎች) ሰንጠረዥ) በያዙት እሴቶች ላይ በመመርኮዝ ፡፡ እንደ ስም ፣ የትእዛዝ-መስመር ፕሮግራም የጽሑፍ መስመሮችን ከፋይሎች ወይም [መደበኛ ግቤት](#stdin) ያነባል ፣ የተወሰኑትን ያከናውናል በእነሱ ላይ ክዋኔ (እንደ ማጣሪያ) ፣ እና ወደ ፋይል ወይም [stdout](#stdout) ይጽፋል።
+    def: 'እንደ ግስ ፣ የ [መዝገቦችን] ስብስብ ለመምረጥ (#record) (ማለትም ፣ የ ሀ ረድፎች) ሰንጠረዥ) በያዙት እሴቶች
+      ላይ በመመርኮዝ ፡፡ እንደ ስም ፣ የትእዛዝ-መስመር ፕሮግራም የጽሑፍ መስመሮችን ከፋይሎች ወይም [መደበኛ ግቤት](#stdin)
+      ያነባል ፣ የተወሰኑትን ያከናውናል በእነሱ ላይ ክዋኔ (እንደ ማጣሪያ) ፣ እና ወደ ፋይል ወይም [stdout](#stdout)
+      ይጽፋል።
 
+      '
+- slug: fine_tuning
+  ref:
+  - deep_learning
+  - neural_network
+  - transfer_learning
+  en:
+    term: fine-tuning (deep learning)
+    def: "Fine-tuning is an approach to transfer learning in which a pre-trained network\
+      \ is adapted to the  specifics of a new dataset. \n"
 - slug: fixture
   en:
-    term: "fixture"
-    def: >
-      The thing on which a test is run, such as the [parameters](#parameter) to the function being
-      tested or the file being processed.
+    term: fixture
+    def: 'The thing on which a test is run, such as the [parameters](#parameter) to
+      the function being tested or the file being processed.
 
+      '
   am:
     term: መሰኪያ
-    def: >
-      አንድ ሙከራ የሚካሄድበት ነገር ለምሳሌ [መለኪያዎች](#parameter) ወደ ሚፈተነው ተግባር ወይም ፋይሉ እየተሰራ ነው።
+    def: 'አንድ ሙከራ የሚካሄድበት ነገር ለምሳሌ [መለኪያዎች](#parameter) ወደ ሚፈተነው ተግባር ወይም ፋይሉ እየተሰራ
+      ነው።
 
+      '
 - slug: folder
   en:
-    term: "folder"
-    def: >
-      Another term for a [directory](#directory).
+    term: folder
+    def: 'Another term for a [directory](#directory).
+
+      '
   de:
-    term: "Ordner"
-    def: >
-      Anderer Begriff für [Verzeichnis](#directory).
+    term: Ordner
+    def: 'Anderer Begriff für [Verzeichnis](#directory).
+
+      '
   es:
-    term: "carpeta"
-    def: >
-      Otro término para hacer referencia a un [directorio](#directory).
+    term: carpeta
+    def: 'Otro término para hacer referencia a un [directorio](#directory).
+
+      '
   am:
     term: አቃፊ
-    def: >
-      ሌላ ቃል ለ [ማውጫ](#directory) ::
-  sw:
-    term: "Kabrasha"
-    def: >
-      Neno lingine kwa saraka.
-  uk:
-    term: "тека"
-    def: >
-      Синонім [каталогу](#directory).
+    def: 'ሌላ ቃል ለ [ማውጫ](#directory) ::
 
+      '
+  sw:
+    term: Kabrasha
+    def: 'Neno lingine kwa saraka.
+
+      '
+  uk:
+    term: тека
+    def: 'Синонім [каталогу](#directory).
+
+      '
 - slug: for_loop
   ref:
-    - while_loop
+  - while_loop
   en:
-    term: "for loop"
-    def: >
-      A construct in a program that repeats one or more other statements (the [loop
-      body](#loop_body)) once for each item in a sequence, such as each number in a
-      range or each element of a list.
-  es:
-    term: "ciclo for"
-    def: >
-      También conocido como bucle for. Estructura dentro de un programa que repite
-      una o más instrucciones (el [cuerpo del ciclo o bucle](#loop_body)) 
-      una vez por cada elemento de una secuencia, por ejemplo, cada número
-      dentro de un rango o cada elemento de una lista. 
+    term: for loop
+    def: 'A construct in a program that repeats one or more other statements (the
+      [loop body](#loop_body)) once for each item in a sequence, such as each number
+      in a range or each element of a list.
 
+      '
+  es:
+    term: ciclo for
+    def: "También conocido como bucle for. Estructura dentro de un programa que repite\
+      \ una o más instrucciones (el [cuerpo del ciclo o bucle](#loop_body))  una vez\
+      \ por cada elemento de una secuencia, por ejemplo, cada número dentro de un\
+      \ rango o cada elemento de una lista. \n"
   am:
     term: ለሉፕ(ፎር ሉፕ)
-    def: >
-      አንድ ወይም ከዚያ በላይ መግለጫዎችን በሚደግመው ፕሮግራም ውስጥ አንድ ግንባታ (የ [loop body](#loop_body)) አንድ ጊዜ ለእያንዳንዱ ንጥል በቅደም ተከተል እንደ እያንዳንዱ በአንድ ክልል ውስጥ ወይም በእያንዳንዱ የዝርዝር አካል ውስጥ ቁጥር።
+    def: 'አንድ ወይም ከዚያ በላይ መግለጫዎችን በሚደግመው ፕሮግራም ውስጥ አንድ ግንባታ (የ [loop body](#loop_body))
+      አንድ ጊዜ ለእያንዳንዱ ንጥል በቅደም ተከተል እንደ እያንዳንዱ በአንድ ክልል ውስጥ ወይም በእያንዳንዱ የዝርዝር አካል ውስጥ
+      ቁጥር።
 
+      '
 - slug: fork
   ref:
-    - branch
+  - branch
   en:
-    term: "fork"
-    def: >
-      A copy of one person's [Git](#git) [repository](#repository)
-      that lives in another person's GitHub account. Changes to the content of a fork
-      can be submitted to the [upstream repository](#upstream_repository) via a
-      [pull request](#pull_request).
+    term: fork
+    def: 'A copy of one person''s [Git](#git) [repository](#repository) that lives
+      in another person''s GitHub account. Changes to the content of a fork can be
+      submitted to the [upstream repository](#upstream_repository) via a [pull request](#pull_request).
 
+      '
   am:
     term: ሹካ
-    def: >
-      በሌላ ሰው የ GitHub አካውንት ውስጥ የሚኖር የአንድ ሰው [Git](#git) [ማከማቻ](#repository) ቅጅ። በሹካ ይዘት ላይ የተደረጉ ለውጦች በ [ጎትት ጥያቄ](#upstream_repository) በኩል ወደ [ወደ ላይኛው መጋዘን](#pull_request) ሊቀርቡ ይችላሉ ፡፡
+    def: 'በሌላ ሰው የ GitHub አካውንት ውስጥ የሚኖር የአንድ ሰው [Git](#git) [ማከማቻ](#repository) ቅጅ።
+      በሹካ ይዘት ላይ የተደረጉ ለውጦች በ [ጎትት ጥያቄ](#upstream_repository) በኩል ወደ [ወደ ላይኛው መጋዘን](#pull_request)
+      ሊቀርቡ ይችላሉ ፡፡
 
+      '
 - slug: fragment_shader
   ref:
-    - gpu
-    - geometry_shader
-    - shader
-    - vertex_shader
+  - gpu
+  - geometry_shader
+  - shader
+  - vertex_shader
   en:
-    term: "fragment shader"
-    def: >
-      The [shader](#shader) stage in the rendering pipeline designated towards calculating
-      colours for each fragment on the screen. For each pixel covered by a primitive, a
-      fragment is generated. All fragments for each pixel will have their colours combined
-      based on depth and opacity after the fragment shader stage is complete.
+    term: fragment shader
+    def: 'The [shader](#shader) stage in the rendering pipeline designated towards
+      calculating colours for each fragment on the screen. For each pixel covered
+      by a primitive, a fragment is generated. All fragments for each pixel will have
+      their colours combined based on depth and opacity after the fragment shader
+      stage is complete.
 
+      '
 - slug: full_identifier_git
   en:
-    term: "full identifier (of a commit)"
-    def: >
-      A unique 160-bit identifier for a [commit](#commit) in a [Git](#git)
-      [repository](#repository), usually written as a 20-character
-      [hexadecimal](#hexadecimal) character [string](#string).
+    term: full identifier (of a commit)
+    def: 'A unique 160-bit identifier for a [commit](#commit) in a [Git](#git) [repository](#repository),
+      usually written as a 20-character [hexadecimal](#hexadecimal) character [string](#string).
 
+      '
   am:
     term: ሙሉ መለያ (የአንድ ቃል)
-    def: >
-      በ [Git](#git) [ማከማቻ](#commit) ውስጥ ለ [ቃል](#repository) ልዩ የ 160 ቢት መለያ ለይቶ የሚታወቅ ፣ ብዙውን ጊዜ እንደ 20-ቁምፊ [ሄክሳዴሲማል](#hexadecimal) ቁምፊ [ክር](#string)
+    def: 'በ [Git](#git) [ማከማቻ](#commit) ውስጥ ለ [ቃል](#repository) ልዩ የ 160 ቢት መለያ ለይቶ
+      የሚታወቅ ፣ ብዙውን ጊዜ እንደ 20-ቁምፊ [ሄክሳዴሲማል](#hexadecimal) ቁምፊ [ክር](#string)
 
+      '
 - slug: full_join
   ref:
-    - anti_join
-    - cross_join
-    - full_join
-    - inner_join
-    - left_join
-    - right_join
-    - self_join
+  - anti_join
+  - cross_join
+  - full_join
+  - inner_join
+  - left_join
+  - right_join
+  - self_join
   en:
-    term: "full join"
-    def: >
-      A [join](#join) that returns all rows and all columns from two tables A and B.
-      Where the [keys](#key) of A and B match, values are combined; where they do not,
-      missing values from either table are filled with [null](#null), [NA](#na), or
-      some other [missing value](#missing_value) signifier.
+    term: full join
+    def: 'A [join](#join) that returns all rows and all columns from two tables A
+      and B. Where the [keys](#key) of A and B match, values are combined; where they
+      do not, missing values from either table are filled with [null](#null), [NA](#na),
+      or some other [missing value](#missing_value) signifier.
 
+      '
   am:
     term: ሙሉ መቀላቀል
-    def: >
-      ሁሉንም ረድፎች እና ሁሉንም አምዶች ከሁለት የሚመልስ [መቀላቀል](#join) ሰንጠረ Aች ሀ እና ቢ የ "A" እና "ቢ" (ቁልፎች)(#key) የሚዛመዱበት ፣ እሴቶች የተዋሃዱ ናቸው ፤ እነሱ ከሌሉበት ፣ ከየትኛውም ሰንጠረዥ የሚጎድሉ እሴቶች በ [null](#null) ፣ [NA](#na) ፣ ወይም በሌላ ሌላ [የጠፋ እሴት](#missing_value) አመላካች ተሞልተዋል።
+    def: 'ሁሉንም ረድፎች እና ሁሉንም አምዶች ከሁለት የሚመልስ [መቀላቀል](#join) ሰንጠረ Aች ሀ እና ቢ የ "A" እና
+      "ቢ" (ቁልፎች)(#key) የሚዛመዱበት ፣ እሴቶች የተዋሃዱ ናቸው ፤ እነሱ ከሌሉበት ፣ ከየትኛውም ሰንጠረዥ የሚጎድሉ እሴቶች
+      በ [null](#null) ፣ [NA](#na) ፣ ወይም በሌላ ሌላ [የጠፋ እሴት](#missing_value) አመላካች ተሞልተዋል።
 
+      '
   af:
-    term: "volle koppeling"
-    def: >
-      'n [Koppeling](#join) wat alle rye en alle kolomme uit twee tabelle A en B oplewer. Waar die [ID-sleutels](#key) van A en B by mekaar pas, word die waardes gekombineer; waar dit nie die geval is nie, word ontbrekende waardes uit enige van die twee tabelle gevul met [nul](#null), [NA](#na), of enige ander aanduier van 'n [ontbrekende waarde](#missing_value).
+    term: volle koppeling
+    def: '''n [Koppeling](#join) wat alle rye en alle kolomme uit twee tabelle A en
+      B oplewer. Waar die [ID-sleutels](#key) van A en B by mekaar pas, word die waardes
+      gekombineer; waar dit nie die geval is nie, word ontbrekende waardes uit enige
+      van die twee tabelle gevul met [nul](#null), [NA](#na), of enige ander aanduier
+      van ''n [ontbrekende waarde](#missing_value).
 
-
+      '
 - slug: fully_qualified_name
   en:
-    term: "fully-qualified name"
-    def: >
-      An unambiguous name of the form `package::thing`, indicating the original source
-      of the [object](#object) in question.
+    term: fully-qualified name
+    def: 'An unambiguous name of the form `package::thing`, indicating the original
+      source of the [object](#object) in question.
 
+      '
   am:
     term: ሙሉ ብቃት ያለው ስም
-    def: >
-      የቅጹን ጥቅል የማያሻማ ስም :: ነገር " በጥያቄ ውስጥ ያለው (ነገር)(#object) የመጀመሪያ ምንጭ።
+    def: 'የቅጹን ጥቅል የማያሻማ ስም :: ነገር " በጥያቄ ውስጥ ያለው (ነገር)(#object) የመጀመሪያ ምንጭ።
 
+      '
 - slug: function
   ref:
-    - command
+  - command
   en:
-    term: "function"
-    def: >
-      A code block which gathers a sequence of operations into a whole, preserving it for ongoing use
-      by defining a set of tasks that takes zero or more required and optional arguments as inputs
-      and returns expected outputs (return values), if any. Functions enable repeating these defined
-      tasks with one command, known as a function call.
-  ja:
-    term: "関数"
-    def: >
-      別の処理の中で使用する、あるいは繰り返し使用するために、連続した操作をひとかたまりの
-      コードブロックとして名前を付けて定義したもの。関数は任意の引数を使って、
-      入力ともしあれば返された出力(返り値)を定義します。関数は定義されたタスクを、
-      関数呼び出しと呼ばれる１つのコマンドで繰り返し使用することを可能にします。
-  de:
-    term: "Funktion"
-    def: >
-      Eine Funktion ist ein in sich abgeschlossener Teil eines Programmcodes, der eine Abfolge
-      von Anweisungen umfasst und mehrere optionale oder notwendige Eingansparameter akzeptieren
-      kann. Funktionen haben einen eindeutigen Namen, der es erlaubt die Funktion durch einen
-      Funktionsaufruf mehrfach in einem Programm zu verwenden. Eine Funktion kann mehrere optionale
-      oder notwendige Eingangsparameter akzeptieren. Eine Funktion kann Werte zurückgeben, deren
-      Datentypen in einer Funktionsdokumentation niedergeschrieben sein sollten.
+    term: function
+    def: 'A code block which gathers a sequence of operations into a whole, preserving
+      it for ongoing use by defining a set of tasks that takes zero or more required
+      and optional arguments as inputs and returns expected outputs (return values),
+      if any. Functions enable repeating these defined tasks with one command, known
+      as a function call.
 
+      '
+  ja:
+    term: 関数
+    def: '別の処理の中で使用する、あるいは繰り返し使用するために、連続した操作をひとかたまりの コードブロックとして名前を付けて定義したもの。関数は任意の引数を使って、
+      入力ともしあれば返された出力(返り値)を定義します。関数は定義されたタスクを、 関数呼び出しと呼ばれる１つのコマンドで繰り返し使用することを可能にします。
+
+      '
+  de:
+    term: Funktion
+    def: 'Eine Funktion ist ein in sich abgeschlossener Teil eines Programmcodes,
+      der eine Abfolge von Anweisungen umfasst und mehrere optionale oder notwendige
+      Eingansparameter akzeptieren kann. Funktionen haben einen eindeutigen Namen,
+      der es erlaubt die Funktion durch einen Funktionsaufruf mehrfach in einem Programm
+      zu verwenden. Eine Funktion kann mehrere optionale oder notwendige Eingangsparameter
+      akzeptieren. Eine Funktion kann Werte zurückgeben, deren Datentypen in einer
+      Funktionsdokumentation niedergeschrieben sein sollten.
+
+      '
   am:
     term: ተግባር
-    def: >
-      ከዜሮ ወይም ከዚያ በላይ የሚፈለጉ እና አማራጭ ክርክሮችን የሚወስዱ የተወሰኑ ተግባሮችን እንደ ግብዓቶች እና የሚመልሱ ውጤቶችን (ተመላሽ እሴቶችን) የሚመልሱ ተግባሮችን በመለየት ለቀጣይ አገልግሎት የሚጠብቅ የኮድ ብሎክ ፣ ካለ ፡፡ ተግባራት የተገለጹ ተግባሮችን እንደ አንድ ተግባር ጥሪ በመባል በሚታወቀው በአንድ ትእዛዝ መድገምን ያስችሉታል ፡፡
+    def: 'ከዜሮ ወይም ከዚያ በላይ የሚፈለጉ እና አማራጭ ክርክሮችን የሚወስዱ የተወሰኑ ተግባሮችን እንደ ግብዓቶች እና የሚመልሱ
+      ውጤቶችን (ተመላሽ እሴቶችን) የሚመልሱ ተግባሮችን በመለየት ለቀጣይ አገልግሎት የሚጠብቅ የኮድ ብሎክ ፣ ካለ ፡፡ ተግባራት
+      የተገለጹ ተግባሮችን እንደ አንድ ተግባር ጥሪ በመባል በሚታወቀው በአንድ ትእዛዝ መድገምን ያስችሉታል ፡፡
 
+      '
 - slug: functional_programming
   ref:
-    - higher_order_function
-    - oop
+  - higher_order_function
+  - oop
   en:
-    term: "functional programming"
-    def: >
-      A style of programming in which data is transformed through successive
-      application of functions, rather than by using control structures such as loops.
-      In functional programming, there must be a direct relationship between the input
-      to a function and the output produced by the function, meaning the result should not
-      be affected by the current values of global variables or other parts of the [global
-      program state](#global_environment). It also requires that functions do not produce [side effects](#side_effect),
-      meaning they do not modify the global program state, or do anything other than computing
-      the return value, such as writing output to a [log](#log) file, or printing to the [console](#console).
+    term: functional programming
+    def: 'A style of programming in which data is transformed through successive application
+      of functions, rather than by using control structures such as loops. In functional
+      programming, there must be a direct relationship between the input to a function
+      and the output produced by the function, meaning the result should not be affected
+      by the current values of global variables or other parts of the [global program
+      state](#global_environment). It also requires that functions do not produce
+      [side effects](#side_effect), meaning they do not modify the global program
+      state, or do anything other than computing the return value, such as writing
+      output to a [log](#log) file, or printing to the [console](#console).
 
-
+      '
 - slug: garbage_in_garbage_out
   en:
-    term: "garbage in, garbage out"
-    acronym: "GIGO"
-    def: >
-      The idea that messy data as an input will result in messy data as an output.
+    term: garbage in, garbage out
+    acronym: GIGO
+    def: 'The idea that messy data as an input will result in messy data as an output.
 
+      '
   am:
     term: ተግባራዊ ፕሮግራም
-    def: >
-      መረጃዎች በሚቀየሩበት የፕሮግራም ዘይቤ እንደ ቀለበቶች ያሉ የመቆጣጠሪያ አሠራሮችን ከመጠቀም ይልቅ የተግባሮችን ትግበራ በመተግበር ላይ በተግባራዊ መርሃግብር ውስጥ በግብአት መካከል ቀጥተኛ ግንኙነት መኖር አለበት ወደ ተግባር እና በተግባሩ የሚመረተው ውጤት ፣ ውጤቱ በአለምአቀፍ ተለዋዋጮች ወይም በሌሎች የዓለም ክፍሎች የፕሮግራም ሁኔታ](#global_environment). እንዲሁም ተግባራት [የጎንዮሽ ጉዳቶች](#side_effect) እንዳያወጡ ይጠይቃል ፡፡ ማለትም የዓለም አቀፍ ፕሮግራሙን ሁኔታ አያሻሽሉም ፣ ወይም የመመለሻውን ዋጋ ከማስላት ውጭ ሌላ ነገር አያደርጉም ፣ ለምሳሌ ውጤትን በ [መዝገብ](#log) ፋይል ላይ መጻፍ ፣ ወይም ወደ [ኮንሶል](#console) ማተም።
+    def: 'መረጃዎች በሚቀየሩበት የፕሮግራም ዘይቤ እንደ ቀለበቶች ያሉ የመቆጣጠሪያ አሠራሮችን ከመጠቀም ይልቅ የተግባሮችን ትግበራ
+      በመተግበር ላይ በተግባራዊ መርሃግብር ውስጥ በግብአት መካከል ቀጥተኛ ግንኙነት መኖር አለበት ወደ ተግባር እና በተግባሩ
+      የሚመረተው ውጤት ፣ ውጤቱ በአለምአቀፍ ተለዋዋጮች ወይም በሌሎች የዓለም ክፍሎች የፕሮግራም ሁኔታ](#global_environment).
+      እንዲሁም ተግባራት [የጎንዮሽ ጉዳቶች](#side_effect) እንዳያወጡ ይጠይቃል ፡፡ ማለትም የዓለም አቀፍ ፕሮግራሙን
+      ሁኔታ አያሻሽሉም ፣ ወይም የመመለሻውን ዋጋ ከማስላት ውጭ ሌላ ነገር አያደርጉም ፣ ለምሳሌ ውጤትን በ [መዝገብ](#log)
+      ፋይል ላይ መጻፍ ፣ ወይም ወደ [ኮንሶል](#console) ማተም።
 
-
+      '
 - slug: generator_function
   ref:
-    - iterator_pattern
+  - iterator_pattern
   en:
-    term: "generator function"
-    def: >
-      A function whose state is automatically saved when it returns a value so that
-      execution can be restarted from that point the next time it is called.
-      One example of generator functions use is to produce
-      streams of values that can be processed by [for loops](#for_loop).
+    term: generator function
+    def: 'A function whose state is automatically saved when it returns a value so
+      that execution can be restarted from that point the next time it is called.
+      One example of generator functions use is to produce streams of values that
+      can be processed by [for loops](#for_loop).
 
+      '
   am:
     term: ጄነሬተር ተግባር
-    def: >
-      ሀ ሲመለስ ሁኔታው በራስ-ሰር የሚቀመጥ ተግባር በሚቀጥለው ጊዜ በሚጠራበት ጊዜ አፈፃፀም ከዚያ ነጥብ እንደገና እንዲጀመር ዋጋ ይስጡ ፡፡ የጄነሬተር ተግባራት አጠቃቀም አንዱ ምሳሌ በ [ለ loops](#for_loop) ሊሠሩ የሚችሉ የእሴቶችን ጅረቶች ማምረት ነው ፡፡
+    def: 'ሀ ሲመለስ ሁኔታው በራስ-ሰር የሚቀመጥ ተግባር በሚቀጥለው ጊዜ በሚጠራበት ጊዜ አፈፃፀም ከዚያ ነጥብ እንደገና እንዲጀመር
+      ዋጋ ይስጡ ፡፡ የጄነሬተር ተግባራት አጠቃቀም አንዱ ምሳሌ በ [ለ loops](#for_loop) ሊሠሩ የሚችሉ የእሴቶችን
+      ጅረቶች ማምረት ነው ፡፡
 
+      '
 - slug: generic_function
   en:
-    term: "generic function"
-    def: >
-      A collection of functions with similar purpose, each operating on a different
+    term: generic function
+    def: 'A collection of functions with similar purpose, each operating on a different
       class of data.
-  fr:
-    term: "fonction générique"
-    def: >
-      Une collection de fonctions ayant un objectif similaire, chacune opérant sur une
-      classe de données différente.
-  pt:
-    term: "função genérica"
-    def: >
-      Um conjunto de funções com propósito similar, cada uma operando em uma classe diferente
-      de dados.
-  es:
-    term: "función genérica"
-    def: >
-      Un conjunto de funciones con propósitos similares, cada una operando en una clase
-      diferente de datos.
 
+      '
+  fr:
+    term: fonction générique
+    def: 'Une collection de fonctions ayant un objectif similaire, chacune opérant
+      sur une classe de données différente.
+
+      '
+  pt:
+    term: função genérica
+    def: 'Um conjunto de funções com propósito similar, cada uma operando em uma classe
+      diferente de dados.
+
+      '
+  es:
+    term: función genérica
+    def: 'Un conjunto de funciones con propósitos similares, cada una operando en
+      una clase diferente de datos.
+
+      '
   am:
     term: አጠቃላይ ተግባር
-    def: >
-      ተመሳሳይ ዓላማ ያላቸው የተግባሮች ስብስብ ፣ እያንዳንዱ በተለየ የውሂብ ክፍል ላይ ይሠራል።
+    def: 'ተመሳሳይ ዓላማ ያላቸው የተግባሮች ስብስብ ፣ እያንዳንዱ በተለየ የውሂብ ክፍል ላይ ይሠራል።
 
+      '
 - slug: geometric_mean
   ref:
-    - mean
-    - harmonic_mean
+  - mean
+  - harmonic_mean
   en:
-    term: "Geometric Mean"
-    def: >
-      Calculated from a set of n numbers by first computing the product of those
-      numbers, and then computing the n-th [root](#root_math) of the result. In
-      contrast to the [arithmetic mean](#arithmetic_mean), which measures
-      central tendancy in an "additive" way, the geometric mean measures central
-      tendancy in a "multiplicative" way, and hence is often appropriate when
-      estimating an average rates of change or some other multiplicative
-      constant.
+    term: Geometric Mean
+    def: 'Calculated from a set of n numbers by first computing the product of those
+      numbers, and then computing the n-th [root](#root_math) of the result. In contrast
+      to the [arithmetic mean](#arithmetic_mean), which measures central tendancy
+      in an "additive" way, the geometric mean measures central tendancy in a "multiplicative"
+      way, and hence is often appropriate when estimating an average rates of change
+      or some other multiplicative constant.
 
+      '
 - slug: geometry_shader
   ref:
-    - gpu
-    - shader
-    - tessellation_shader
+  - gpu
+  - shader
+  - tessellation_shader
   en:
-    term: "geometry shader"
-    def: >
-      The [shader](#shader) stage in the rendering pipeline designated towards processing
-      primitives. Not to be confused with [tessellation shaders](#tessellation_shader), geometry
-      shaders are focused on modifying the shape of primitives to create new results. For
-      example, pixels may be converted into particles using a geometry shader.
+    term: geometry shader
+    def: 'The [shader](#shader) stage in the rendering pipeline designated towards
+      processing primitives. Not to be confused with [tessellation shaders](#tessellation_shader),
+      geometry shaders are focused on modifying the shape of primitives to create
+      new results. For example, pixels may be converted into particles using a geometry
+      shader.
 
+      '
 - slug: ggplot2
   en:
-    term: "ggplot2"
-    def: >
-      A [package](#package) in [R](#r_language) that implements a layered grammar of graphics for generating plots. It is a popular alternative to plotting with [base R](#base_r) and part of the [tidyverse](#tidyverse).
+    term: ggplot2
+    def: 'A [package](#package) in [R](#r_language) that implements a layered grammar
+      of graphics for generating plots. It is a popular alternative to plotting with
+      [base R](#base_r) and part of the [tidyverse](#tidyverse).
 
+      '
 - slug: git
   en:
-    term: "Git"
-    def: >
-      A [version control tool](#version_control_system) to record and manage changes to a project.
+    term: Git
+    def: 'A [version control tool](#version_control_system) to record and manage changes
+      to a project.
+
+      '
   fr:
-    term: "Git"
-    def: >
-      Un outil de gestion des versions qui permet d'enregistrer et de piloter les
-      modifications effectuées au niveau d'un projet.
+    term: Git
+    def: 'Un outil de gestion des versions qui permet d''enregistrer et de piloter
+      les modifications effectuées au niveau d''un projet.
+
+      '
   ja:
-    term: "Git(ギット)"
-    def: >
-       プロジェクトなどの変更履歴を記録・追跡するための分散型バージョン管理システムのこと。
+    term: Git(ギット)
+    def: 'プロジェクトなどの変更履歴を記録・追跡するための分散型バージョン管理システムのこと。
+
+      '
   pt:
-    term: "Git"
-    def: >
-      Uma ferramenta de controle de versão para registrar e gerenciar mudanças em um projeto.
+    term: Git
+    def: 'Uma ferramenta de controle de versão para registrar e gerenciar mudanças
+      em um projeto.
+
+      '
   am:
     term: ጋት
-    def: >
-      ለመቅረጽ እና [የስሪት መቆጣጠሪያ መሳሪያ](#version_control_system) በፕሮጀክት ላይ ለውጦችን ማስተዳደር።
-  uk:
-    term: "Git"
-    def: >
-      [Система контролю версій](#version_control_system) для запису історїї змін у проєкті.
+    def: 'ለመቅረጽ እና [የስሪት መቆጣጠሪያ መሳሪያ](#version_control_system) በፕሮጀክት ላይ ለውጦችን ማስተዳደር።
 
+      '
+  uk:
+    term: Git
+    def: '[Система контролю версій](#version_control_system) для запису історїї змін
+      у проєкті.
+
+      '
 - slug: git_branch
   ref:
-    - feature_branch
-    - fork
-    - master_branch
+  - feature_branch
+  - fork
+  - master_branch
   en:
-    term: "Git branch"
-    def: >
-      A snapshot of a version of a [Git](#git) [repository](#repository).
-      Multiple branches can capture multiple versions of the same repository.
+    term: Git branch
+    def: 'A snapshot of a version of a [Git](#git) [repository](#repository). Multiple
+      branches can capture multiple versions of the same repository.
+
+      '
   fr:
-    term: "Git branch"
-    def: >
-      Une photographie d'une version d'un dépôt Git. Plusieurs branches peuvent
-      capturer plusieurs versions au niveau d'un même dépôt.
+    term: Git branch
+    def: 'Une photographie d''une version d''un dépôt Git. Plusieurs branches peuvent
+      capturer plusieurs versions au niveau d''un même dépôt.
+
+      '
   pt:
-    term: "Git branch"
-    def: >
-      Uma fotografia de uma versão de um repositório Git. Múltiplos branches podem
+    term: Git branch
+    def: 'Uma fotografia de uma versão de um repositório Git. Múltiplos branches podem
       capturar múltiplas versões de um mesmo repositório.
 
+      '
   am:
     term: የጊት ቅርንጫፍ
-    def: >
-      የአንድ [Git](#git) [ማከማቻ](#repository) ስሪት ቅጽበታዊ ገጽ እይታ። በርካታ ቅርንጫፎች አንድ ዓይነት ማከማቻ ብዙ ስሪቶችን መያዝ ይችላሉ።
-  uk:
-    term: "гілка Git"
-    def: >
-      Відгалуження від основної гілки розробки, що дозволяє ізолювати роботу над певними завданнями, 
-      такими як додання нових функцій або виправлення помилок, незалежно від змін в основній гілці чи інших відгалуженнях.
+    def: 'የአንድ [Git](#git) [ማከማቻ](#repository) ስሪት ቅጽበታዊ ገጽ እይታ። በርካታ ቅርንጫፎች አንድ ዓይነት
+      ማከማቻ ብዙ ስሪቶችን መያዝ ይችላሉ።
 
+      '
+  uk:
+    term: гілка Git
+    def: 'Відгалуження від основної гілки розробки, що дозволяє ізолювати роботу над
+      певними завданнями,  такими як додання нових функцій або виправлення помилок,
+      незалежно від змін в основній гілці чи інших відгалуженнях.
+
+      '
 - slug: git_clone
   en:
-    term: "Git clone"
-    def: >
-      Copies (and usually downloads) of a [Git](#git) [remote repository](#remote_repository)
+    term: Git clone
+    def: 'Copies (and usually downloads) of a [Git](#git) [remote repository](#remote_repository)
       on a local computer.
+
+      '
   fr:
-    term: "Git clone"
-    def: >
-      Permet de copier (et généralement de télécharger) un [dépôt Git distant](#remote_repository)
-      sur l'ordinateur local.
+    term: Git clone
+    def: 'Permet de copier (et généralement de télécharger) un [dépôt Git distant](#remote_repository)
+      sur l''ordinateur local.
+
+      '
   am:
     term: የጌት ክሎኒ
-    def: >
-      የ [ጂት](#git) [የርቀት) ቅጂዎች (እና አብዛኛውን ጊዜ ውርዶች) ማከማቻ](#remote_repository)
-      በአካባቢያዊ ኮምፒተር ላይ ፡፡
-  uk: 
-    term: "Git clone"
-    def: >
-      Копіює (і зазвичай завантажує) [віддалений репозиторій](#remote_repository) [Git](#git) на локальну файлову систему.
+    def: 'የ [ጂት](#git) [የርቀት) ቅጂዎች (እና አብዛኛውን ጊዜ ውርዶች) ማከማቻ](#remote_repository) በአካባቢያዊ
+      ኮምፒተር ላይ ፡፡
 
+      '
+  uk:
+    term: Git clone
+    def: 'Копіює (і зазвичай завантажує) [віддалений репозиторій](#remote_repository)
+      [Git](#git) на локальну файлову систему.
+
+      '
 - slug: git_conflict
   en:
-    term: "Git conflict"
-    def: >
-      A situation in which incompatible or overlapping changes have been made on
-      different [branches](#branch) that are now being [merged](#git_merge).
+    term: Git conflict
+    def: 'A situation in which incompatible or overlapping changes have been made
+      on different [branches](#branch) that are now being [merged](#git_merge).
+
+      '
   am:
     term: የጂት ግጭት
     def: 'አሁን ባሉ የተለያዩ [ቅርንጫፎች](#branch) ላይ የማይጣጣሙ ወይም ተደራራቢ ለውጦች የተደረጉበት ሁኔታ [ተዋህዷል](#git_merge)::'
   uk:
-    term: "конфлікт Git"
-    def: >
-      Ситуація, в якій несумісні або конфліктуючі зміни були внесені до різних [гілок](#git_branch) і виявлені під час їх об'єднання.
+    term: конфлікт Git
+    def: 'Ситуація, в якій несумісні або конфліктуючі зміни були внесені до різних
+      [гілок](#git_branch) і виявлені під час їх об''єднання.
 
+      '
 - slug: git_fork
   ref:
-    - git_clone
+  - git_clone
   en:
-    term: "Git fork"
-    def: >
-      To make a new copy of a [Git](#git) [repository](#repository)
-      on a [server](#server), or the copy that is made.
+    term: Git fork
+    def: 'To make a new copy of a [Git](#git) [repository](#repository) on a [server](#server),
+      or the copy that is made.
 
+      '
   am:
     term: የጂት ሹካ
     def: በ [አገልጋይ](#repository) ላይ የ [Git](#git) [ማከማቻ](#server) አዲስ ቅጅ ወይም የተሰራውን
       ቅጅ ለማድረግ።
   uk:
-    term: "Git fork"
-    def: >
-      Копія існуючого [репозиторію](#repository) [Git](#git), власник якої може незалежно
-      працювати над кодом, не впливаючи на оригінальний репозиторій. 
-
+    term: Git fork
+    def: "Копія існуючого [репозиторію](#repository) [Git](#git), власник якої може\
+      \ незалежно працювати над кодом, не впливаючи на оригінальний репозиторій. \n"
 - slug: git_merge
   en:
-    term: "Git merge"
-    def: >
-      Merging branches in [Git](#git) incorporates development
-      histories of two [branches](#branch) in one. If changes are made to similar
-      parts of the branches on both branches, a [conflict](#git_conflict) will occur and
+    term: Git merge
+    def: 'Merging branches in [Git](#git) incorporates development histories of two
+      [branches](#branch) in one. If changes are made to similar parts of the branches
+      on both branches, a [conflict](#git_conflict) will occur and
+
+      '
   am:
     term: Git ውህደት
     def: በ [Git](#git) ውስጥ ቅርንጫፎችን ማዋሃድ በአንዱ ውስጥ የሁለት [ቅርንጫፎች](#branch) የልማት ታሪኮችን
       ያካትታል ፡፡ በሁለቱም ቅርንጫፎች ላይ ባሉ ተመሳሳይ ቅርንጫፎች ላይ ለውጦች ከተደረጉ አንድ "ግጭት" (#git_conflict)
       ይከሰታል እናም ውህደቱ ከመጠናቀቁ በፊት ይህ መፍትሄ ማግኘት አለበት ፡፡
   uk:
-    term: "Git merge"
-    def: >
-      Злиття [гілок](#git_branch) у [Git](#git) об'єднує історії розробки двох гілок в одну. 
-      Якщо зміни були внесені в ті ж самі частини коду в обох гілках, виникне [конфлікт](#git_conflict),
-      який необхідно вирішити перед завершенням злиття.
+    term: Git merge
+    def: 'Злиття [гілок](#git_branch) у [Git](#git) об''єднує історії розробки двох
+      гілок в одну.  Якщо зміни були внесені в ті ж самі частини коду в обох гілках,
+      виникне [конфлікт](#git_conflict), який необхідно вирішити перед завершенням
+      злиття.
 
+      '
 - slug: git_pull
   en:
-    term: "Git pull"
-    def: >
-      Downloads and synchronizes changes between a [remote
-      repository](#remote_repository) and a local [repository](#repository).
+    term: Git pull
+    def: 'Downloads and synchronizes changes between a [remote repository](#remote_repository)
+      and a local [repository](#repository).
+
+      '
   fr:
-    term: "Git pull"
-    def: >
-      Télécharge et synchronise les modifications entre le [dépôt distant](#remote_repository)
+    term: Git pull
+    def: 'Télécharge et synchronise les modifications entre le [dépôt distant](#remote_repository)
       et le [dépôt](#repository) local.
+
+      '
   am:
     term: Git መጎተት
     def: በአንድ [የርቀት ማከማቻ](#remote_repository) እና በአከባቢው [ማከማቻ](#repository) መካከል ለውጦችን
       ያውርዳል እና ያመሳስላል።
   uk:
-    term: "Git pull"
-    def: >
-      Отримує зміни з [віддаленого репозиторію](#remote_repository)
-      до локального [репозиторію](#repository).
+    term: Git pull
+    def: 'Отримує зміни з [віддаленого репозиторію](#remote_repository) до локального
+      [репозиторію](#repository).
 
+      '
 - slug: git_push
   en:
-    term: "Git push"
-    def: >
-      Uploads and synchronizes changes between a local [repository](#repository) and a
-      [remote repository](#remote_repository).
-  fr:
-    term: "Git push"
-    def: >
-      Charge et synchronise des modifications entre le [dépôt](#repository) local et
-      le [dépôt distant](#remote_repository).
+    term: Git push
+    def: 'Uploads and synchronizes changes between a local [repository](#repository)
+      and a [remote repository](#remote_repository).
 
+      '
+  fr:
+    term: Git push
+    def: 'Charge et synchronise des modifications entre le [dépôt](#repository) local
+      et le [dépôt distant](#remote_repository).
+
+      '
   am:
     term: Git መግፋት
     def: በአካባቢያዊ [ማከማቻ](#repository) እና ሀ መካከል ለውጦችን ይሰቅላል እና ያመሳስላቸዋል [የርቀት ማከማቻ](#remote_repository)።
   uk:
-    term: "Git push"
-    def: >
-      Надсилає зміни з локального [репозиторію](#repository) до [віддаленого репозиторію](#remote_repository).
+    term: Git push
+    def: 'Надсилає зміни з локального [репозиторію](#repository) до [віддаленого репозиторію](#remote_repository).
 
+      '
 - slug: git_remote
   en:
-    term: "Git remote"
-    def: >
-      A short name for a [remote repository](#remote_repository) (like a bookmark).
+    term: Git remote
+    def: 'A short name for a [remote repository](#remote_repository) (like a bookmark).
+
+      '
   am:
     term: ጌት በርቀት
     def: ለ [የርቀት ማከማቻ] አጭር ስም (#remote_repository) (እንደ ዕልባት)።
   uk:
-    term: "Git remote"
-    def: >
-      URL-адреса, що вказує на [віддалений репозиторій](#remote_repository), яка дозволяє надсилати локальні 
-      зміни або отримувати оновлення для проекту. Часто встановлюється з коротким
-      ім'ям, таким як "origin", для зручності. Іменування [віддаленого репозиторію](#remote_repository)
-      спрощує використання повторюваних команд, замість введення повного URL кожного разу.
+    term: Git remote
+    def: 'URL-адреса, що вказує на [віддалений репозиторій](#remote_repository), яка
+      дозволяє надсилати локальні  зміни або отримувати оновлення для проекту. Часто
+      встановлюється з коротким ім''ям, таким як "origin", для зручності. Іменування
+      [віддаленого репозиторію](#remote_repository) спрощує використання повторюваних
+      команд, замість введення повного URL кожного разу.
 
+      '
 - slug: github
   en:
-    term: "GitHub"
-    def: >
-      A cloud-based platform built around [Git](#git) that allows you to save versions
-      of your project online and collaborate with other Git users.
-  fr:
-    term: "GitHub"
-    def: >
-      Une platefome dans le Cloud, construite autour de [Git](#git) qui permet de
-      sauvegarder en ligne les versions d'un projet et de collaborer avec d'autres
-      utilisateurs Git.
-  pt:
-    term: "GitHub"
-    def: >
-      Uma plataforma baseada em nuvem construída em torno do [Git](#git) que permite
-      salvar versões do seu projeto online e colaborar com outras pessoas usuárias do Git.
+    term: GitHub
+    def: 'A cloud-based platform built around [Git](#git) that allows you to save
+      versions of your project online and collaborate with other Git users.
 
+      '
+  fr:
+    term: GitHub
+    def: 'Une platefome dans le Cloud, construite autour de [Git](#git) qui permet
+      de sauvegarder en ligne les versions d''un projet et de collaborer avec d''autres
+      utilisateurs Git.
+
+      '
+  pt:
+    term: GitHub
+    def: 'Uma plataforma baseada em nuvem construída em torno do [Git](#git) que permite
+      salvar versões do seu projeto online e colaborar com outras pessoas usuárias
+      do Git.
+
+      '
   am:
     term: ጊት ሀብ
     def: የፕሮጀክትዎን ስሪቶች በመስመር ላይ እንዲያስቀምጡ እና ከሌሎች የጂት ተጠቃሚዎች ጋር እንዲተባበሩ የሚያስችልዎ በ [Git](#git)
       ዙሪያ የተገነባ ደመና-ተኮር መድረክ።
   uk:
-    term: "GitHub"
-    def: >
-      Хмарна платформа, побудована навколо [Git](#git), яка дозволяє зберігати версії вашого 
-      проекту онлайн і співпрацювати з іншими користувачами Git.
-      
+    term: GitHub
+    def: 'Хмарна платформа, побудована навколо [Git](#git), яка дозволяє зберігати
+      версії вашого  проекту онлайн і співпрацювати з іншими користувачами Git.
+
+      '
 - slug: global_environment
   en:
-    term: "global environment"
-    def: >
-      The [environment](#environment) that holds top-level definitions in a programming language, e.g.,
-      those written directly in the interpreter.
-  fr:
-    term: "environnement global"
-    def: >
-      L'[environnement](#environment) qui contient des définitions de premier niveau
-      dans un langage de programmation, par exemple celles écrites directement dans l'interpréteur.
+    term: global environment
+    def: 'The [environment](#environment) that holds top-level definitions in a programming
+      language, e.g., those written directly in the interpreter.
 
+      '
+  fr:
+    term: environnement global
+    def: 'L''[environnement](#environment) qui contient des définitions de premier
+      niveau dans un langage de programmation, par exemple celles écrites directement
+      dans l''interpréteur.
+
+      '
   am:
     term: ዓለም አቀፍ አካባቢ
     def: በፕሮግራም ቋንቋ የከፍተኛ ደረጃ ትርጓሜዎችን የሚይዝ (አካባቢው)(#environment) ፣ ለምሳሌ በቀጥታ በአስተርጓሚው
       ውስጥ የተፃፉ ፡፡
-
 - slug: global_installation
   ref:
-    - local_installation
+  - local_installation
   en:
-    term: "global installation"
-    def: >
-      Installing a package in a location where it can be accessed by all users and projects.
+    term: global installation
+    def: 'Installing a package in a location where it can be accessed by all users
+      and projects.
+
+      '
   es:
-    term: "instalación global"
-    def: >
-      El acto de instalar un paquete en una ubicación donde pueda ser accedido por todas las usuarias y proyectos.
+    term: instalación global
+    def: 'El acto de instalar un paquete en una ubicación donde pueda ser accedido
+      por todas las usuarias y proyectos.
+
+      '
   fr:
-    term: "installation globale"
-    def: >
-      Le fait d'installer un package dans un emplacement où il peut être accessible
+    term: installation globale
+    def: 'Le fait d''installer un package dans un emplacement où il peut être accessible
       par tous les utilisateurs ainsi que tous les projets.
 
+      '
   am:
     term: ዓለም አቀፍ ጭነት
     def: አንድ ጥቅል በሁሉም ተጠቃሚዎች እና ፕሮጀክቶች ሊደረስበት በሚችልበት ቦታ ላይ መጫን።
-
 - slug: global_variable
   ref:
-    - local_variable
+  - local_variable
   en:
-    term: "global variable"
-    def: >
-      A variable defined outside any particular function or [package](#package) namespace, which is
-      therefore visible to all functions.
+    term: global variable
+    def: 'A variable defined outside any particular function or [package](#package)
+      namespace, which is therefore visible to all functions.
+
+      '
   es:
-    term: "variable global"
-    def: >
-      Una variable definida fuera de alguna función en particular, por lo que es
-      visible para todas las funciones.
+    term: variable global
+    def: 'Una variable definida fuera de alguna función en particular, por lo que
+      es visible para todas las funciones.
+
+      '
   fr:
-    term: "variable globale"
-    def: >
-      Une variable définie en dehors de l'espace de noms d'une quelconque fonction, qui est par
-      conséquent visible pour toutes les fonctions.
+    term: variable globale
+    def: 'Une variable définie en dehors de l''espace de noms d''une quelconque fonction,
+      qui est par conséquent visible pour toutes les fonctions.
+
+      '
   ko:
-    term: "전역 변수"
-    def: >
-      소스 코드 상의 모든 곳에서 접근할 수 있는 변수.
+    term: 전역 변수
+    def: '소스 코드 상의 모든 곳에서 접근할 수 있는 변수.
+
+      '
   hr:
-    term: "globalna varijabla"
-    def: >
-      Varijabla definirana izvan bilo koje određene funkcije, koja je stoga vidljiva svim funkcijama.
+    term: globalna varijabla
+    def: 'Varijabla definirana izvan bilo koje određene funkcije, koja je stoga vidljiva
+      svim funkcijama.
+
+      '
   am:
     term: ዓለም አቀፍ ተለዋዋጭ
     def: 'ከማንኛውም የተለየ ተግባር ወይም [ጥቅል](#package) የስም ቦታ ውጭ የተገለጸ ተለዋዋጭ ፣ ስለሆነም የሚታየው
       ወደ ሁሉም ተግባራት::'
-
 - slug: globbing
   en:
-    term: "globbing"
-    def: >
-      To specify a set of filenames using a simplified form of [regular
-      expressions](#regular_expression), such as `*.dat` to mean "all files whose
-      names end in `.dat`". The name is derived from "global".
+    term: globbing
+    def: 'To specify a set of filenames using a simplified form of [regular expressions](#regular_expression),
+      such as `*.dat` to mean "all files whose names end in `.dat`". The name is derived
+      from "global".
 
+      '
   am:
     term: ግሎባልንግ
-    def: >
-      ቀለል ያለ የ [መደበኛ] ቅጽ በመጠቀም የፋይል ስሞችን ስብስብ ለመለየት መግለጫዎች](#regular_expression) ፣ እንደ"* .dat`"ማለት"ስማቸው በ".dat`"የሚያበቃ ሁሉም ፋይሎች ማለት ነው። ስሙ የተገኘው ከ "ዓለምአቀፋዊ" ነው ፡፡
+    def: 'ቀለል ያለ የ [መደበኛ] ቅጽ በመጠቀም የፋይል ስሞችን ስብስብ ለመለየት መግለጫዎች](#regular_expression)
+      ፣ እንደ"* .dat`"ማለት"ስማቸው በ".dat`"የሚያበቃ ሁሉም ፋይሎች ማለት ነው። ስሙ የተገኘው ከ "ዓለምአቀፋዊ" ነው
+      ፡፡
 
+      '
 - slug: gnu
   ref:
-    - gpl
+  - gpl
   en:
-    term: "GNU Operating System"
-    acronym: "GNU"
-    def: >
-      "GNU" is an [operating system](#operating_system) that is free software.
-      GNU is a recursive acronym for "GNU is Not Unix!". The GNU operating
-      system consists of GNU [packages](#package) as well as free software realeased by third parties.
+    term: GNU Operating System
+    acronym: GNU
+    def: '"GNU" is an [operating system](#operating_system) that is free software.
+      GNU is a recursive acronym for "GNU is Not Unix!". The GNU operating system
+      consists of GNU [packages](#package) as well as free software realeased by third
+      parties.
 
-
+      '
 - slug: gpl
   ref:
-    - gnu
+  - gnu
   en:
-    term: "GNU Public License"
-    acronym: "GPL"
-    def: >
-      A [license](#license) that allows people to re-use software as long as they
+    term: GNU Public License
+    acronym: GPL
+    def: 'A [license](#license) that allows people to re-use software as long as they
       distribute the source of their changes.
 
+      '
   am:
     term: የጂኤንዩ የህዝብ ፈቃድ
-    def: >
-      ሰዎች የለውጦቻቸውን ምንጭ እስካሰራጩ ድረስ ሶፍትዌሮችን እንደገና እንዲጠቀሙ የሚያስችል (ፈቃድ)፡፡
+    def: 'ሰዎች የለውጦቻቸውን ምንጭ እስካሰራጩ ድረስ ሶፍትዌሮችን እንደገና እንዲጠቀሙ የሚያስችል (ፈቃድ)፡፡
 
-
-- slug: gradient_boosting
-  en:
-    term: "gradient boosting"
-    def: >
-      A [machine learning](#machine_learning) technique that produces an ensemble of
-      weak prediction models (typically [decision trees](#decision_tree)) in a
-      stepwise fashion.
-
-  am:
-    term: የቀስታ መጨመር
-    def: >
-      አንድ ስብስብ የሚያመነጭ [የማሽን መማሪያ](#machine_learning) ዘዴ ደካማ የትንበያ ሞዴሎች (በተለምዶ [የውሳኔ ዛፎች](#decision_tree)) በ ደረጃ በደረጃ ፋሽን.
-
-- slug: gradient_descent
-  ref:
-    - backpropagation
-  en:
-    term: "gradient descent"
-    def: >
-      An optimization algorithm that repeatedly calculates the gradient at the current
-      point takes a small step in the direction in which the gradient is decreasing,
-      and then recalculates the gradient.
-
-  am:
-    term: የግራዲያንት ዝርያ
-    def: >
-      በአሁኑ ጊዜ የግራዲያተሩን ደጋግሞ የሚያሰላ የማመቻቸት ስልተ ቀመር ነጥብ ቀስ በቀስ እየቀነሰ በሚሄድበት አቅጣጫ ትንሽ ደረጃን ይወስዳል እና ከዚያ የግራዲየሙን እንደገና ያሰላል።
-
-  es:
-    term: "descenso del gradiente"
-    def: >
-      Un algoritmo de optimización que calcula repetidamente el gradiente en el punto actual, 
-      da un pequeño paso en la dirección en la que el gradiente está disminuyendo, y luego 
-      recalcula el gradiente.
-
-- slug: graph
-  ref:
-    - tree
-  en:
-    term: "graph"
-    def: >
-      1. A plot or a chart that displays data, or 2. a data structure in which
-      [nodes](#node) are connected to one another by [edges](#edge).
-
-  am:
-    term: ቀመር
-    def: >
-      1. መረጃን የሚያሳይ ሴራ ወይም ገበታ ፣ ወይም 2. በውስጡ የውሂብ መዋቅር [nodes](#node) እርስ በእርሳቸው በ [ጠርዞች](#edge) ተገናኝተዋል።
-
+      '
 - slug: gpu
   ref:
-    - cpu
-    - shader
-    - compute_shader
+  - cpu
+  - shader
+  - compute_shader
   en:
-    term: "Graphics Processing Unit"
-    acronym: "GPU"
-    def: >
-      Specialized processor designed to run many instances of
-      a single program in parallel. Orginally designed for use
-      in graphics, but is also used for general computation in
-      the form of [compute shaders](#compute_shader).
+    term: Graphics Processing Unit
+    acronym: GPU
+    def: 'Specialized processor designed to run many instances of a single program
+      in parallel. Orginally designed for use in graphics, but is also used for general
+      computation in the form of [compute shaders](#compute_shader).
+
+      '
   uk:
-    term: "графічний процесор"
-    acronym: "GPU"
-    def: >
-      Спеціалізований процесор, призначений для паралельного 
-      виконання багатьох копій однієї програми. Спочатку 
-      розроблений для обробки графіки, але зараз також використовується
-      для загальних обчислень у вигляді [обчислювальних шейдерів](#compute_shader).
-    
+    term: графічний процесор
+    acronym: GPU
+    def: 'Спеціалізований процесор, призначений для паралельного  виконання багатьох
+      копій однієї програми. Спочатку  розроблений для обробки графіки, але зараз
+      також використовується для загальних обчислень у вигляді [обчислювальних шейдерів](#compute_shader).
+
+      '
+- slug: gradient_boosting
+  en:
+    term: gradient boosting
+    def: 'A [machine learning](#machine_learning) technique that produces an ensemble
+      of weak prediction models (typically [decision trees](#decision_tree)) in a
+      stepwise fashion.
+
+      '
+  am:
+    term: የቀስታ መጨመር
+    def: 'አንድ ስብስብ የሚያመነጭ [የማሽን መማሪያ](#machine_learning) ዘዴ ደካማ የትንበያ ሞዴሎች (በተለምዶ
+      [የውሳኔ ዛፎች](#decision_tree)) በ ደረጃ በደረጃ ፋሽን.
+
+      '
+- slug: gradient_descent
+  ref:
+  - backpropagation
+  en:
+    term: gradient descent
+    def: 'An optimization algorithm that repeatedly calculates the gradient at the
+      current point takes a small step in the direction in which the gradient is decreasing,
+      and then recalculates the gradient.
+
+      '
+  am:
+    term: የግራዲያንት ዝርያ
+    def: 'በአሁኑ ጊዜ የግራዲያተሩን ደጋግሞ የሚያሰላ የማመቻቸት ስልተ ቀመር ነጥብ ቀስ በቀስ እየቀነሰ በሚሄድበት አቅጣጫ
+      ትንሽ ደረጃን ይወስዳል እና ከዚያ የግራዲየሙን እንደገና ያሰላል።
+
+      '
+  es:
+    term: descenso del gradiente
+    def: 'Un algoritmo de optimización que calcula repetidamente el gradiente en el
+      punto actual,  da un pequeño paso en la dirección en la que el gradiente está
+      disminuyendo, y luego  recalcula el gradiente.
+
+      '
+- slug: graph
+  ref:
+  - tree
+  en:
+    term: graph
+    def: '1. A plot or a chart that displays data, or 2. a data structure in which
+      [nodes](#node) are connected to one another by [edges](#edge).
+
+      '
+  am:
+    term: ቀመር
+    def: '1. መረጃን የሚያሳይ ሴራ ወይም ገበታ ፣ ወይም 2. በውስጡ የውሂብ መዋቅር [nodes](#node) እርስ በእርሳቸው
+      በ [ጠርዞች](#edge) ተገናኝተዋል።
+
+      '
+- slug: greedy_algorithm
+  ref:
+  - algorithm
+  en:
+    term: greedy algorithm
+    def: 'An algorithmic approach that makes the locally optimal choice at each step
+      with the hope of finding a global optimum. Greedy algorithms are often simpler
+      and faster but don''t always produce the optimal solution.
+
+      '
 - slug: group
   en:
-    term: "group"
-    def: >
-      To divide data into subsets according to a set of criteria while leaving records in
-      a single structure.
+    term: group
+    def: 'To divide data into subsets according to a set of criteria while leaving
+      records in a single structure.
+
+      '
   af:
     term: groepeer
-    def: >
-      Om data in groepe te verdeel volgens 'n stel kriteria terwyl die rekords in 'n enkele struktuur gelaat word.
+    def: 'Om data in groepe te verdeel volgens ''n stel kriteria terwyl die rekords
+      in ''n enkele struktuur gelaat word.
+
+      '
   am:
     term: ቡድን
-    def: >
-      በአንድ መዋቅር ውስጥ መዝገቦችን በሚተዉበት ጊዜ መረጃን እንደ መስፈርት ስብስብ በንዑስ ክፍልፋዮች ለመከፋፈል ፡፡
+    def: 'በአንድ መዋቅር ውስጥ መዝገቦችን በሚተዉበት ጊዜ መረጃን እንደ መስፈርት ስብስብ በንዑስ ክፍልፋዮች ለመከፋፈል ፡፡
 
+      '
 - slug: gui
   en:
-    term: "graphical user interface"
-    acronym: "GUI"
-    def: >
-      A user interface that relies on windows, menus, pointers, and other graphical
+    term: graphical user interface
+    acronym: GUI
+    def: 'A user interface that relies on windows, menus, pointers, and other graphical
       elements, as opposed to a [command-line interface](#cli) or voice-driven interface.
+
+      '
   pt:
-    term: "interface gráfica de usuário"
-    acronym: "GUI"
-    def: >
-      Uma interface de usuário cujo uso depende de janelas, menus, ponteiros e outros
-      elementos gráficos, em oposição a uma [interface de linha de comando](#cli) ou
-      interface comandada por voz.
+    term: interface gráfica de usuário
+    acronym: GUI
+    def: 'Uma interface de usuário cujo uso depende de janelas, menus, ponteiros e
+      outros elementos gráficos, em oposição a uma [interface de linha de comando](#cli)
+      ou interface comandada por voz.
 
-
+      '
 - slug: handle_condition
   ref:
-    - condition
-    - exception
+  - condition
+  - exception
   en:
-    term: "handle (condition)"
-    def: >
-      To accept responsibility for handling an error or other unexpected event. [R](#r_language)
-      prefers "handling a condition" to "[catching an exception](catch_exception)". [Python](#python), on the other hand,
-      encourages raising and catching exceptions, and in some situations, requires it.
+    term: handle (condition)
+    def: 'To accept responsibility for handling an error or other unexpected event.
+      [R](#r_language) prefers "handling a condition" to "[catching an exception](catch_exception)".
+      [Python](#python), on the other hand, encourages raising and catching exceptions,
+      and in some situations, requires it.
 
+      '
   am:
     term: እጀታ (ሁኔታ)
-    def: >
-      ስህተት ወይም ሌላ ያልተጠበቀ ክስተት ለማስተናገድ ሃላፊነትን ለመቀበል። [R](#r_language) "ሁኔታን ማስተናገድ"ከሚለው ይልቅ"(ለየት ያለ ሁኔታ ለመያዝ) (catch_exception)"ን ይመርጣል። [Python](#python) ፣ በሌላ በኩል ፣ ልዩነቶችን ማሳደግ እና መያዝን ያበረታታል ፣ እና በአንዳንድ ሁኔታዎችም ይጠይቃል ፡፡
+    def: 'ስህተት ወይም ሌላ ያልተጠበቀ ክስተት ለማስተናገድ ሃላፊነትን ለመቀበል። [R](#r_language) "ሁኔታን ማስተናገድ"ከሚለው
+      ይልቅ"(ለየት ያለ ሁኔታ ለመያዝ) (catch_exception)"ን ይመርጣል። [Python](#python) ፣ በሌላ በኩል
+      ፣ ልዩነቶችን ማሳደግ እና መያዝን ያበረታታል ፣ እና በአንዳንድ ሁኔታዎችም ይጠይቃል ፡፡
 
+      '
 - slug: hardware
   en:
-    term: "hardware"
-    acronym: "HW"
-    def: >
-      Any physical component of a computer system. Hardware can be internal, such as CPU, memory,
-      and graphics cards; or external, such as monitors and keyboards. Hardware operates in conjunction
-      with software to produce a functioning computer system.
+    term: hardware
+    acronym: HW
+    def: 'Any physical component of a computer system. Hardware can be internal, such
+      as CPU, memory, and graphics cards; or external, such as monitors and keyboards.
+      Hardware operates in conjunction with software to produce a functioning computer
+      system.
 
+      '
   am:
     term: ሃርድዌር(ከብረት የተሰሩ እቃዎች)
-    def: >
-      የኮምፒተር ስርዓት ማንኛውም አካላዊ አካል። ሃርድዌር እንደ ሲፒዩ ፣ ማህደረ ትውስታ ፣ ውስጣዊ ሊሆን ይችላል እና ግራፊክስ ካርዶች; ወይም እንደ ማሳያ እና የቁልፍ ሰሌዳዎች ያሉ ውጫዊ። ሃርድዌር አብሮ ይሠራል የሚሰራ የኮምፒተር ስርዓት ለማምረት ከሶፍትዌር ጋር ፡፡
+    def: 'የኮምፒተር ስርዓት ማንኛውም አካላዊ አካል። ሃርድዌር እንደ ሲፒዩ ፣ ማህደረ ትውስታ ፣ ውስጣዊ ሊሆን ይችላል እና
+      ግራፊክስ ካርዶች; ወይም እንደ ማሳያ እና የቁልፍ ሰሌዳዎች ያሉ ውጫዊ። ሃርድዌር አብሮ ይሠራል የሚሰራ የኮምፒተር ስርዓት
+      ለማምረት ከሶፍትዌር ጋር ፡፡
 
+      '
 - slug: harmonic_mean
   ref:
-    - mean
+  - mean
   en:
-    term: "Harmonic Mean"
-    def: >
-      Calculated from a set of n numbers by first computing the sum of the
-      [reciprocals](#reciprocal) of those numbers, and then dividing n by the
-      resulting sum. Alternatively, it can be computed as the
-      [reciprocal](#reciprocal) of the [arithmetic mean](#arithmetic_mean) of
-      the [reciprocal](#reciprocal) values. Similarly to the
-      [geometric mean](#geometric_mean), the harmonic mean is often used as an
-      alternative measure of central tendancy to the usual
-      [arithmetic mean](#arithmetic_mean) when estimating an average rates of
-      change or some other multiplicative constant. For a set of positive
-      numbers that are not all equal, the min < HM < GM < AM < max where min is
-      the minimum value, max is the maximum value, and HM GM and AM are the
-      harmonic, [geometric](#geometric_mean), and [arithmetic](#arithmetic_mean)
-      means respectively.
-  uk:
-    term: "середнє гармонійне"
-    def: >
-      Обчислюється для набору з n чисел шляхом обчислення суми обернених величин цих чисел,
-      а потім ділення n на отриману суму.
-      Його також можна обчислити як обернене від арифметичного середнього обернених значень. 
-      Гармонійне середнє використовується для оцінки середніх швидкостей зміни або інших 
-      коефіцієнтів. Для набору додатних чисел, які не всі рівні між собою (або одне одному) виконується наступна нерівність:
-      Мінімальне значення < Гармонійне середнє < Геометричне середнє < Арифметичне середнє < Максимальне значення.
+    term: Harmonic Mean
+    def: 'Calculated from a set of n numbers by first computing the sum of the [reciprocals](#reciprocal)
+      of those numbers, and then dividing n by the resulting sum. Alternatively, it
+      can be computed as the [reciprocal](#reciprocal) of the [arithmetic mean](#arithmetic_mean)
+      of the [reciprocal](#reciprocal) values. Similarly to the [geometric mean](#geometric_mean),
+      the harmonic mean is often used as an alternative measure of central tendancy
+      to the usual [arithmetic mean](#arithmetic_mean) when estimating an average
+      rates of change or some other multiplicative constant. For a set of positive
+      numbers that are not all equal, the min < HM < GM < AM < max where min is the
+      minimum value, max is the maximum value, and HM GM and AM are the harmonic,
+      [geometric](#geometric_mean), and [arithmetic](#arithmetic_mean) means respectively.
 
+      '
+  uk:
+    term: середнє гармонійне
+    def: 'Обчислюється для набору з n чисел шляхом обчислення суми обернених величин
+      цих чисел, а потім ділення n на отриману суму. Його також можна обчислити як
+      обернене від арифметичного середнього обернених значень.  Гармонійне середнє
+      використовується для оцінки середніх швидкостей зміни або інших  коефіцієнтів.
+      Для набору додатних чисел, які не всі рівні між собою (або одне одному) виконується
+      наступна нерівність: Мінімальне значення < Гармонійне середнє < Геометричне
+      середнє < Арифметичне середнє < Максимальне значення.
+
+      '
 - slug: hash_function
   en:
-    term: "hash function"
-    def: >
-      A function that turns arbitrary data into a bit array, or a [key](#key), of a fixed size. Hash
-      functions are used to determine where data should be stored in a [hash table](#hash_table).
+    term: hash function
+    def: 'A function that turns arbitrary data into a bit array, or a [key](#key),
+      of a fixed size. Hash functions are used to determine where data should be stored
+      in a [hash table](#hash_table).
 
+      '
   am:
     term: ሃሽ ተግባር
-    def: >
-      የዘፈቀደ ውሂብን ወደ ትንሽ ድርድር ወይም ወደ አንድ የተወሰነ መጠን [ቁልፍ](#key) የሚቀይር ተግባር። ሃሽ ተግባራት በ [ሃሽ ሰንጠረዥ] ውስጥ የት እንደሚቀመጡ ለመወሰን ተግባሮች ጥቅም ላይ ይውላሉ (#hash_table) ፡፡
+    def: 'የዘፈቀደ ውሂብን ወደ ትንሽ ድርድር ወይም ወደ አንድ የተወሰነ መጠን [ቁልፍ](#key) የሚቀይር ተግባር። ሃሽ ተግባራት
+      በ [ሃሽ ሰንጠረዥ] ውስጥ የት እንደሚቀመጡ ለመወሰን ተግባሮች ጥቅም ላይ ይውላሉ (#hash_table) ፡፡
 
+      '
 - slug: hash_table
   en:
-    term: "hash table"
-    def: >
-      A data structure that calculates a pseudo-random key (location) for each value passed to it and stores
-      the value in that location. Hash tables enable fast lookup for arbitrary data. This occurs
-      at the cost of extra memory because hash tables must always be larger than the amount
-      of information they need to store, to avoid the possibility of data collisions, when the
-      hash function returns the same key for two different values.
+    term: hash table
+    def: 'A data structure that calculates a pseudo-random key (location) for each
+      value passed to it and stores the value in that location. Hash tables enable
+      fast lookup for arbitrary data. This occurs at the cost of extra memory because
+      hash tables must always be larger than the amount of information they need to
+      store, to avoid the possibility of data collisions, when the hash function returns
+      the same key for two different values.
 
+      '
   am:
     term: ሃሽ ጠረጴዛ
-    def: >
-      ለእሱ ለተላለፈው ለእያንዳንዱ እሴት የሐሰት-የዘፈቀደ ቁልፍ (ሥፍራ) የሚሰላ የውሂብ መዋቅር በዚያ ቦታ ያለው እሴት። የሃሽ ሰንጠረ arች የዘፈቀደ ውሂብ ፈጣን ፍለጋን ያንቁ ፡፡ ይህ ይከሰታል ተጨማሪ የማስታወስ ችሎታ ባለው ወጪ ፣ ምክንያቱም የሃሽ ሰንጠረ alwaysች ሁል ጊዜ ከቁጥር የበለጠ መሆን አለባቸው የመረጃ ግጭቶች እንዳይከሰቱ ለማስቀመጥ የሚፈልጉትን መረጃ ፣ መቼ ሃሽ ተግባር ለሁለት የተለያዩ እሴቶች ተመሳሳይ ቁልፍን ይመልሳል።
+    def: 'ለእሱ ለተላለፈው ለእያንዳንዱ እሴት የሐሰት-የዘፈቀደ ቁልፍ (ሥፍራ) የሚሰላ የውሂብ መዋቅር በዚያ ቦታ ያለው እሴት።
+      የሃሽ ሰንጠረ arች የዘፈቀደ ውሂብ ፈጣን ፍለጋን ያንቁ ፡፡ ይህ ይከሰታል ተጨማሪ የማስታወስ ችሎታ ባለው ወጪ ፣ ምክንያቱም
+      የሃሽ ሰንጠረ alwaysች ሁል ጊዜ ከቁጥር የበለጠ መሆን አለባቸው የመረጃ ግጭቶች እንዳይከሰቱ ለማስቀመጥ የሚፈልጉትን
+      መረጃ ፣ መቼ ሃሽ ተግባር ለሁለት የተለያዩ እሴቶች ተመሳሳይ ቁልፍን ይመልሳል።
 
+      '
+- slug: hashing
+  ref:
+  - hash_table
+  - algorithm
+  en:
+    term: hashing
+    def: 'The process of converting input data of any size into a fixed-size value
+      (hash code) using a hash function. Used in hash tables, cryptography, and data
+      integrity verification.
+
+      '
 - slug: header_row
   ref:
-    - csv
+  - csv
   en:
-    term: "header row"
-    def: >
-      If present, the first row of a data file that defines column names (but
+    term: header row
+    def: 'If present, the first row of a data file that defines column names (but
       not their data types or units).
 
+      '
   am:
     term: የራስጌ ረድፍ
-    def: >
-      የሚገኝ ከሆነ ፣ የዓምድ ስሞችን (ግን የውሂብ አይነቶቻቸውን ወይም አሃዶቻቸውን ሳይሆን) የሚወስን የመረጃ ፋይል የመጀመሪያ ረድፍ።
+    def: 'የሚገኝ ከሆነ ፣ የዓምድ ስሞችን (ግን የውሂብ አይነቶቻቸውን ወይም አሃዶቻቸውን ሳይሆን) የሚወስን የመረጃ ፋይል
+      የመጀመሪያ ረድፍ።
 
+      '
+- slug: heap
+  ref:
+  - binary_tree
+  en:
+    term: heap
+    def: 'A specialized [binary tree](#binary_tree)-based data structure that satisfies
+      the heap property: in a max heap, parent nodes are greater than or equal to
+      their children; in a min heap, parent nodes are less than or equal to their
+      children. Used for priority queues and heap sort.
+
+      '
 - slug: heterogeneous
   ref:
-    - homogeneous
+  - homogeneous
   en:
-    term: "heterogeneous"
-    def: >
-      Containing mixed data types. For example, in [Python](#python) and [R](#r_language), a [list](#list) can contain a mix of numbers, character
-      strings, and values of other types.
+    term: heterogeneous
+    def: 'Containing mixed data types. For example, in [Python](#python) and [R](#r_language),
+      a [list](#list) can contain a mix of numbers, character strings, and values
+      of other types.
 
+      '
   am:
     term: የተለያዩ
-    def: >
-      የተደባለቀ የውሂብ አይነቶችን የያዘ። ለምሳሌ ፣ በ [Python](#python) እና [R](#r_language) ውስጥ [ዝርዝር](#list) የቁጥሮች ፣ የቁምፊ ሕብረቁምፊዎች እና የሌሎች ዓይነቶች እሴቶች ድብልቅ ሊይዝ ይችላል ፡፡
+    def: 'የተደባለቀ የውሂብ አይነቶችን የያዘ። ለምሳሌ ፣ በ [Python](#python) እና [R](#r_language) ውስጥ
+      [ዝርዝር](#list) የቁጥሮች ፣ የቁምፊ ሕብረቁምፊዎች እና የሌሎች ዓይነቶች እሴቶች ድብልቅ ሊይዝ ይችላል ፡፡
 
+      '
 - slug: hexadecimal
   en:
-    term: "hexadecimal"
-    def: >
-      A base-16 number system. Hexadecimal values are usually written using the digits
-      0-9 and the characters A-F in either upper or lower case. Hexadecimal is often
-      used to represent [binary](#binary) values, since two hexadecimal digits use exactly
-      one byte of storage.
+    term: hexadecimal
+    def: 'A base-16 number system. Hexadecimal values are usually written using the
+      digits 0-9 and the characters A-F in either upper or lower case. Hexadecimal
+      is often used to represent [binary](#binary) values, since two hexadecimal digits
+      use exactly one byte of storage.
 
+      '
   am:
     term: አስራስድስትዮሽ
-    def: >
-      የመሠረት-16 ቁጥር ስርዓት. ሄክሳዴሲማል እሴቶች ብዙውን ጊዜ አሃዞችን በመጠቀም ይጻፋሉ 0-9 እና ቁምፊዎች A-F በሁለቱም በላይኛው ወይም በታችኛው ጉዳይ። ሄክሳዴሲማል ብዙ ጊዜ ነው ሁለት ሄክሳዴሲማል አሃዞች በትክክል አንድ ባይት ክምችት ስለሚጠቀሙ የ [ሁለትዮሽ](#binary) እሴቶችን ይወክላል።
+    def: 'የመሠረት-16 ቁጥር ስርዓት. ሄክሳዴሲማል እሴቶች ብዙውን ጊዜ አሃዞችን በመጠቀም ይጻፋሉ 0-9 እና ቁምፊዎች A-F
+      በሁለቱም በላይኛው ወይም በታችኛው ጉዳይ። ሄክሳዴሲማል ብዙ ጊዜ ነው ሁለት ሄክሳዴሲማል አሃዞች በትክክል አንድ ባይት ክምችት
+      ስለሚጠቀሙ የ [ሁለትዮሽ](#binary) እሴቶችን ይወክላል።
 
+      '
+- slug: hidden_layer
+  ref:
+  - neural_network
+  - machine_learning
+  - deep_learning
+  - perceptron
+  en:
+    term: hidden layer (deep learning)
+    def: 'A hidden layer in a [neural network](#neural_network) refers to the layers
+      of neurons that are not directly connected to input or output. The layers are
+      "hidden" because you do not directly observe their input and output values.
+
+      '
+  es:
+    term: capa oculta (deep learning)
+    def: 'Una capa oculta en una [red neuronal](#neural_network) hace referencia a
+      las capas de neuronas que no están directamente conectadas al ingreso o salida
+      de información. Las capas están "escondidas" porque no puedes observar directamente
+      el ingreso y salida de valores.
+
+      '
+- slug: high_performance_computing
+  en:
+    term: high performance computing
+    acronym: HPC
+    def: 'When computing power is drawn from multiple powerful processors that work
+      together in parallel, rather than from a single desktop computer, laptop, or
+      work station. This significantly speeds up analysis and reduces computing time,
+      which allows people to work with [big data](#big_data).
+
+      '
+  es:
+    term: computación de alto rendimiento
+    def: 'Método que utiliza procesadores poderosos, usualmente trabajando en paralelo,
+      para analizar datos. Su uso adecuado reduce el tiempo de análisis en comparación
+      con una computadora personal y permite la exploración de grandes colecciones
+      de datos.
+
+      '
 - slug: higher_order_function
   en:
-    term: "higher-order function"
-    def: >
-      A function that operates on other functions. For example, the higher-order
+    term: higher-order function
+    def: 'A function that operates on other functions. For example, the higher-order
       function `map` executes a given function once on each value in a [list](#list).
       Higher-order functions are heavily used in [functional programming](#functional_programming).
 
+      '
   am:
     term: ከፍተኛ-ትዕዛዝ ተግባር
-    def: >
-      በሌሎች ተግባራት ላይ የሚሰራ ተግባር ፡፡ ለምሳሌ ፣ ከፍተኛ-ትዕዛዝ ተግባር "ካርታ` በ [ዝርዝር](#list) ውስጥ በእያንዳንዱ እሴት ላይ አንድ ጊዜ የተሰጠ ተግባርን ያከናውናል። የከፍተኛ ትዕዛዝ ተግባራት [በተግባራዊ መርሃግብር](#functional_programming) ውስጥ በጣም ያገለግላሉ።
+    def: 'በሌሎች ተግባራት ላይ የሚሰራ ተግባር ፡፡ ለምሳሌ ፣ ከፍተኛ-ትዕዛዝ ተግባር "ካርታ` በ [ዝርዝር](#list) ውስጥ
+      በእያንዳንዱ እሴት ላይ አንድ ጊዜ የተሰጠ ተግባርን ያከናውናል። የከፍተኛ ትዕዛዝ ተግባራት [በተግባራዊ መርሃግብር](#functional_programming)
+      ውስጥ በጣም ያገለግላሉ።
 
-- slug: high_performance_computing
-  en:
-    term: "high performance computing"
-    acronym: "HPC"
-    def: >
-        When computing power is drawn from multiple powerful processors that work together in parallel, rather than from a single desktop computer, laptop, or work station.
-        This significantly speeds up analysis and reduces computing time, which allows people to work with [big data](#big_data).
-  es:
-    term: "computación de alto rendimiento"
-    def: >
-       Método que utiliza procesadores poderosos, usualmente trabajando en paralelo, para analizar datos.
-       Su uso adecuado reduce el tiempo de análisis en comparación con una computadora personal y permite la exploración de grandes colecciones de datos.
-
+      '
 - slug: hippocratic_license
   en:
-    term: "Hippocratic License"
-    def: >
-      An ethical software [license](#license) that allows free use for any purpose
+    term: Hippocratic License
+    def: 'An ethical software [license](#license) that allows free use for any purpose
       that does not contravene the Universal Declaration of Human Rights.
 
+      '
   am:
     term: የሂፖክራሲያዊ ፈቃድ
-    def: >
-      ለማንኛውም ዓላማ ነፃ አጠቃቀምን የሚፈቅድ የስነምግባር ሶፍትዌር [ፈቃድ](#license) ዓለም አቀፍ የሰብአዊ መብቶች ድንጋጌን አይቃረንም ፡፡
+    def: 'ለማንኛውም ዓላማ ነፃ አጠቃቀምን የሚፈቅድ የስነምግባር ሶፍትዌር [ፈቃድ](#license) ዓለም አቀፍ የሰብአዊ መብቶች
+      ድንጋጌን አይቃረንም ፡፡
 
+      '
 - slug: histogram
   en:
-    term: "histogram"
-    def: >
-      A graphical representation of the distribution of a set of numeric data, usually
-      a vertical bar graph.
-  af:
-    term: "histogram"
-    def: >
-     'n Grafiese voorstelling van die verspreiding van 'n data, gewoonlik 'n vertikale staafgrafiek.
+    term: histogram
+    def: 'A graphical representation of the distribution of a set of numeric data,
+      usually a vertical bar graph.
 
+      '
+  af:
+    term: histogram
+    def: '''n Grafiese voorstelling van die verspreiding van ''n data, gewoonlik ''n
+      vertikale staafgrafiek.
+
+      '
   am:
     term: ግጥም ጥርብ ግራፍ
-    def: >
-      የቁጥር ውሂብ ስብስብ ስርጭት ግራፊክ ውክልና ፣ ብዙውን ጊዜ ቀጥ ያለ የአሞሌ ግራፍ
-  uk:
-    term: "гістограма"
-    def: >
-      Графічне представлення розподілу числових даних, де дані згруповані у рівновіддалені 
-      інтервали, а висота кожного стовпця відповідає частоті точок даних у цьому інтервалі.
+    def: 'የቁጥር ውሂብ ስብስብ ስርጭት ግራፊክ ውክልና ፣ ብዙውን ጊዜ ቀጥ ያለ የአሞሌ ግራፍ
 
+      '
+  uk:
+    term: гістограма
+    def: 'Графічне представлення розподілу числових даних, де дані згруповані у рівновіддалені  інтервали,
+      а висота кожного стовпця відповідає частоті точок даних у цьому інтервалі.
+
+      '
 - slug: hitchhiker
   en:
-    term: "hitchhiker"
-    def: >
-      Someone who is part of a project but does not actually do any work on it.
+    term: hitchhiker
+    def: 'Someone who is part of a project but does not actually do any work on it.
 
+      '
   am:
     term: ሂቼቺከር
-    def: >
-      አንድ የፕሮጀክት አካል የሆነ ነገር ግን በእውነቱ በእሱ ላይ ምንም ሥራ የማይሠራ ሰው ፡፡
+    def: 'አንድ የፕሮጀክት አካል የሆነ ነገር ግን በእውነቱ በእሱ ላይ ምንም ሥራ የማይሠራ ሰው ፡፡
 
+      '
   st:
-    term: "mohahlaudi"
-    def: >
-      Motho a leng karolo ya letsema empa a sa etse letho ho lona.
+    term: mohahlaudi
+    def: 'Motho a leng karolo ya letsema empa a sa etse letho ho lona.
 
+      '
 - slug: home_directory
   en:
-    term: "home directory"
-    def: >
-      A directory that contains a user's files. Each user on a multi-user computer
-      will have their own home directory; a personal computer will often only have one
-      home directory.
+    term: home directory
+    def: 'A directory that contains a user''s files. Each user on a multi-user computer
+      will have their own home directory; a personal computer will often only have
+      one home directory.
 
+      '
   am:
     term: መኖሪያ ሀጸ ማውጫ
-    def: >
-      የተጠቃሚ ፋይሎችን የያዘ ማውጫ. እያንዳንዱ ተጠቃሚ በብዙ ተጠቃሚ ኮምፒተር ላይ የራሳቸው ቤት ማውጫ ይኖራቸዋል; የግል ኮምፒተር ብዙ ጊዜ አንድ የቤት ማውጫ ብቻ ይኖረዋል ፡፡
+    def: 'የተጠቃሚ ፋይሎችን የያዘ ማውጫ. እያንዳንዱ ተጠቃሚ በብዙ ተጠቃሚ ኮምፒተር ላይ የራሳቸው ቤት ማውጫ ይኖራቸዋል;
+      የግል ኮምፒተር ብዙ ጊዜ አንድ የቤት ማውጫ ብቻ ይኖረዋል ፡፡
 
+      '
 - slug: homogeneous
   ref:
-    - heterogeneous
+  - heterogeneous
   en:
-    term: "homogeneous"
-    def: >
-      Containing a single data type. For example, a [vector](#vector) must be homogeneous: its
-      values must all be numeric, logical, etc.
+    term: homogeneous
+    def: 'Containing a single data type. For example, a [vector](#vector) must be
+      homogeneous: its values must all be numeric, logical, etc.
 
+      '
   am:
     term: ተመሳሳይነት ያለው
-    def: >
-      አንድ ነጠላ የውሂብ አይነት የያዘ። ለምሳሌ ፣ አንድ [ቬክተር](#vector) ተመሳሳይ መሆን አለበት-የእሱ እሴቶች ሁሉም ቁጥራዊ ፣ ሎጂካዊ ፣ ወዘተ መሆን አለባቸው ፡፡
+    def: 'አንድ ነጠላ የውሂብ አይነት የያዘ። ለምሳሌ ፣ አንድ [ቬክተር](#vector) ተመሳሳይ መሆን አለበት-የእሱ እሴቶች
+      ሁሉም ቁጥራዊ ፣ ሎጂካዊ ፣ ወዘተ መሆን አለባቸው ፡፡
 
+      '
 - slug: html
   ref:
-    - xml
+  - xml
   en:
-    term: "HyperText Markup Language"
-    acronym: "HTML"
-    def: >
-      The standard [markup language](#markup_language) used for web pages. HTML is
-      represented in memory using [DOM](#dom) (Document Object Model).
-  de:
-    term: "Hypertext-Auszeichnungssprache"
-    acronym: "HTML"
-    def: >
-      Die Standard-[Auszeichnungssprache](#markup_language) für Webseiten. HTML wird
-      im Speicher durch das [Dokumenten-Objekt-Modell](#dom) repräsentiert.
+    term: HyperText Markup Language
+    acronym: HTML
+    def: 'The standard [markup language](#markup_language) used for web pages. HTML
+      is represented in memory using [DOM](#dom) (Document Object Model).
 
+      '
+  de:
+    term: Hypertext-Auszeichnungssprache
+    acronym: HTML
+    def: 'Die Standard-[Auszeichnungssprache](#markup_language) für Webseiten. HTML
+      wird im Speicher durch das [Dokumenten-Objekt-Modell](#dom) repräsentiert.
+
+      '
   am:
     term: የሃይፐር ጽሑፍ ምልክት ማድረጊያ ቋንቋ
-    def: >
-      ለድር ገጾች ጥቅም ላይ የዋለው መደበኛው [ምልክት ማድረጊያ ቋንቋ](#markup_language) ኤችቲኤምኤል ነው [DOM](#dom) (ዲጂታል ነገር ሞዴል) በመጠቀም በማስታወስ ውስጥ ተወክሏል።
-  uk:
-    term: "мова розмітки гіпертексту (HyperText Markup Language)"
-    acronym: "HTML"
-    def: >
-      Стандартна [мова розмітки](#markup_language), що використовується для створення 
-      та структурування вебсторінок. HTML представлено у пам'яті за допомогою [DOM](#dom) (об'єктна модель документа).
+    def: 'ለድር ገጾች ጥቅም ላይ የዋለው መደበኛው [ምልክት ማድረጊያ ቋንቋ](#markup_language) ኤችቲኤምኤል ነው
+      [DOM](#dom) (ዲጂታል ነገር ሞዴል) በመጠቀም በማስታወስ ውስጥ ተወክሏል።
 
+      '
+  uk:
+    term: мова розмітки гіпертексту (HyperText Markup Language)
+    acronym: HTML
+    def: 'Стандартна [мова розмітки](#markup_language), що використовується для створення  та
+      структурування вебсторінок. HTML представлено у пам''яті за допомогою [DOM](#dom)
+      (об''єктна модель документа).
+
+      '
 - slug: http
   en:
-    term: "HyperText Transfer Protocol"
-    acronym: "HTTP"
-    def: >
-      The standard [protocol](#protocol) for data transfer on the World-Wide Web. HTTP
-      defines the format of [requests](#http_request) and [responses](#http_response),
+    term: HyperText Transfer Protocol
+    acronym: HTTP
+    def: 'The standard [protocol](#protocol) for data transfer on the World-Wide Web.
+      HTTP defines the format of [requests](#http_request) and [responses](#http_response),
       the meanings of standard error codes, and other features.
 
+      '
   am:
     term: የሃይፐር ጽሑፍ ማስተላለፍ ፕሮቶኮል
-    def: >
-      በአለም አቀፍ ድር ላይ ለመረጃ ማስተላለፍ መደበኛ [ፕሮቶኮል](#protocol)። ኤች.ቲ.ፒ.ፒ. የ [ጥያቄዎች](#http_request) ቅርጸት እና [ምላሾች](#http_response) ፣ የመደበኛ ስህተት ኮዶች ትርጓሜዎች እና ሌሎች ባህሪዎች ይገልፃል።
+    def: 'በአለም አቀፍ ድር ላይ ለመረጃ ማስተላለፍ መደበኛ [ፕሮቶኮል](#protocol)። ኤች.ቲ.ፒ.ፒ. የ [ጥያቄዎች](#http_request)
+      ቅርጸት እና [ምላሾች](#http_response) ፣ የመደበኛ ስህተት ኮዶች ትርጓሜዎች እና ሌሎች ባህሪዎች ይገልፃል።
 
+      '
 - slug: http_header
   en:
-    term: "HTTP header"
-    def: >
-      A key-value pair at the top of an [HTTP](#http) [request](#http_request) or
-      [response](#http_response) that carries additional information such as the
-      user's preferred language or the length of the data being transferred.
+    term: HTTP header
+    def: 'A key-value pair at the top of an [HTTP](#http) [request](#http_request)
+      or [response](#http_response) that carries additional information such as the
+      user''s preferred language or the length of the data being transferred.
 
+      '
   am:
     term: የኤችቲቲፒ ራስጌ
-    def: >
-      በ [HTTP] አናት ላይ የቁልፍ እሴት ጥንድ (#http) [ጥያቄ](#http_request) ወይም እንደ "መረጃ" ተጨማሪ መረጃዎችን የሚያስተላልፍ [ምላሽ](#http_response) የተጠቃሚው ተመራጭ ቋንቋ ወይም የተላለፈው የውሂብ ርዝመት።
+    def: 'በ [HTTP] አናት ላይ የቁልፍ እሴት ጥንድ (#http) [ጥያቄ](#http_request) ወይም እንደ "መረጃ"
+      ተጨማሪ መረጃዎችን የሚያስተላልፍ [ምላሽ](#http_response) የተጠቃሚው ተመራጭ ቋንቋ ወይም የተላለፈው የውሂብ ርዝመት።
 
+      '
 - slug: http_request
   ref:
-    - http_response
+  - http_response
   en:
-    term: "HTTP request"
-    def: >
-      A message sent from a [client](#client) to a [server](#server) using the
-      [HTTP](#http) [protocol](#protocol) asking for data. A request usually asks for
-      a web page, image, or other data.
+    term: HTTP request
+    def: 'A message sent from a [client](#client) to a [server](#server) using the
+      [HTTP](#http) [protocol](#protocol) asking for data. A request usually asks
+      for a web page, image, or other data.
 
+      '
   am:
     term: የኤችቲቲፒ ጥያቄ
-    def: >
-      በመጠቀም ከ [ደንበኛ](#client) ወደ [አገልጋይ](#server) የተላከ መልእክት
-      [HTTP](#http) [ፕሮቶኮል](#protocol) መረጃን በመጠየቅ ላይ። ጥያቄ ብዙውን ጊዜ ይጠይቃል አንድ ድር ገጽ ፣ ምስል ወይም ሌላ ውሂብ።
+    def: 'በመጠቀም ከ [ደንበኛ](#client) ወደ [አገልጋይ](#server) የተላከ መልእክት [HTTP](#http) [ፕሮቶኮል](#protocol)
+      መረጃን በመጠየቅ ላይ። ጥያቄ ብዙውን ጊዜ ይጠይቃል አንድ ድር ገጽ ፣ ምስል ወይም ሌላ ውሂብ።
 
+      '
 - slug: http_response
   en:
-    term: "HTTP response"
-    def: >
-      A reply sent from a [server](#server) to a [client](#client) using the
-      [HTTP](#http) [protocol](#protocol) in response to a [request](#http_request).
-      The response usually contains a web page, image, or data.
+    term: HTTP response
+    def: 'A reply sent from a [server](#server) to a [client](#client) using the [HTTP](#http)
+      [protocol](#protocol) in response to a [request](#http_request). The response
+      usually contains a web page, image, or data.
 
+      '
   am:
     term: የኤችቲቲፒ ምላሽ
-    def: >
-      በመጠቀም ከ [አገልጋይ](#server) ለ [ደንበኛ](#client) የተላከ መልስ [HTTP](#http) [ፕሮቶኮል](#protocol) ለ [ጥያቄ] ምላሽ ለመስጠት (#http_request)። ምላሹ ብዙውን ጊዜ የድር ገጽን ፣ ምስልን ወይም መረጃን ይ containsል።
+    def: 'በመጠቀም ከ [አገልጋይ](#server) ለ [ደንበኛ](#client) የተላከ መልስ [HTTP](#http) [ፕሮቶኮል](#protocol)
+      ለ [ጥያቄ] ምላሽ ለመስጠት (#http_request)። ምላሹ ብዙውን ጊዜ የድር ገጽን ፣ ምስልን ወይም መረጃን ይ containsል።
 
+      '
+- slug: hypothesis_testing
+  ref:
+  - p_value
+  - null_hypothesis
+  en:
+    term: hypothesis testing
+    def: 'A statistical method for making decisions using data, where a [null hypothesis](#null_hypothesis)
+      is tested against an alternative hypothesis. Results are evaluated using [p-values](#p_value)
+      to determine statistical significance.
+
+      '
 - slug: icon
   en:
-    term: "icon"
-    def: >
-      In computing, an icon is a graphic symbol that is displayed on a computer screen to help a user navigate the computer system.
-  af:
-    term: "ikoon"
-    def: >
-      In rekenaarkunde is 'n ikoon 'n grafiese simbool wat op 'n rekenaarskerm vertoon word om die gebruiker te help om 'n rekenaarstelsel te navigeer.
+    term: icon
+    def: 'In computing, an icon is a graphic symbol that is displayed on a computer
+      screen to help a user navigate the computer system.
 
+      '
+  af:
+    term: ikoon
+    def: 'In rekenaarkunde is ''n ikoon ''n grafiese simbool wat op ''n rekenaarskerm
+      vertoon word om die gebruiker te help om ''n rekenaarstelsel te navigeer.
+
+      '
 - slug: ide
   ref:
-    - repl
+  - repl
   en:
-    term: "Integrated Development Environment"
-    acronym: "IDE"
-    def: >
-      An application that helps programmers develop software. IDEs typically have a
-      built-in editor, a [console](#console) to execute code immediately, and browsers for
-      exploring data structures in memory and files on disk.
+    term: Integrated Development Environment
+    acronym: IDE
+    def: 'An application that helps programmers develop software. IDEs typically have
+      a built-in editor, a [console](#console) to execute code immediately, and browsers
+      for exploring data structures in memory and files on disk.
+
+      '
   es:
-    term: "Entorno de Desarrollo Integrado"
-    acronym: "EDI"
-    def: >
-      Una aplicación que ayuda a programadores a desarrollar software. Los EDI
-      usualmente tiene un editor incorporado, una consola que ejecuta el código
-      inmediatamente y navegadores para explorar estructuras de datos en la memoria y
-      archivos en el disco.
+    term: Entorno de Desarrollo Integrado
+    acronym: EDI
+    def: 'Una aplicación que ayuda a programadores a desarrollar software. Los EDI
+      usualmente tiene un editor incorporado, una consola que ejecuta el código inmediatamente
+      y navegadores para explorar estructuras de datos en la memoria y archivos en
+      el disco.
+
+      '
   am:
     term: የተቀናጀ የልማት አካባቢ
-    def: >
-      ፕሮግራም ሰሪዎች ሶፍትዌሮችን እንዲያዳብሩ የሚያግዝ መተግበሪያ ፡፡ መታወቂያዎች በተለምዶ ሀ አብሮገነብ አርታዒ ፣ ኮዱን ወዲያውኑ ለማስፈፀም [ኮንሶል](#console) እና አሳሾች ለ በማስታወሻ ውስጥ እና በዲስክ ላይ ባሉ ፋይሎች ውስጥ የውሂብ መዋቅሮችን ማሰስ ፡፡
+    def: 'ፕሮግራም ሰሪዎች ሶፍትዌሮችን እንዲያዳብሩ የሚያግዝ መተግበሪያ ፡፡ መታወቂያዎች በተለምዶ ሀ አብሮገነብ አርታዒ ፣
+      ኮዱን ወዲያውኑ ለማስፈፀም [ኮንሶል](#console) እና አሳሾች ለ በማስታወሻ ውስጥ እና በዲስክ ላይ ባሉ ፋይሎች ውስጥ
+      የውሂብ መዋቅሮችን ማሰስ ፡፡
 
+      '
 - slug: imap
   ref:
-    - pop
-    - smtp
+  - pop
+  - smtp
   en:
-    term: "Internet Message Access Protocol"
-    acronym: "IMAP"
-    def: >
-      A standard internet protocol used by email clients to retrieve messages from an email server.
-      Messages are left on the server so that they can be accessed from multiple email clients.
+    term: Internet Message Access Protocol
+    acronym: IMAP
+    def: 'A standard internet protocol used by email clients to retrieve messages
+      from an email server. Messages are left on the server so that they can be accessed
+      from multiple email clients.
 
+      '
 - slug: immutable_type
   en:
-    term: "immutable type"
-    def: >
-      Immutable is when no change is possible over time.
-      An object of this type can not be changed and its state can not be modified after it is created.
+    term: immutable type
+    def: 'Immutable is when no change is possible over time. An object of this type
+      can not be changed and its state can not be modified after it is created.
 
+      '
 - slug: import
   en:
-    term: "import"
-    def: >
-      To bring things from a [module](#module) into a program for use. In most
-      languages a program can only import things that the module explicitly
-      [exports](#export).
+    term: import
+    def: 'To bring things from a [module](#module) into a program for use. In most
+      languages a program can only import things that the module explicitly [exports](#export).
+
+      '
   es:
-    term: "importar"
-    def: >
-      traer cosas de un [módulo](#module) para incorporarlas al programa. En la mayoría
-      de las lenguajes, un programa solo puede importar cosas que el módulo
+    term: importar
+    def: 'traer cosas de un [módulo](#module) para incorporarlas al programa. En la
+      mayoría de las lenguajes, un programa solo puede importar cosas que el módulo
       [exporta](#export) explícitamente.
 
+      '
   am:
     term: ማስመጣት
-    def: >
-      ነገሮችን ከ [ሞጁል](#module) ወደ አገልግሎት ፕሮግራም ለማምጣት ፡፡ በአብዛኛዎቹ ቋንቋዎች አንድ ፕሮግራም ሞጁሉን በግልፅ የሚያስገቡ ነገሮችን ብቻ ማስመጣት ይችላል [ወደ ውጭ መላክ](#export)
+    def: 'ነገሮችን ከ [ሞጁል](#module) ወደ አገልግሎት ፕሮግራም ለማምጣት ፡፡ በአብዛኛዎቹ ቋንቋዎች አንድ ፕሮግራም
+      ሞጁሉን በግልፅ የሚያስገቡ ነገሮችን ብቻ ማስመጣት ይችላል [ወደ ውጭ መላክ](#export)
 
+      '
 - slug: impostor_syndrome
   en:
-    term: "impostor syndrome"
-    def: >
-      The [false](#false) belief that one's successes are a result of accident or luck rather
-      than ability.
+    term: impostor syndrome
+    def: 'The [false](#false) belief that one''s successes are a result of accident
+      or luck rather than ability.
 
+      '
   st:
-    term: "lefu la kaketso"
-    def: >
-      Tumelo e fosahetseng ya hore katleho ya emong e tlile ka lehlohonolo eseng hobane a tshwanetswe kapa a sebeditse ka thata.
+    term: lefu la kaketso
+    def: 'Tumelo e fosahetseng ya hore katleho ya emong e tlile ka lehlohonolo eseng
+      hobane a tshwanetswe kapa a sebeditse ka thata.
 
+      '
   am:
     term: አስመሳይ ሲንድሮም
-    def: >
-      የአንድ ሰው ስኬቶች በአጋጣሚ ወይም በእድል ዕድል የተገኙ ናቸው የሚለው [ውሸት](#false) እምነት ከችሎታ ይልቅ ፡፡
+    def: 'የአንድ ሰው ስኬቶች በአጋጣሚ ወይም በእድል ዕድል የተገኙ ናቸው የሚለው [ውሸት](#false) እምነት ከችሎታ ይልቅ
+      ፡፡
 
+      '
 - slug: in_place_operator
   en:
-    term: "in-place operator"
-    def: >
-      An operator that updates one of its operands. For example, the expression
-      `x += 2` uses the in-place operator `+=` to add 2 to the current value of `x` and
-      assign the result back to `x`.
+    term: in-place operator
+    def: 'An operator that updates one of its operands. For example, the expression
+      `x += 2` uses the in-place operator `+=` to add 2 to the current value of `x`
+      and assign the result back to `x`.
 
+      '
   am:
     term: በቦታው ውስጥ ኦፕሬተር
-    def: >
-      አንዱን ኦፕሬዶቹን የሚያሻሽል ኦፕሬተር ፡፡ ለምሳሌ አገላለፁ "x + = 2` አሁን ባለው የ" x` እና "እሴት ላይ 2 ለመጨመር የቦታውን ኦፕሬተር ይጠቀማል ውጤቱን ወደ ‹x` ይመልሱ ፡፡
+    def: 'አንዱን ኦፕሬዶቹን የሚያሻሽል ኦፕሬተር ፡፡ ለምሳሌ አገላለፁ "x + = 2` አሁን ባለው የ" x` እና "እሴት ላይ
+      2 ለመጨመር የቦታውን ኦፕሬተር ይጠቀማል ውጤቱን ወደ ‹x` ይመልሱ ፡፡
 
+      '
 - slug: increment
   ref:
-    - decrement
+  - decrement
   en:
-    term: "increment"
-    def: >
-      A unary operation that increases the value of a variable, usually by 1.
+    term: increment
+    def: 'A unary operation that increases the value of a variable, usually by 1.
+
+      '
   es:
-    term: "incrementar"
-    def: >
-      Una operación unaria que aumenta el valor de una variable, generalmente en 1.
+    term: incrementar
+    def: 'Una operación unaria que aumenta el valor de una variable, generalmente
+      en 1.
+
+      '
   pt:
-    term: "incrementar"
-    def: >
-      Uma operação unária que aumenta o valor de uma variável, geralmente em um.
+    term: incrementar
+    def: 'Uma operação unária que aumenta o valor de uma variável, geralmente em um.
 
-
+      '
 - slug: independent_variable
   en:
-    term: "independent variable"
-    def: >
-      The factor that you purposely change or control in order to see what effect
+    term: independent variable
+    def: 'The factor that you purposely change or control in order to see what effect
       it has on the [dependent variable](#dependent_variable).
+
+      '
   es:
-    term: "variable independiente"
-    def: >
-      El factor que cambias o controlas intencionadamente para ver qué efecto tiene
-      sobre la [variable dependiente](#dependent_variable).
+    term: variable independiente
+    def: 'El factor que cambias o controlas intencionadamente para ver qué efecto
+      tiene sobre la [variable dependiente](#dependent_variable).
+
+      '
   de:
-    term: "Unabhängige Variable"
-    def: >
-      Der Faktor, der vorsätzlich verändert oder kontrolliert wird, um die Auswirkung
+    term: Unabhängige Variable
+    def: 'Der Faktor, der vorsätzlich verändert oder kontrolliert wird, um die Auswirkung
       auf die [abhängige Variable](#dependent_variable) zu beobachten.
 
+      '
 - slug: index
   en:
-    term: "index"
-    def: >
-      Each of the elements of an array. Indexes represent the position by numerical representation.
+    term: index
+    def: 'Each of the elements of an array. Indexes represent the position by numerical
+      representation.
 
+      '
 - slug: infinite_loop
   ref:
-    - loop
+  - loop
   en:
-    term: "infinite loop"
-    def: >
-      A loop where the exit condition is never met, so the loop continues to repeat itself.
-      Often a programming error.
+    term: infinite loop
+    def: 'A loop where the exit condition is never met, so the loop continues to repeat
+      itself. Often a programming error.
 
-
+      '
 - slug: inner_join
   ref:
-    - anti_join
-    - cross_join
-    - full_join
-    - inner_join
-    - left_join
-    - right_join
-    - self_join
+  - anti_join
+  - cross_join
+  - full_join
+  - inner_join
+  - left_join
+  - right_join
+  - self_join
   en:
-    term: "inner join"
-    def: >
-      A [join](#join) that returns the combination of rows from two tables, A and B, whose
-      [keys](#key) exist in both tables.
+    term: inner join
+    def: 'A [join](#join) that returns the combination of rows from two tables, A
+      and B, whose [keys](#key) exist in both tables.
 
+      '
   am:
     term: ውስጣዊ መቀላቀል
-    def: >
-      የሁለት ጠረጴዛዎች ሀ እና ቢ የማን ረድፎችን ጥምር የሚመልስ [መቀላቀል](#join) [ቁልፎች](#key) በሁለቱም ጠረጴዛዎች ውስጥ አሉ ፡፡
+    def: 'የሁለት ጠረጴዛዎች ሀ እና ቢ የማን ረድፎችን ጥምር የሚመልስ [መቀላቀል](#join) [ቁልፎች](#key) በሁለቱም
+      ጠረጴዛዎች ውስጥ አሉ ፡፡
 
+      '
   af:
-    term: "binnekoppeling"
-    def: >
-      'n [Koppeling](#join) wat die kombinasie van rye uit twee tabelle A en B oplewer, waarvan die [ID-sleutels](#key) in beide tabelle bestaan.
+    term: binnekoppeling
+    def: '''n [Koppeling](#join) wat die kombinasie van rye uit twee tabelle A en
+      B oplewer, waarvan die [ID-sleutels](#key) in beide tabelle bestaan.
 
-
+      '
 - slug: instance
   en:
-    term: "instance"
-    def: >
-      An [object](#object) of a particular [class](#class).
+    term: instance
+    def: 'An [object](#object) of a particular [class](#class).
 
+      '
   am:
     term: አብነት
-    def: >
-      የአንድ የተወሰነ (ክፍል)(#object) (#ነገር)(#class)።
+    def: 'የአንድ የተወሰነ (ክፍል)(#object) (#ነገር)(#class)።
 
+      '
 - slug: integration_test
   ref:
-    - unit_test
+  - unit_test
   en:
-    term: "integration test"
-    def: >
-      A test that checks whether the parts of a system work properly when put together.
+    term: integration test
+    def: 'A test that checks whether the parts of a system work properly when put
+      together.
 
+      '
   am:
     term: የውህደት ሙከራ
-    def: >
-      አንድ ሲስተም ሲስተም አካላት በትክክል መሥራታቸውን የሚያረጋግጥ ሙከራ።
+    def: 'አንድ ሲስተም ሲስተም አካላት በትክክል መሥራታቸውን የሚያረጋግጥ ሙከራ።
 
+      '
 - slug: interface
   en:
-    term: "interface"
-    def: >
-      A ubiquitously used phrase in computing that describes a point of contact. This could be
-      a user interface (e.g. [graphical user interface](#gui) or [command line](#cli)), the
-      interface of an [object](#object) with the rest of the [code](#source_code) or how a
-      program can interact with web services through an [API](#api).
+    term: interface
+    def: 'A ubiquitously used phrase in computing that describes a point of contact.
+      This could be a user interface (e.g. [graphical user interface](#gui) or [command
+      line](#cli)), the interface of an [object](#object) with the rest of the [code](#source_code)
+      or how a program can interact with web services through an [API](#api).
 
+      '
 - slug: interpreted_language
   en:
-    term: "interpreted language"
-    def: >
-      A high-level language that is not executed directly by the computer, but instead
-      is run by an [interpreter](#interpreter) that translates program instructions
+    term: interpreted language
+    def: 'A high-level language that is not executed directly by the computer, but
+      instead is run by an [interpreter](#interpreter) that translates program instructions
       into machine commands on the fly.
 
+      '
   am:
     term: የተተረጎመ ቋንቋ
-    def: >
-      በቀጥታ በኮምፒተር የማይተገበር የከፍተኛ ደረጃ ቋንቋ ፣ ግን ይልቁንስ የሚከናወነው የፕሮግራም መመሪያዎችን በሚተረጎም በ [አስተርጓሚ](#interpreter) ነው በመብረር ላይ ወደ ማሽን ትዕዛዞች ፡፡
-  uk:
-    term: "інтерпретована мова"
-    def: >
-      Мова високого рівня, інструкції якої не виконуються напряму комп'ютером. Натомість її інструкції 
-      перекладаються у машинний код безпосередньо під час виконання за допомогою [інтерпретатора](#interpreter).
+    def: 'በቀጥታ በኮምፒተር የማይተገበር የከፍተኛ ደረጃ ቋንቋ ፣ ግን ይልቁንስ የሚከናወነው የፕሮግራም መመሪያዎችን በሚተረጎም
+      በ [አስተርጓሚ](#interpreter) ነው በመብረር ላይ ወደ ማሽን ትዕዛዞች ፡፡
 
+      '
+  uk:
+    term: інтерпретована мова
+    def: 'Мова високого рівня, інструкції якої не виконуються напряму комп''ютером.
+      Натомість її інструкції  перекладаються у машинний код безпосередньо під час
+      виконання за допомогою [інтерпретатора](#interpreter).
+
+      '
 - slug: interpreter
   en:
-    term: "interpreter"
-    def: >
-      A program whose job it is to run programs written in a high-level [interpreted language](#interpreted_language).
-      Interpreters can run interactively, but may also execute commands saved in a file.
+    term: interpreter
+    def: 'A program whose job it is to run programs written in a high-level [interpreted
+      language](#interpreted_language). Interpreters can run interactively, but may
+      also execute commands saved in a file.
 
+      '
   am:
     term: አስተርጓሚ
-    def: >
-      በከፍተኛ ደረጃ [በተተረጎመ ቋንቋ] የተጻፉ ፕሮግራሞችን ማካሄድ ሥራው የሆነ ፕሮግራም (#interpreted_language) ፡፡ አስተርጓሚዎች በይነተገናኝ ሆነው ሊሰሩ ይችላሉ ፣ ግን ደግሞ በአንድ ፋይል ውስጥ የተቀመጡ ትዕዛዞችን ያስፈጽሙ ይሆናል።
-  uk:
-    term: "інтерпретатор"
-    def: >
-      Програма, завдання якої полягає у виконанні програм, написаних високорівневою
-      [інтерпретованою мовою](#interpreted_language). Інтерпретатори можуть 
-      працювати інтерактивно або виконувати команди, збережені у файлі.
+    def: 'በከፍተኛ ደረጃ [በተተረጎመ ቋንቋ] የተጻፉ ፕሮግራሞችን ማካሄድ ሥራው የሆነ ፕሮግራም (#interpreted_language)
+      ፡፡ አስተርጓሚዎች በይነተገናኝ ሆነው ሊሰሩ ይችላሉ ፣ ግን ደግሞ በአንድ ፋይል ውስጥ የተቀመጡ ትዕዛዞችን ያስፈጽሙ ይሆናል።
 
+      '
+  uk:
+    term: інтерпретатор
+    def: 'Програма, завдання якої полягає у виконанні програм, написаних високорівневою
+      [інтерпретованою мовою](#interpreted_language). Інтерпретатори можуть  працювати
+      інтерактивно або виконувати команди, збережені у файлі.
+
+      '
 - slug: invariant
   en:
-    term: "invariant"
-    def: >
-      Something that must be [true](#true) at all times inside of a program or during the
-      [lifecycle](#lifecycle) of an [object](#object). Invariants are often expressed using [assertions](#assertion).
-      If an invariant expression is not true, this is indicative of a problem, and
-      may result in failure or early termination of the program.
+    term: invariant
+    def: 'Something that must be [true](#true) at all times inside of a program or
+      during the [lifecycle](#lifecycle) of an [object](#object). Invariants are often
+      expressed using [assertions](#assertion). If an invariant expression is not
+      true, this is indicative of a problem, and may result in failure or early termination
+      of the program.
 
+      '
 - slug: ipython
   ref:
-    - jupyter
+  - jupyter
   en:
-    term: "IPython"
-    def: >
-      Short for "Interactive [Python](#python)", it is a [console](#console) designed
-      to assist interactive and exploratory programming with features such
-      as coloured text, [tab-completion](#tab_completion),
-      [filesystem](#filesystem) navigation, quick access to
-      [documentation](#docstring) and [shell commands](#shell).
+    term: IPython
+    def: 'Short for "Interactive [Python](#python)", it is a [console](#console) designed
+      to assist interactive and exploratory programming with features such as coloured
+      text, [tab-completion](#tab_completion), [filesystem](#filesystem) navigation,
+      quick access to [documentation](#docstring) and [shell commands](#shell).
 
+      '
   am:
     term: የማይለዋወጥ
-    def: >
-      የሆነ ነገር በማንኛውም ጊዜ በፕሮግራሙ ውስጥ ወይም በ ውስጥ (እውነት)(#true) መሆን አለበት [የሕይወት ዑደት](#lifecycle) የአንድ [ነገር](#object)። ተለዋዋጭነት ብዙውን ጊዜ የሚገለጸው [ማረጋገጫዎችን](#assertion) በመጠቀም ነው  ፡፡
+    def: 'የሆነ ነገር በማንኛውም ጊዜ በፕሮግራሙ ውስጥ ወይም በ ውስጥ (እውነት)(#true) መሆን አለበት [የሕይወት ዑደት](#lifecycle)
+      የአንድ [ነገር](#object)። ተለዋዋጭነት ብዙውን ጊዜ የሚገለጸው [ማረጋገጫዎችን](#assertion) በመጠቀም ነው  ፡፡
 
-
+      '
 - slug: iso_date_format
   en:
-    term: "ISO date format"
-    def: >
-      An international for formatting dates. While the full standard is complex, the
-      most common form is `YYYY-MM-DD`, i.e., a four-digit year, a two-digit month,
+    term: ISO date format
+    def: 'An international for formatting dates. While the full standard is complex,
+      the most common form is `YYYY-MM-DD`, i.e., a four-digit year, a two-digit month,
       and a two-digit day, separated by hyphens.
 
+      '
   am:
     term: የ ISO ቀን ቅርጸት
-    def: >
-      ቀኖችን ለመቅረጽ ዓለም አቀፍ ፡፡ ሙሉው መስፈርት ውስብስብ ቢሆንም ፣ እ.ኤ.አ. በጣም የተለመደው ቅጽ "YYYY-MM-DD" ነው ፣ ማለትም ፣ ባለ አራት አሃዝ ዓመት ፣ ባለ ሁለት አሃዝ ወር ፣ እና በሰልፍ ተለያይተው ባለ ሁለት አሃዝ ቀን።
+    def: 'ቀኖችን ለመቅረጽ ዓለም አቀፍ ፡፡ ሙሉው መስፈርት ውስብስብ ቢሆንም ፣ እ.ኤ.አ. በጣም የተለመደው ቅጽ "YYYY-MM-DD"
+      ነው ፣ ማለትም ፣ ባለ አራት አሃዝ ዓመት ፣ ባለ ሁለት አሃዝ ወር ፣ እና በሰልፍ ተለያይተው ባለ ሁለት አሃዝ ቀን።
 
+      '
 - slug: issue
   en:
-    term: "issue"
-    def: >
-      A [bug report](#bug_report), feature request, or other to-do item associated
+    term: issue
+    def: 'A [bug report](#bug_report), feature request, or other to-do item associated
       with a project. Also called a [ticket](#ticket).
 
+      '
   am:
     term: ርዕሰ ጉዳይ
-    def: >
-      አንድ [የሳንካ ዘገባ](#bug_report) ፣ የባህሪይ ጥያቄ ወይም ሌላ የሚደረገው ንጥል ከአንድ ፕሮጀክት ጋር. እንዲሁም [ትኬት] ተብሎ ይጠራል (#ticket)።
+    def: 'አንድ [የሳንካ ዘገባ](#bug_report) ፣ የባህሪይ ጥያቄ ወይም ሌላ የሚደረገው ንጥል ከአንድ ፕሮጀክት ጋር.
+      እንዲሁም [ትኬት] ተብሎ ይጠራል (#ticket)።
 
+      '
 - slug: issue_label
   en:
-    term: "label (an issue)"
-    def: >
-      A short textual tag associated with an [issue](#issue) to categorize it. Common
-      labels include [`bug`](#bug) and `feature request`.
+    term: label (an issue)
+    def: 'A short textual tag associated with an [issue](#issue) to categorize it.
+      Common labels include [`bug`](#bug) and `feature request`.
 
+      '
   am:
     term: መለያ (ጉዳይ)
-    def: >
-      ለመመደብ ከ [ጉዳይ](#issue) ጋር የተቆራኘ አጭር የጽሑፍ መለያ። የተለመደ መለያዎች ["bug`]" (#bug) እና "feature request` ን ያካትታሉ።
+    def: 'ለመመደብ ከ [ጉዳይ](#issue) ጋር የተቆራኘ አጭር የጽሑፍ መለያ። የተለመደ መለያዎች ["bug`]" (#bug)
+      እና "feature request` ን ያካትታሉ።
 
+      '
 - slug: issue_tracking_system
   en:
-    term: "issue tracking system"
-    def: >
-      Similar to a [bug tracking system](#bug_tracker) in that it tracks [issues](#issue)
-      made to a [repository](#repository), usually in the form of [feature
-      requests](#feature_request), [bug reports](#bug_report), or some other to-do item.
+    term: issue tracking system
+    def: 'Similar to a [bug tracking system](#bug_tracker) in that it tracks [issues](#issue)
+      made to a [repository](#repository), usually in the form of [feature requests](#feature_request),
+      [bug reports](#bug_report), or some other to-do item.
 
+      '
   am:
     term: ጉዳይ የመከታተያ ስርዓት
-    def: >
-      ከ "ሳንካ መከታተያ ስርዓት](#bug_tracker) ጋር ተመሳሳይ ነው [" ጉዳዮች "](#issue) ወደ [ማከማቻ](#repository) የተሰራ ፣ ብዙውን ጊዜ በ [ባህሪይ] ጥያቄዎች](#feature_request) ፣ [የሳንካ ሪፖርቶች](#bug_report) ፣ ወይም ሌላ የሚደረጉ ነገሮች።
+    def: 'ከ "ሳንካ መከታተያ ስርዓት](#bug_tracker) ጋር ተመሳሳይ ነው [" ጉዳዮች "](#issue) ወደ [ማከማቻ](#repository)
+      የተሰራ ፣ ብዙውን ጊዜ በ [ባህሪይ] ጥያቄዎች](#feature_request) ፣ [የሳንካ ሪፖርቶች](#bug_report)
+      ፣ ወይም ሌላ የሚደረጉ ነገሮች።
 
+      '
 - slug: iterator_pattern
   ref:
-    - visitor_pattern
+  - visitor_pattern
   en:
-    term: "Iterator pattern"
-    def: >
-      A [design pattern](#design_pattern) in which a temporary [object](#object) or [generator
-      function](#generator_function) produces each value from a collection in turn for
-      processing. This pattern hides the differences between different kinds of data
-      structures so that everything can be processed using loops.
+    term: Iterator pattern
+    def: 'A [design pattern](#design_pattern) in which a temporary [object](#object)
+      or [generator function](#generator_function) produces each value from a collection
+      in turn for processing. This pattern hides the differences between different
+      kinds of data structures so that everything can be processed using loops.
 
+      '
   am:
     term: የኢተራክተር ንድፍ
-    def: >
-      ጊዜያዊ [ነገር](#design_pattern) ወይም [ጄኔሬተር) ውስጥ አንድ [ንድፍ ንድፍ](#object) ተግባር](#generator_function) እያንዳንዱን እሴት ከአንድ ክምችት በተራ ያወጣል ማቀነባበር. ይህ ንድፍ በተለያዩ የውሂብ ዓይነቶች መካከል ያለውን ልዩነት ይደብቃል ሁሉም ነገሮች ቀለበቶችን በመጠቀም እንዲከናወኑ መዋቅሮች ፡፡
+    def: 'ጊዜያዊ [ነገር](#design_pattern) ወይም [ጄኔሬተር) ውስጥ አንድ [ንድፍ ንድፍ](#object) ተግባር](#generator_function)
+      እያንዳንዱን እሴት ከአንድ ክምችት በተራ ያወጣል ማቀነባበር. ይህ ንድፍ በተለያዩ የውሂብ ዓይነቶች መካከል ያለውን ልዩነት
+      ይደብቃል ሁሉም ነገሮች ቀለበቶችን በመጠቀም እንዲከናወኑ መዋቅሮች ፡፡
 
+      '
 - slug: java
   en:
-    term: "Java"
-    def: >
-      Java is a high-level, cross-platform, object-oriented and general-purpose programming language. Programs written in Java will run on any platform that supports
-      the Java software platform without having to be recompiled. This feature gave rise to the slogan "Write Once Run Anywhere". Java syntax is similar to that of C and C++.
+    term: Java
+    def: 'Java is a high-level, cross-platform, object-oriented and general-purpose
+      programming language. Programs written in Java will run on any platform that
+      supports the Java software platform without having to be recompiled. This feature
+      gave rise to the slogan "Write Once Run Anywhere". Java syntax is similar to
+      that of C and C++.
 
+      '
   af:
-    term: "Java"
-    def: >
-      Java is 'n hoëvlak, kruisplatvorm, objekgeoriënteerde en algemene-gebruik programmeertaal. Programme wat in Java geskryf is sal op enige platform werk,
-      wat die Java sagtewareplatform implementeer, sonder dat dit hersaamgestel hoef te word. Die kenmerk het gelei tot die slagspreuk "skryf eenkeer, hardloop enige
+    term: Java
+    def: 'Java is ''n hoëvlak, kruisplatvorm, objekgeoriënteerde en algemene-gebruik
+      programmeertaal. Programme wat in Java geskryf is sal op enige platform werk,
+      wat die Java sagtewareplatform implementeer, sonder dat dit hersaamgestel hoef
+      te word. Die kenmerk het gelei tot die slagspreuk "skryf eenkeer, hardloop enige
       plek". Die Javasintaks is soortgelyk aan die van C en C++.
 
+      '
 - slug: join
   ref:
-    - anti_join
-    - cross_join
-    - full_join
-    - inner_join
-    - left_join
-    - right_join
-    - self_join
+  - anti_join
+  - cross_join
+  - full_join
+  - inner_join
+  - left_join
+  - right_join
+  - self_join
   en:
-    term: "join"
-    def: >
-      One of several operations that combine values from two [tables](#table).
+    term: join
+    def: 'One of several operations that combine values from two [tables](#table).
 
+      '
   am:
     term: ተቀላቀል
-    def: >
-      እሴቶችን ከሁለት [ሰንጠረ ](#table)ች] ከሚያጣምሩ በርካታ ክዋኔዎች አንዱ ፡፡
+    def: 'እሴቶችን ከሁለት [ሰንጠረ ](#table)ች] ከሚያጣምሩ በርካታ ክዋኔዎች አንዱ ፡፡
 
+      '
   af:
-    term: "koppeling"
-    def: >
-      Een van verskeie bewerkings wat waardes uit twee [tabelle](#table) aan mekaar koppel.
+    term: koppeling
+    def: 'Een van verskeie bewerkings wat waardes uit twee [tabelle](#table) aan mekaar
+      koppel.
 
-
+      '
 - slug: json
   ref:
-    - yaml
+  - yaml
   en:
-    term: "JavaScript Object Notation"
-    acronym: "JSON"
-    def: >
-      A way to represent data by combining basic values like numbers and character
-      strings in [lists](#list) and [key/value](#dictionary) structures. The acronym stands for "JavaScript
-      Object Notation"; unlike better-defined standards like [XML](#xml), it is
-      unencumbered by a syntax for comments or ways to define a [schema](#schema).
+    term: JavaScript Object Notation
+    acronym: JSON
+    def: 'A way to represent data by combining basic values like numbers and character
+      strings in [lists](#list) and [key/value](#dictionary) structures. The acronym
+      stands for "JavaScript Object Notation"; unlike better-defined standards like
+      [XML](#xml), it is unencumbered by a syntax for comments or ways to define a
+      [schema](#schema).
+
+      '
   fr:
-    term: "JavaScript Object Notation"
-    acronym: "JSON"
-    def: >
-      Un façon de représenter des données textuelles ou numériques en combinant des
-      ensembles de paires nom/valeurs et des listes de valeurs. L'acronyme signifie
-      "JavaScript Object Notation", car il s'agit d'un format dérivé de la notation
-      des objets du langage JavaScript. Contrairement à d'autres standards plus
-      structurés comme [XML](#xml), JSON ne permet pas de définir un [schéma](#schema)
-      de données, ni ne supporte l'ajout de commentaires.
+    term: JavaScript Object Notation
+    acronym: JSON
+    def: 'Un façon de représenter des données textuelles ou numériques en combinant
+      des ensembles de paires nom/valeurs et des listes de valeurs. L''acronyme signifie
+      "JavaScript Object Notation", car il s''agit d''un format dérivé de la notation
+      des objets du langage JavaScript. Contrairement à d''autres standards plus structurés
+      comme [XML](#xml), JSON ne permet pas de définir un [schéma](#schema) de données,
+      ni ne supporte l''ajout de commentaires.
+
+      '
   uk:
-    term: "нотація об'єктів JavaScript"
-    acronym: "JSON"
-    def: >
-      Спосіб представлення даних шляхом комбінування значень у базових форматах (числа, рядки символів тощо) у структурах даних, таких як [списки](#list) та [словники](#dictionary). JSON
-      розшифровується як "JavaScript Object Notation"; на відміну від більш чітко визначених 
-      стандартів, наприклад, [XML](#xml), цей формат не ускладнений синтаксисом для коментарів 
-      або методами визначення [схеми](#schema).
+    term: нотація об'єктів JavaScript
+    acronym: JSON
+    def: 'Спосіб представлення даних шляхом комбінування значень у базових форматах
+      (числа, рядки символів тощо) у структурах даних, таких як [списки](#list) та
+      [словники](#dictionary). JSON розшифровується як "JavaScript Object Notation";
+      на відміну від більш чітко визначених  стандартів, наприклад, [XML](#xml), цей
+      формат не ускладнений синтаксисом для коментарів  або методами визначення [схеми](#schema).
+
+      '
   am:
     term: የጃቫስክሪፕት ነገር ማስታወሻ
-    def: >
-      እንደ ቁጥሮች እና ባህሪ ያሉ መሰረታዊ እሴቶችን በማጣመር መረጃን ለመወከል የሚያስችል መንገድ [ዝርዝሮች](#list) እና [ቁልፍ / እሴት](#dictionary) መዋቅሮች ውስጥ ሕብረቁምፊዎች። አህጽሮተ ቃል "ጃቫስክሪፕት" ማለት ነው የነገር ማሳወቂያ"፤ እንደ [XML](#xml) ካሉ በተሻለ ከተገለጹ ደረጃዎች በተለየ ፣ እሱ ነው ለአስተያየቶች አገባብ (ሰነድ) ያልተመዘገበ ወይም [መርሃግብር](#schema) ን የሚገልጹ መንገዶች ።
+    def: 'እንደ ቁጥሮች እና ባህሪ ያሉ መሰረታዊ እሴቶችን በማጣመር መረጃን ለመወከል የሚያስችል መንገድ [ዝርዝሮች](#list)
+      እና [ቁልፍ / እሴት](#dictionary) መዋቅሮች ውስጥ ሕብረቁምፊዎች። አህጽሮተ ቃል "ጃቫስክሪፕት" ማለት ነው የነገር
+      ማሳወቂያ"፤ እንደ [XML](#xml) ካሉ በተሻለ ከተገለጹ ደረጃዎች በተለየ ፣ እሱ ነው ለአስተያየቶች አገባብ (ሰነድ)
+      ያልተመዘገበ ወይም [መርሃግብር](#schema) ን የሚገልጹ መንገዶች ።
 
+      '
 - slug: jupyter
   ref:
-    - jupyter_notebook
+  - jupyter_notebook
   en:
-    term: "Jupyter"
-    def: >
-      Project Jupyter is a non-profit, open-source project that was born out of the IPython Project
-      in 2014 as [IPython](#ipython) evolved to support interactive [data science](#data_science) and scientific
-      computing in many different programming languages.
+    term: Jupyter
+    def: 'Project Jupyter is a non-profit, open-source project that was born out of
+      the IPython Project in 2014 as [IPython](#ipython) evolved to support interactive
+      [data science](#data_science) and scientific computing in many different programming
+      languages.
 
+      '
   am:
     term: ጁፒተር
-    def: >
-      ፕሮጀክት ጁፒተር ከ ‹አይፒን› ፕሮጀክት የተወለደው ለትርፍ ያልተቋቋመ ፣ ክፍት ምንጭ ፕሮጀክት ነው እ.ኤ.አ በ 2014 አይፒንቶን በይነተገናኝ [ዳታ ሳይንስ](#data_science) እና ሳይንሳዊን ለመደገፍ እንደተሻሻለ በበርካታ የተለያዩ የፕሮግራም ቋንቋዎች ማስላት።
+    def: 'ፕሮጀክት ጁፒተር ከ ‹አይፒን› ፕሮጀክት የተወለደው ለትርፍ ያልተቋቋመ ፣ ክፍት ምንጭ ፕሮጀክት ነው እ.ኤ.አ በ
+      2014 አይፒንቶን በይነተገናኝ [ዳታ ሳይንስ](#data_science) እና ሳይንሳዊን ለመደገፍ እንደተሻሻለ በበርካታ የተለያዩ
+      የፕሮግራም ቋንቋዎች ማስላት።
 
-- slug: jupyterlab
-  ref:
-    - jupyter
-    - jupyter_notebook
-  en:
-    term: "JupyterLab"
-    def: >
-      A next-generation interface to [Jupyter Notebooks](#jupyter_notebook).
-      JupyterLab is open-source, web-based and has a multiple-document interface which supports working with multiple notebooks and [Markdown](#markdown) files in a single browser tab.
-      JupyterLab also supports opening terminal/[console](#console) windows in the browser.
-
+      '
 - slug: jupyter_notebook
   ref:
-    - jupyter
+  - jupyter
   en:
-    term: "Jupyter Notebook"
-    def: >
-      An open-source, web-based [computational notebook](#computational_notebook)
-      that allows the user to write and share live code, equations, visualisations, and narrative text.
+    term: Jupyter Notebook
+    def: 'An open-source, web-based [computational notebook](#computational_notebook)
+      that allows the user to write and share live code, equations, visualisations,
+      and narrative text.
 
+      '
   am:
     term: የጁፒተር ማስታወሻ ደብተር
-    def: >
-      የጁፒተር ማስታወሻ ደብተር ክፍት ምንጭ ፣ በድር ላይ የተመሠረተ [የሂሳብ ማስታወሻ ደብተር](#computational_notebook) ነው  ተጠቃሚው የቀጥታ ኮድ ፣ እኩልታዎች ፣ ምስላዊ እይታዎች እና የትረካ ጽሑፍን እንዲጽፍ እና እንዲያጋራ ያስችለዋል።
+    def: 'የጁፒተር ማስታወሻ ደብተር ክፍት ምንጭ ፣ በድር ላይ የተመሠረተ [የሂሳብ ማስታወሻ ደብተር](#computational_notebook)
+      ነው  ተጠቃሚው የቀጥታ ኮድ ፣ እኩልታዎች ፣ ምስላዊ እይታዎች እና የትረካ ጽሑፍን እንዲጽፍ እና እንዲያጋራ ያስችለዋል።
 
+      '
+- slug: jupyterlab
+  ref:
+  - jupyter
+  - jupyter_notebook
+  en:
+    term: JupyterLab
+    def: 'A next-generation interface to [Jupyter Notebooks](#jupyter_notebook). JupyterLab
+      is open-source, web-based and has a multiple-document interface which supports
+      working with multiple notebooks and [Markdown](#markdown) files in a single
+      browser tab. JupyterLab also supports opening terminal/[console](#console) windows
+      in the browser.
+
+      '
 - slug: k_means_clustering
   ref:
-    - clustering
+  - clustering
   en:
-    term: "k-means clustering"
-    def: >
-      An [unsupervised_learning](#unsupervised_learning) algorithm that forms *k*
-      groups by repeatedly calculating the [centroid](#centroid) of the current groups
-      and then reallocating data points to the nearest centroid until the centroids no
-      longer move.
+    term: k-means clustering
+    def: 'An [unsupervised_learning](#unsupervised_learning) algorithm that forms
+      *k* groups by repeatedly calculating the [centroid](#centroid) of the current
+      groups and then reallocating data points to the nearest centroid until the centroids
+      no longer move.
 
+      '
   am:
     term: k-ማለት ማሰባሰብ ማለት
-    def: >
-      * ቁጥጥር * ያልተደረገበት ትምህርት (#unsupervised_learning) ስልተ ቀመር * k * የወቅቱን ቡድኖች [ሴንትሮይድ](#centroid) በተደጋጋሚ በማስላት ቡድኖች እና ከዚያ የመረጃ ማከፋፈያ ቦታ ወደ ሴንትሮይድ ቁ ረዘም ያለ እንቅስቃሴ።
+    def: '* ቁጥጥር * ያልተደረገበት ትምህርት (#unsupervised_learning) ስልተ ቀመር * k * የወቅቱን ቡድኖች
+      [ሴንትሮይድ](#centroid) በተደጋጋሚ በማስላት ቡድኖች እና ከዚያ የመረጃ ማከፋፈያ ቦታ ወደ ሴንትሮይድ ቁ ረዘም ያለ
+      እንቅስቃሴ።
 
+      '
 - slug: k_nearest_neighbors
   en:
-    term: "k-nearest neighbors"
-    def: >
-      A [classification](#classification) algorithm that classifies data points based
-      on their similarity to their *k* nearest neighbours.
+    term: k-nearest neighbors
+    def: 'A [classification](#classification) algorithm that classifies data points
+      based on their similarity to their *k* nearest neighbours.
 
+      '
   am:
     term: k-ቅርብ ጎረቤቶች
-    def: >
-      የመረጃ ነጥቦችን በመለየት የሚመደብ አንድ [ምደባ](#classification) ስልተ ቀመር ከቅርብ ጎረቤቶቻቸው *k* ተመሳሳይነት ላይ።
+    def: 'የመረጃ ነጥቦችን በመለየት የሚመደብ አንድ [ምደባ](#classification) ስልተ ቀመር ከቅርብ ጎረቤቶቻቸው *k*
+      ተመሳሳይነት ላይ።
 
+      '
 - slug: kebab_case
   ref:
-    - camel_case
-    - pothole_case
+  - camel_case
+  - pothole_case
   en:
-    term: "kebab case"
-    def: >
-      A naming convention in which the parts of a name are separated with dashes, as
-      in `first-second-third`.
+    term: kebab case
+    def: 'A naming convention in which the parts of a name are separated with dashes,
+      as in `first-second-third`.
 
+      '
   am:
     term: kebab ጉዳይ
-    def: >
-      የስም ክፍሎች ከዳሽን ጋር የሚለዩበት የስያሜ ስብሰባ ፣ እንደ በ ‹የመጀመሪያ-ሁለተኛ-ሦስተኛ› ውስጥ ፡፡
+    def: 'የስም ክፍሎች ከዳሽን ጋር የሚለዩበት የስያሜ ስብሰባ ፣ እንደ በ ‹የመጀመሪያ-ሁለተኛ-ሦስተኛ› ውስጥ ፡፡
 
+      '
 - slug: key
   en:
-    term: "key"
-    def: >
-      1. A [field](#field) or combination of fields whose value(s) uniquely identify a
-      [record](#record) within a [table](#table) or dataset. Keys are often used to
-      select specific records and in [joins](#join).
-      
+    term: key
+    def: '1. A [field](#field) or combination of fields whose value(s) uniquely identify
+      a [record](#record) within a [table](#table) or dataset. Keys are often used
+      to select specific records and in [joins](#join).
+
       2. Part of a key/value pair, used as a unique identifier in a data structure
       such as a [dictionary](#dictionary).
 
+      '
   am:
     term: ቁልፍ
-    def: >
-      1. ዋጋቸው (ቸው) በልዩ ሁኔታ የሚለዩት አንድ [መስክ](#field) ወይም የመስኮች ጥምረት ሀ መዝገብ በአንድ [ጠረጴዛ](#record) ወይም የውሂብ ስብስብ ውስጥ። ቁልፎች ብዙውን ጊዜ ጥቅም ላይ ይውላሉ የተወሰኑ መዝገቦችን ይምረጡ እና በ [ተቀላቀል](#table)። በመረጃ አወቃቀር ውስጥ እንደ ልዩ መለያ ጥቅም ላይ የዋለ የቁልፍ / እሴት ጥንድ ክፍል እንደ [መዝገበ-ቃላት](#dictionary)።
+    def: '1. ዋጋቸው (ቸው) በልዩ ሁኔታ የሚለዩት አንድ [መስክ](#field) ወይም የመስኮች ጥምረት ሀ መዝገብ በአንድ
+      [ጠረጴዛ](#record) ወይም የውሂብ ስብስብ ውስጥ። ቁልፎች ብዙውን ጊዜ ጥቅም ላይ ይውላሉ የተወሰኑ መዝገቦችን ይምረጡ
+      እና በ [ተቀላቀል](#table)። በመረጃ አወቃቀር ውስጥ እንደ ልዩ መለያ ጥቅም ላይ የዋለ የቁልፍ / እሴት ጥንድ ክፍል
+      እንደ [መዝገበ-ቃላት](#dictionary)።
 
+      '
   af:
-    term: "ID-sleutel"
-    def: >
-      1. 'n [Veld](#field) of kombinasie van velde waarvan die waarde(s) 'n [rekord](#record) in 'n [tabel](#table) of datastel uniek identifiseer. ID-sleutels word dikwels gebruik om spesifieke rekords te kies, asook in [koppelings](#join).
-      2. 'n Deel van 'n ID-sleutel/waardepaar, wat as 'n unieke identifiseerder gebruik word in 'n datastruktuur soos 'n [woordeboek](#dictionary).
+    term: ID-sleutel
+    def: '1. ''n [Veld](#field) of kombinasie van velde waarvan die waarde(s) ''n
+      [rekord](#record) in ''n [tabel](#table) of datastel uniek identifiseer. ID-sleutels
+      word dikwels gebruik om spesifieke rekords te kies, asook in [koppelings](#join).
+      2. ''n Deel van ''n ID-sleutel/waardepaar, wat as ''n unieke identifiseerder
+      gebruik word in ''n datastruktuur soos ''n [woordeboek](#dictionary).
 
-
+      '
 - slug: keyword_argument
   ref:
-    - named_argument
-    - variable_arguments
+  - named_argument
+  - variable_arguments
   en:
-    term: "keyword arguments"
-    def: >
-      Extra (often optional) arguments given to a function as key/value pairs.
+    term: keyword arguments
+    def: 'Extra (often optional) arguments given to a function as key/value pairs.
 
+      '
   am:
     term: ቁልፍ ቃል ክርክሮች
-    def: >
-      እንደ ቁልፍ / እሴት ጥንዶች ለአንድ ተግባር የተሰጡ ተጨማሪ (ብዙውን ጊዜ አማራጭ) ክርክሮች።
+    def: 'እንደ ቁልፍ / እሴት ጥንዶች ለአንድ ተግባር የተሰጡ ተጨማሪ (ብዙውን ጊዜ አማራጭ) ክርክሮች።
 
+      '
+- slug: knn
+  ref:
+  - machine_learning
+  - classification
+  - supervised_learning
+  en:
+    term: K-Nearest Neighbours
+    acronym: KNN
+    def: 'A [supervised learning](#supervised_learning) algorithm that classifies
+      data points based on the classes of the K nearest data points in the training
+      set. It can be used for both [classification](#classification) and regression
+      tasks.
+
+      '
+- slug: label
+  ref:
+  - supervised_learning
+  - classification
+  en:
+    term: label
+    def: 'In [supervised learning](#supervised_learning), the target value or category
+      that a model is trying to predict. Labels are the "answers" provided in [training
+      data](#training_data).
+
+      '
 - slug: latent_variable
   en:
-    term: "latent variable"
-    def: >
-      A variable that is not observed directly but instead is inferred from the states
-      or values of other variables.
+    term: latent variable
+    def: 'A variable that is not observed directly but instead is inferred from the
+      states or values of other variables.
 
+      '
   am:
     term: ድብቅ ተለዋዋጭ
-    def: >
-      በቀጥታ የማይታይ ተለዋዋጭ በምትኩ ከክልሎች የመነጨ ነው ወይም የሌሎች ተለዋዋጮች እሴቶች።
+    def: 'በቀጥታ የማይታይ ተለዋዋጭ በምትኩ ከክልሎች የመነጨ ነው ወይም የሌሎች ተለዋዋጮች እሴቶች።
 
+      '
 - slug: latex
   en:
-    term: "LaTeX"
-    def: >
-      A typesetting system for document preparation that uses a specialized [markup language](#markup_language) to define a document structure
-      (e.g., headings), stylise text, insert mathematical equations, and manage citations and cross-references. LaTeX is widely
-      used in academia, in particular for scientific papers and theses in mathematics, physics, engineering, and computer science.
-  de:
-    term: "LaTeX"
-    def: >
-      Ein Textsatzsystem zum Erstellen von Dokumenten, das eine spezielle [Auszeichnungssprache](#markup_language)
-      nutzt, um die Dokument-Struktur (z.B. Titel) zu definieren, Text zu setzen, mathematische Gleichungen einzufügen
-      und Zitate und Querverweise zu verwalten. LaTeX  wird häufig in der akademischen Welt verwendet, besonders für
-      wissenschaftliche Veröffentlichungen und Abschlussarbeiten in Mathematik, Physik, Maschinenbau und Informatik.
-  fr:
-    term: "LaTeX"
-    def: >
-      Un système de composition de documents qui utilise un [langage de balisage](#markup_language) pour définir la structure et mise en page
-      d'un document, composer des formules mathématiques et gérer citations et références. Le format LaTeX est très utilisé
-      dans les domaines scientifiques et techniques pour la production d'articles et de mémoires.
+    term: LaTeX
+    def: 'A typesetting system for document preparation that uses a specialized [markup
+      language](#markup_language) to define a document structure (e.g., headings),
+      stylise text, insert mathematical equations, and manage citations and cross-references.
+      LaTeX is widely used in academia, in particular for scientific papers and theses
+      in mathematics, physics, engineering, and computer science.
 
+      '
+  de:
+    term: LaTeX
+    def: 'Ein Textsatzsystem zum Erstellen von Dokumenten, das eine spezielle [Auszeichnungssprache](#markup_language)
+      nutzt, um die Dokument-Struktur (z.B. Titel) zu definieren, Text zu setzen,
+      mathematische Gleichungen einzufügen und Zitate und Querverweise zu verwalten.
+      LaTeX  wird häufig in der akademischen Welt verwendet, besonders für wissenschaftliche
+      Veröffentlichungen und Abschlussarbeiten in Mathematik, Physik, Maschinenbau
+      und Informatik.
+
+      '
+  fr:
+    term: LaTeX
+    def: 'Un système de composition de documents qui utilise un [langage de balisage](#markup_language)
+      pour définir la structure et mise en page d''un document, composer des formules
+      mathématiques et gérer citations et références. Le format LaTeX est très utilisé
+      dans les domaines scientifiques et techniques pour la production d''articles
+      et de mémoires.
+
+      '
   am:
     term: 'ላቲኤክስ '
-    def: >
-      የሰነድ አወቃቀርን ለመግለፅ ልዩ [ምልክት ማድረጊያ ቋንቋ](#markup_language) የሚጠቀም የሰነድ ዝግጅት አጻጻፍ ስርዓት (ለምሳሌ አርእስቶች) ፣ የቅጥ ጽሑፍ ፣ የሂሳብ እኩልታዎችን ያስገቡ ፣ እና ጥቅሶችን እና ማጣቀሻዎችን ያቀናብሩ። ላቲኤክስ በሰፊው ነው በአካዳሚክ ውስጥ በተለይም ለሳይንሳዊ ወረቀቶች እና በሂሳብ ፣ በፊዚክስ ፣ በኢንጂነሪንግ እና በኮምፒተር ሳይንስ ፡፡
+    def: 'የሰነድ አወቃቀርን ለመግለፅ ልዩ [ምልክት ማድረጊያ ቋንቋ](#markup_language) የሚጠቀም የሰነድ ዝግጅት
+      አጻጻፍ ስርዓት (ለምሳሌ አርእስቶች) ፣ የቅጥ ጽሑፍ ፣ የሂሳብ እኩልታዎችን ያስገቡ ፣ እና ጥቅሶችን እና ማጣቀሻዎችን
+      ያቀናብሩ። ላቲኤክስ በሰፊው ነው በአካዳሚክ ውስጥ በተለይም ለሳይንሳዊ ወረቀቶች እና በሂሳብ ፣ በፊዚክስ ፣ በኢንጂነሪንግ
+      እና በኮምፒተር ሳይንስ ፡፡
 
+      '
 - slug: lazy_evaluation
   ref:
-    - short_circuit_test
+  - short_circuit_test
   en:
-    term: "lazy evaluation"
-    def: >
-      Delaying evaluation of an expression until the value is actually needed
-      or, in the case of a conditional expression, only evaluating as much of
-      the expression as is necessary. For instance, the second half of `A and B`
-      will only be evaluated if A is [truthy](#truthy).
+    term: lazy evaluation
+    def: 'Delaying evaluation of an expression until the value is actually needed
+      or, in the case of a conditional expression, only evaluating as much of the
+      expression as is necessary. For instance, the second half of `A and B` will
+      only be evaluated if A is [truthy](#truthy).
 
+      '
   am:
     term: ሰነፍ ግምገማ
-    def: >
-      እሴቱ በትክክል እስኪፈለግ ድረስ የአንድን አገላለጽ ግምገማ መዘግየት ወይም በሁኔታዊ አገላለጽ ሁኔታ ፣ የሚገመገሙትን ያህል ብቻ አገላለጹ እንደአስፈላጊነቱ ፡፡ ለምሳሌ ፣ የ "ሀ እና ቢ" ሁለተኛ አጋማሽ የሚገመገመው ሀ [እውነት](#truthy) ከሆነ  ከሆነ ብቻ ነው።
+    def: 'እሴቱ በትክክል እስኪፈለግ ድረስ የአንድን አገላለጽ ግምገማ መዘግየት ወይም በሁኔታዊ አገላለጽ ሁኔታ ፣ የሚገመገሙትን
+      ያህል ብቻ አገላለጹ እንደአስፈላጊነቱ ፡፡ ለምሳሌ ፣ የ "ሀ እና ቢ" ሁለተኛ አጋማሽ የሚገመገመው ሀ [እውነት](#truthy)
+      ከሆነ  ከሆነ ብቻ ነው።
 
+      '
+- slug: learning_rate
+  ref:
+  - deep_learning
+  - backpropagation
+  - perceptron
+  - neural_network
+  - machine_learning
+  en:
+    term: learning rate (deep learning)
+    def: 'In [artificial neural networks](#neural_network), the learning rate is a
+      hyper-parameter that determines the pace at which the network adjusts the weights
+      to move down the loss gradient. A large learning rate can speed up training,
+      but the network might overshoot and miss the minimum. A small learning rate
+      will overshoot less, but will be slower. It can also get more easily stuck in
+      local minima.
+
+      '
+  es:
+    term: tasa de aprendizaje (aprendizaje profundo)
+    def: 'En [redes neuronales artificiales](#neural_network), la tasa de aprendizaje
+      es un hiperparámetro que  determina el ritmo al que la red ajusta los pesos
+      para poder dar cada vez una mejor aproximación.  Una tasa de aprendizaje grande
+      puede acelerar el entrenamiento, pero la red se puede sobrepasar y  perder el
+      mínimo global. Una tasa de aprendizaje pequeña se sobrepasará menos, pero será
+      más lenta.  También puede caer más fácilmente en mínimos locales.
+
+      '
 - slug: left_join
   ref:
-    - anti_join
-    - cross_join
-    - full_join
-    - inner_join
-    - left_join
-    - right_join
-    - self_join
+  - anti_join
+  - cross_join
+  - full_join
+  - inner_join
+  - left_join
+  - right_join
+  - self_join
   en:
-    term: "left join"
-    def: >
-      A [join](#join) that combines data from two tables, A and B, where [keys](#key) in table
-      A match keys in table B, [fields](#field) are concatenated. Where a key in table
-      A does *not* match a key in table B, columns from table B are filled with
-      [null](#null), [NA](#na), or some other [missing value](#missing_value). Keys from table B
-      that do not match keys from table A are excluded for the result.
+    term: left join
+    def: 'A [join](#join) that combines data from two tables, A and B, where [keys](#key)
+      in table A match keys in table B, [fields](#field) are concatenated. Where a
+      key in table A does *not* match a key in table B, columns from table B are filled
+      with [null](#null), [NA](#na), or some other [missing value](#missing_value).
+      Keys from table B that do not match keys from table A are excluded for the result.
 
+      '
   am:
     term: ግራ መቀላቀል
-    def: >
-      በሰንጠረ in ውስጥ [ቁልፎች](#join) ከሁለት ጠረጴዛዎች ፣ ሀ እና ቢ መረጃዎችን የሚያጣምር አንድ [ተቀላቀል](#key) በሠንጠረዥ B ፣ [ሜዳዎች](#field) ውስጥ የግጥሚያ ቁልፎች ተጣምረዋል። በጠረጴዛ ውስጥ ቁልፍ የት አለ በሠንጠረዥ B ውስጥ አንድ ቁልፍን * አይመሳሰልም * ፣ ከሠንጠረዥ B አምዶች ይሞላሉ [null](#null) ፣ [NA](#na) ፣ ወይም ሌላ (የጠፋ ዋጋ) (missing_value)። ከጠረጴዛ B ውስጥ ቁልፎች ከሠንጠረዥ ሀ ቁልፎችን የማይዛመዱ ለውጤቱ ተገልለዋል ፡፡
+    def: 'በሰንጠረ in ውስጥ [ቁልፎች](#join) ከሁለት ጠረጴዛዎች ፣ ሀ እና ቢ መረጃዎችን የሚያጣምር አንድ [ተቀላቀል](#key)
+      በሠንጠረዥ B ፣ [ሜዳዎች](#field) ውስጥ የግጥሚያ ቁልፎች ተጣምረዋል። በጠረጴዛ ውስጥ ቁልፍ የት አለ በሠንጠረዥ
+      B ውስጥ አንድ ቁልፍን * አይመሳሰልም * ፣ ከሠንጠረዥ B አምዶች ይሞላሉ [null](#null) ፣ [NA](#na) ፣
+      ወይም ሌላ (የጠፋ ዋጋ) (missing_value)። ከጠረጴዛ B ውስጥ ቁልፎች ከሠንጠረዥ ሀ ቁልፎችን የማይዛመዱ ለውጤቱ
+      ተገልለዋል ፡፡
 
+      '
 - slug: lexical_scoping
   en:
-    term: "lexical scoping"
-    def: >
-      To look up the value associated with a name according to the textual structure
+    term: lexical scoping
+    def: 'To look up the value associated with a name according to the textual structure
       of a program. Most programming languages use lexical scoping instead of [dynamic
       scoping](#dynamic_scoping) because the latter is less predictable.
 
+      '
   am:
     term: የቃላት ክልል
-    def: >
-      በጽሑፍ አሠራሩ መሠረት ከስም ጋር የተጎዳኘውን እሴት ለመፈለግ የፕሮግራም አብዛኛዎቹ የፕሮግራም ቋንቋዎች ከ [ተለዋዋጭ] ይልቅ የቃላት አጻጻፍ አጠቃቀምን ይጠቀማሉ የኋላ ኋላ ብዙም ሊተነብይ የማይችል ስለሆነ [dynamic scoping](#dynamic_scoping))።
+    def: 'በጽሑፍ አሠራሩ መሠረት ከስም ጋር የተጎዳኘውን እሴት ለመፈለግ የፕሮግራም አብዛኛዎቹ የፕሮግራም ቋንቋዎች ከ [ተለዋዋጭ]
+      ይልቅ የቃላት አጻጻፍ አጠቃቀምን ይጠቀማሉ የኋላ ኋላ ብዙም ሊተነብይ የማይችል ስለሆነ [dynamic scoping](#dynamic_scoping))።
 
+      '
 - slug: library
   en:
-    term: "library"
-    def: >
-      A reusable software [package](#package), also often called a [module](#module).
-  es:
-    term: "biblioteca"
-    def: >
-      un paquete de software reutilizable, también  se llama un [módulo](#module).
-  fr:
-    term: "bibliothèque"
-    def: >
-      Un [paquet](#package) logiciel réutilisable, parfois aussi appelé [module](#module).
-  pt:
-    term: "biblioteca"
-    def: >
-      Um pacote de programas reutilizáveis, também frequentemente referido como um [módulo](#module).
+    term: library
+    def: 'A reusable software [package](#package), also often called a [module](#module).
 
+      '
+  es:
+    term: biblioteca
+    def: 'un paquete de software reutilizable, también  se llama un [módulo](#module).
+
+      '
+  fr:
+    term: bibliothèque
+    def: 'Un [paquet](#package) logiciel réutilisable, parfois aussi appelé [module](#module).
+
+      '
+  pt:
+    term: biblioteca
+    def: 'Um pacote de programas reutilizáveis, também frequentemente referido como
+      um [módulo](#module).
+
+      '
   am:
     term: ቤተ መጻሕፍት
-    def: >
-      እንደገና ጥቅም ላይ ሊውል የሚችል ሶፍትዌር [ጥቅል](#package) ፣ ብዙውን ጊዜ [ሞዱል](#module) ተብሎም ይጠራል።
-  de:
-    term: "Bibliothek"
-    def: >
-      Ein wiederverwendbares [Softwarepaket](#package), oft auch [Modul] (#module) genannt.
+    def: 'እንደገና ጥቅም ላይ ሊውል የሚችል ሶፍትዌር [ጥቅል](#package) ፣ ብዙውን ጊዜ [ሞዱል](#module) ተብሎም
+      ይጠራል።
 
+      '
+  de:
+    term: Bibliothek
+    def: 'Ein wiederverwendbares [Softwarepaket](#package), oft auch [Modul] (#module)
+      genannt.
+
+      '
 - slug: license
   en:
-    term: "license"
-    def: >
-      A legal document describing how something can be used, and by whom.
+    term: license
+    def: 'A legal document describing how something can be used, and by whom.
 
+      '
   am:
     term: ፈቃድ
-    def: >
-      አንድ ነገር እንዴት ጥቅም ላይ እንደሚውል የሚገልጽ የሕግ ሰነድ ፣ እና በማን ፡፡
+    def: 'አንድ ነገር እንዴት ጥቅም ላይ እንደሚውል የሚገልጽ የሕግ ሰነድ ፣ እና በማን ፡፡
 
+      '
   de:
-    term: "Lizenz"
-    def: >
-      Ein Rechtsdokument, das beschreibt, wie etwas verwendet werden kann und von wem.
-  uk:
-    term: "ліцензія"
-    def: >
-      Офіційний дозвіл, який регламентує умови використання об'єкта
-      інтелектуальної власності третіми особами.
+    term: Lizenz
+    def: 'Ein Rechtsdokument, das beschreibt, wie etwas verwendet werden kann und
+      von wem.
 
+      '
+  uk:
+    term: ліцензія
+    def: 'Офіційний дозвіл, який регламентує умови використання об''єкта інтелектуальної
+      власності третіми особами.
+
+      '
 - slug: lifecycle
   en:
-    term: "lifecycle"
-    def: >
-      The steps that something is allowed or required to go through. The lifecycle of
-      an [object](#object) runs from its [construction](#constructor) through the
+    term: lifecycle
+    def: 'The steps that something is allowed or required to go through. The lifecycle
+      of an [object](#object) runs from its [construction](#constructor) through the
       operations it can or must perform before it is destroyed; the lifecycle of an
       [issue](#issue) may be: "created", "assigned", "in progress", "ready for review",
       and "completed".
 
+      '
   am:
     term: የህይወት ኡደት
     def: አንድ ነገር እንዲያልፍ የተፈቀደለት ወይም የሚፈለግበት ደረጃዎች። የሕይወት ዑደት አንድ (ነገር) (#object) ከሱ
       (ከገንቢው)(#constructor) በኩል በ ከመጥፋቱ በፊት ሊያከናውን ወይም ሊያከናውንባቸው የሚገቡ ክዋኔዎች; የአንድ
       [ጉዳይ](#issue) ምናልባት "ተፈጠረ" ፣ "ተመድቧል" ፣ "በሂደት ላይ" ፣ "ለግምገማ ዝግጁ" ፣ እና"ተጠናቅቋል".
-
 - slug: lift
   en:
-    term: "lift"
-    def: >
-      How well a model predicts or [classifies](#classification) things, measured as the ratio of the
-      response in the segment identified to the response in the population as a whole.
-      A lift of 1 means the model does no better than chance; higher lift means the
-      model is doing better.
+    term: lift
+    def: 'How well a model predicts or [classifies](#classification) things, measured
+      as the ratio of the response in the segment identified to the response in the
+      population as a whole. A lift of 1 means the model does no better than chance;
+      higher lift means the model is doing better.
 
+      '
   am:
     term: ማንሳት
-    def: >
-      እንደ አንድ ጥምርታ የሚለካ አንድ ሞዴል ምን ያህል ነገሮችን በደንብ ይተነብያል ወይም [ይመድባል](#classification) በአጠቃላይ በሕዝቡ ውስጥ ለሚገኘው ምላሽ በተጠቀሰው ክፍል ውስጥ ምላሽ ፡፡ የ 1 ማንሳት ማለት ሞዴሉ ከአጋጣሚ የተሻለ አይሆንም ማለት ነው ፡፡ ከፍተኛ ማንሻ ማለት ሞዴል በተሻለ ሁኔታ እየሰራ ነው ፡፡
+    def: 'እንደ አንድ ጥምርታ የሚለካ አንድ ሞዴል ምን ያህል ነገሮችን በደንብ ይተነብያል ወይም [ይመድባል](#classification)
+      በአጠቃላይ በሕዝቡ ውስጥ ለሚገኘው ምላሽ በተጠቀሰው ክፍል ውስጥ ምላሽ ፡፡ የ 1 ማንሳት ማለት ሞዴሉ ከአጋጣሚ የተሻለ
+      አይሆንም ማለት ነው ፡፡ ከፍተኛ ማንሻ ማለት ሞዴል በተሻለ ሁኔታ እየሰራ ነው ፡፡
 
+      '
 - slug: line_comment
   en:
-    term: "line comment"
-    def: >
-      A [comment](#comment) in a program that spans part of a single line, as opposed
-      to a [block comment](#block_comment) that may span multiple lines.
+    term: line comment
+    def: 'A [comment](#comment) in a program that spans part of a single line, as
+      opposed to a [block comment](#block_comment) that may span multiple lines.
+
+      '
   pt:
-    term: "comentário de linha"
-    def: >
-      Um [comentário](#comment) em um programa que abrange parte de uma única linha,
-      em contraste a um [bloco de comentário](#block_comment) que pode abranger
+    term: comentário de linha
+    def: 'Um [comentário](#comment) em um programa que abrange parte de uma única
+      linha, em contraste a um [bloco de comentário](#block_comment) que pode abranger
       mútiplas linhas.
 
+      '
   am:
     term: የመስመር አስተያየት
-    def: >
-      በተቃራኒው የአንድ መስመርን ክፍል በሚዘረጋ ፕሮግራም ውስጥ አንድ [አስተያየት](#comment) ወደ [አግድ አስተያየት](#block_comment) ብዙ መስመሮችን ሊዘረጋ ይችላል።
+    def: 'በተቃራኒው የአንድ መስመርን ክፍል በሚዘረጋ ፕሮግራም ውስጥ አንድ [አስተያየት](#comment) ወደ [አግድ አስተያየት](#block_comment)
+      ብዙ መስመሮችን ሊዘረጋ ይችላል።
 
+      '
 - slug: linear_regression
   ref:
-    - logistic_regression
+  - logistic_regression
   en:
-    term: "linear regression"
-    def: >
-      A method for finding the best straight-line fit between two datasets, typically
-      by minimizing the squares of the distances between the points and a regression line.
-  af:
-    term: "lineêre regressie"
-    def: >
-      'n Metode om die beste pas tussen twee datastelle te vind deur die vierkante van die
-      afstande tussen die punte en 'n regressielyn te minimaliseer.
+    term: linear regression
+    def: 'A method for finding the best straight-line fit between two datasets, typically
+      by minimizing the squares of the distances between the points and a regression
+      line.
 
+      '
+  af:
+    term: lineêre regressie
+    def: '''n Metode om die beste pas tussen twee datastelle te vind deur die vierkante
+      van die afstande tussen die punte en ''n regressielyn te minimaliseer.
+
+      '
   am:
     term: መስመራዊ ማፈግፈግ
-    def: >
-      በተለይም በሁለት የውሂብ ስብስቦች መካከል በጣም ጥሩውን ቀጥተኛ መስመር የሚመጥን ዘዴ በነጥቦች እና በድጋሜ መስመር መካከል ያሉ ርቀቶችን ካሬዎች በመቀነስ ፡፡
+    def: 'በተለይም በሁለት የውሂብ ስብስቦች መካከል በጣም ጥሩውን ቀጥተኛ መስመር የሚመጥን ዘዴ በነጥቦች እና በድጋሜ መስመር
+      መካከል ያሉ ርቀቶችን ካሬዎች በመቀነስ ፡፡
 
+      '
+- slug: linked_list
+  ref:
+  - node
+  - data_structure
+  en:
+    term: linked list
+    def: 'A data structure consisting of a sequence of [nodes](#node), where each
+      node contains data and a reference (link) to the next node in the sequence.
+      Unlike [arrays](#array), linked lists don''t require contiguous memory.
+
+      '
 - slug: linter
   en:
-    term: "linter"
-    def: >
-      A program that checks for common problems in software, such as violations of
-      indentation rules or variable naming conventions. The name comes from the first
-      tool of its kind, called `lint`.
+    term: linter
+    def: 'A program that checks for common problems in software, such as violations
+      of indentation rules or variable naming conventions. The name comes from the
+      first tool of its kind, called `lint`.
 
+      '
   am:
     term: ተልባ
-    def: >
-      እንደ ጥሰቶች ያሉ በሶፍትዌሮች ውስጥ የተለመዱ ችግሮችን የሚያጣራ ፕሮግራም የመግቢያ ደንቦች ወይም ተለዋዋጭ የስም ስምምነቶች። ስሙ የመጣው ከመጀመሪያው ነው የዚህ ዓይነት መሣሪያ ፣ "lint"።
+    def: 'እንደ ጥሰቶች ያሉ በሶፍትዌሮች ውስጥ የተለመዱ ችግሮችን የሚያጣራ ፕሮግራም የመግቢያ ደንቦች ወይም ተለዋዋጭ የስም
+      ስምምነቶች። ስሙ የመጣው ከመጀመሪያው ነው የዚህ ዓይነት መሣሪያ ፣ "lint"።
 
+      '
 - slug: lisp
   en:
-    term: "Lisp"
-    def: >
-      A family of programming languages that represent programs and data as nested
+    term: Lisp
+    def: 'A family of programming languages that represent programs and data as nested
       lists. Many other programming languages have borrowed ideas from Lisp.
 
+      '
   am:
     term: ሊፕስ
-    def: >
-      እንደ ጎጆ ፕሮግራሞችን እና መረጃዎችን የሚወክሉ የፕሮግራም ቋንቋዎች ቤተሰብ ዝርዝሮች. ሌሎች ብዙ የፕሮግራም ቋንቋዎች ሀሳቦችን ከሊስፕ ተውሰዋል ፡፡
+    def: 'እንደ ጎጆ ፕሮግራሞችን እና መረጃዎችን የሚወክሉ የፕሮግራም ቋንቋዎች ቤተሰብ ዝርዝሮች. ሌሎች ብዙ የፕሮግራም ቋንቋዎች
+      ሀሳቦችን ከሊስፕ ተውሰዋል ፡፡
 
+      '
 - slug: list
   en:
-    term: "list"
-    def: >
-      A [vector](#vector) that can contain values of many different ([heterogeneous](#heterogeneous)) types.
+    term: list
+    def: 'A [vector](#vector) that can contain values of many different ([heterogeneous](#heterogeneous))
+      types.
 
+      '
   am:
     term: ዝርዝር
-    def: >
-      የብዙ የተለያዩ ([የተለያዩ)(#vector) እሴቶችን ሊይዝ የሚችል አንድ ([heterogeneous](#heterogeneous))።
+    def: 'የብዙ የተለያዩ ([የተለያዩ)(#vector) እሴቶችን ሊይዝ የሚችል አንድ ([heterogeneous](#heterogeneous))።
 
+      '
 - slug: list_comprehension
   en:
-    term: "list comprehension"
-    def: >
-      In [Python](#python), an expression that creates a new list in place. For
+    term: list comprehension
+    def: 'In [Python](#python), an expression that creates a new list in place. For
       example, `[2*x for x in values]` creates a new list whose items are the doubles
       of those in `values`.
 
+      '
   am:
     term: የዝርዝር ግንዛቤ
-    def: >
-      በ [Python](#python) ውስጥ በቦታው አዲስ ዝርዝርን የሚፈጥሩ አገላለጾች ፡፡ ለ ለምሳሌ ፣ "[2 * x ለ x በእሴቶች]" ንጥሎቹ ሁለት እጥፍ የሚሆኑበትን አዲስ ዝርዝር ይፈጥራል በ ‹እሴቶች› ውስጥ ካሉ ፡፡
+    def: 'በ [Python](#python) ውስጥ በቦታው አዲስ ዝርዝርን የሚፈጥሩ አገላለጾች ፡፡ ለ ለምሳሌ ፣ "[2 * x
+      ለ x በእሴቶች]" ንጥሎቹ ሁለት እጥፍ የሚሆኑበትን አዲስ ዝርዝር ይፈጥራል በ ‹እሴቶች› ውስጥ ካሉ ፡፡
 
+      '
 - slug: literate_programming
   ref:
-    - computational_notebook
-    - r_markdown
+  - computational_notebook
+  - r_markdown
   en:
-    term: "literate programming"
-    def: >
-      A programming paradigm that mixes prose and code.
+    term: literate programming
+    def: 'A programming paradigm that mixes prose and code.
+
+      '
   fr:
-    term: "programmation lettrée"
-    def: >
-      Une approche de la programmation qui mélange langage naturel (prose) et code.
+    term: programmation lettrée
+    def: 'Une approche de la programmation qui mélange langage naturel (prose) et
+      code.
+
+      '
   de:
-    term: "literarisches Programmieren"
-    def: >
-      Ein Programmierparadigma, dass Dokumentation und Programmkode in einer
-      gemeinsamen Datei handelt.
+    term: literarisches Programmieren
+    def: 'Ein Programmierparadigma, dass Dokumentation und Programmkode in einer gemeinsamen
+      Datei handelt.
+
+      '
   es:
-    term: "programación literaria"
-    def: >
-      Un paradigma de programación que combina código y documentación en un solo
+    term: programación literaria
+    def: 'Un paradigma de programación que combina código y documentación en un solo
       archivo.
 
+      '
   am:
     term: ማንበብና መጻፍ መርሃግብር
-    def: >
-      ጽሑፍ እና ኮድን የሚቀላቀል የፕሮግራም ዘይቤ ፡፡
+    def: 'ጽሑፍ እና ኮድን የሚቀላቀል የፕሮግራም ዘይቤ ፡፡
 
+      '
 - slug: local_installation
   ref:
-    - global_installation
+  - global_installation
   en:
-    term: "local installation"
-    def: >
-      Placing a [package](#package) inside a particular project so that it is only accessible
-      within that project.
-  es:
-    term: "instalación local"
-    def: >
-      El acto de ubicar un paquete en un proyecto en particular para que sólo sea accesible
-      dentro de ese proyecto.
-  fr:
-    term: "installation locale"
-    def: >
-      Mettre un [paquet](#package) à l'intérieur d'un projet particulier, de façon à ce qu'il
-      ne soit accessible que depuis ce projet.
+    term: local installation
+    def: 'Placing a [package](#package) inside a particular project so that it is
+      only accessible within that project.
 
+      '
+  es:
+    term: instalación local
+    def: 'El acto de ubicar un paquete en un proyecto en particular para que sólo
+      sea accesible dentro de ese proyecto.
+
+      '
+  fr:
+    term: installation locale
+    def: 'Mettre un [paquet](#package) à l''intérieur d''un projet particulier, de
+      façon à ce qu''il ne soit accessible que depuis ce projet.
+
+      '
   am:
     term: አካባቢያዊ ጭነት
-    def: >
-      በዚያ ፕሮጀክት ውስጥ ብቻ ተደራሽ እንዲሆን በአንድ የተወሰነ ፕሮጀክት ውስጥ [ጥቅል](#package) በማስቀመጥ ላይ።
+    def: 'በዚያ ፕሮጀክት ውስጥ ብቻ ተደራሽ እንዲሆን በአንድ የተወሰነ ፕሮጀክት ውስጥ [ጥቅል](#package) በማስቀመጥ
+      ላይ።
 
+      '
 - slug: local_variable
   ref:
-    - closure
-    - global_variable
+  - closure
+  - global_variable
   en:
-    term: "local variable"
-    def: >
-      A variable defined inside a function which is only visible within that function.
-  es:
-    term: "variable local"
-    def: >
-      Una variable definida dentro de una función, por lo que solo es visible dentro
-      de ella.
-  fr:
-    term: "variable locale"
-    def: >
-      Une variable définie à l'intérieur d'une fonction, qui n'est visible qu'au sein de
-      cette fonction.
-  ko:
-    term: "지역 변수"
-    def: >
-      특정 함수 내에서 정의되고 그 함수 내에서만 유효한 변수.
+    term: local variable
+    def: 'A variable defined inside a function which is only visible within that function.
 
+      '
+  es:
+    term: variable local
+    def: 'Una variable definida dentro de una función, por lo que solo es visible
+      dentro de ella.
+
+      '
+  fr:
+    term: variable locale
+    def: 'Une variable définie à l''intérieur d''une fonction, qui n''est visible
+      qu''au sein de cette fonction.
+
+      '
+  ko:
+    term: 지역 변수
+    def: '특정 함수 내에서 정의되고 그 함수 내에서만 유효한 변수.
+
+      '
   am:
     term: አካባቢያዊ ተለዋዋጭ
-    def: >
-      በዚያ ተግባር ውስጥ ብቻ በሚታየው ተግባር ውስጥ የተገለፀ ተለዋዋጭ።
+    def: 'በዚያ ተግባር ውስጥ ብቻ በሚታየው ተግባር ውስጥ የተገለፀ ተለዋዋጭ።
 
+      '
 - slug: log
   en:
-    term: "log"
-    def: >
-      A record of a program's execution containing [messages](#log_message) written
+    term: log
+    def: 'A record of a program''s execution containing [messages](#log_message) written
       via a [logging framework](#logging_framework) for later inspection.
 
+      '
   am:
     term: መዝገብ
-    def: >
-      የተፃፈ [መልዕክቶች](#log_message) የያዘ የፕሮግራም አፈፃፀም መዝገብ በኋላ ለማጣራት [የምዝግብ ማስታወሻ ማዕቀፍ](#logging_framework)
+    def: 'የተፃፈ [መልዕክቶች](#log_message) የያዘ የፕሮግራም አፈፃፀም መዝገብ በኋላ ለማጣራት [የምዝግብ ማስታወሻ
+      ማዕቀፍ](#logging_framework)
 
+      '
 - slug: log_message
   en:
-    term: "log message"
-    def: >
-      A single entry in a [log](#log) of a program's execution. Log messages are
-      usually highly structured so that data (such as the time or the severity) can be
-      recovered later.
+    term: log message
+    def: 'A single entry in a [log](#log) of a program''s execution. Log messages
+      are usually highly structured so that data (such as the time or the severity)
+      can be recovered later.
 
+      '
   am:
     term: የምዝግብ ማስታወሻ
-    def: >
-      በፕሮግራሙ አፈፃፀም [መዝገብ](#log) ውስጥ አንድ ነጠላ ግቤት የምዝግብ ማስታወሻ መልዕክቶች ናቸው መረጃ (እንደ ጊዜ ወይም ክብደት ያሉ) በኋላ ላይ መልሶ ማግኘት እንዲችል ብዙውን ጊዜ በጣም የተዋቀረ ነው።
+    def: 'በፕሮግራሙ አፈፃፀም [መዝገብ](#log) ውስጥ አንድ ነጠላ ግቤት የምዝግብ ማስታወሻ መልዕክቶች ናቸው መረጃ (እንደ
+      ጊዜ ወይም ክብደት ያሉ) በኋላ ላይ መልሶ ማግኘት እንዲችል ብዙውን ጊዜ በጣም የተዋቀረ ነው።
 
+      '
 - slug: logging_framework
   en:
-    term: "logging framework"
-    def: >
-      A software [library](#library) that manages internal reporting for programs.
+    term: logging framework
+    def: 'A software [library](#library) that manages internal reporting for programs.
 
+      '
   am:
     term: የምዝግብ ማስታወሻ ማዕቀፍ
-    def: >
-      ለፕሮግራሞች ውስጣዊ ሪፖርትን የሚያስተዳድር ሶፍትዌር [ቤተ-መጽሐፍት](#library) ፡፡
+    def: 'ለፕሮግራሞች ውስጣዊ ሪፖርትን የሚያስተዳድር ሶፍትዌር [ቤተ-መጽሐፍት](#library) ፡፡
 
+      '
 - slug: logging_level
   en:
-    term: "logging level"
-    def: >
-      A setting that controls how much information is generated by a [logging
-      framework](#logging_framework). Typical logging levels include `DEBUG`,
-      `WARNING`, and `ERROR`.
+    term: logging level
+    def: 'A setting that controls how much information is generated by a [logging
+      framework](#logging_framework). Typical logging levels include `DEBUG`, `WARNING`,
+      and `ERROR`.
 
+      '
   am:
     term: የምዝግብ ማስታወሻ ደረጃ
-    def: >
-      በ [ምዝግብ ማስታወሻ] ምን ያህል መረጃ እንደሚመነጭ የሚቆጣጠር ቅንብር ማዕቀፍ](#logging_framework)። የተለመዱ የምዝግብ ማስታወሻዎች ደረጃዎች «DEBUG` ን ያካትታሉ ፣ ማስጠንቀቂያ ፣ እና "ስህተት"።
+    def: 'በ [ምዝግብ ማስታወሻ] ምን ያህል መረጃ እንደሚመነጭ የሚቆጣጠር ቅንብር ማዕቀፍ](#logging_framework)።
+      የተለመዱ የምዝግብ ማስታወሻዎች ደረጃዎች «DEBUG` ን ያካትታሉ ፣ ማስጠንቀቂያ ፣ እና "ስህተት"።
 
+      '
 - slug: logical_indexing
   en:
-    term: "logical indexing"
-    def: >
-      To index a [vector](#vector) or other structure with a vector of [Booleans](#boolean), keeping only the
-      values that correspond to [true](#true) values. Also referred to as [masking](#masking).
+    term: logical indexing
+    def: 'To index a [vector](#vector) or other structure with a vector of [Booleans](#boolean),
+      keeping only the values that correspond to [true](#true) values. Also referred
+      to as [masking](#masking).
 
+      '
   am:
     term: አመክንዮአዊ ማውጫ
-    def: >
-      አንድን [ቬክተር](#vector) ወይም ሌላ መዋቅርን ከ [ቦሌያን](#boolean) ጋር ለማቆጣጠር ፣ የ ከ [እውነተኛ](#true) እሴቶች ጋር የሚዛመዱ እሴቶች። እንደዚሁም [ማስክ](#masking) ተብሎ ይጠራል
+    def: 'አንድን [ቬክተር](#vector) ወይም ሌላ መዋቅርን ከ [ቦሌያን](#boolean) ጋር ለማቆጣጠር ፣ የ ከ [እውነተኛ](#true)
+      እሴቶች ጋር የሚዛመዱ እሴቶች። እንደዚሁም [ማስክ](#masking) ተብሎ ይጠራል
 
+      '
 - slug: logistic_regression
   ref:
-    - linear_regression
+  - linear_regression
   en:
-    term: "logistic regression"
-    def: >
-      A method for fitting a model to some data that uses logistic (S-shaped) curves
-      instead of straight lines.
-  af:
-    term: "logistiese regressie "
-    def: >
-      'n Metode om 'n model aan te pas tot data wat van logistieke (S-vormige) kurwes gebruik
-      maak.
+    term: logistic regression
+    def: 'A method for fitting a model to some data that uses logistic (S-shaped)
+      curves instead of straight lines.
 
+      '
+  af:
+    term: 'logistiese regressie '
+    def: '''n Metode om ''n model aan te pas tot data wat van logistieke (S-vormige)
+      kurwes gebruik maak.
+
+      '
   am:
     term: የሎጂስቲክ ማሽቆልቆል
-    def: >
-      ከቀጥታ መስመሮች ይልቅ የሎጂስቲክስ (ኤስ-ቅርጽ) ኩርባን ከሚጠቀም አንዳንድ መረጃዎች ጋር ሞዴልን ለመግጠም ዘዴ ፡፡
+    def: 'ከቀጥታ መስመሮች ይልቅ የሎጂስቲክስ (ኤስ-ቅርጽ) ኩርባን ከሚጠቀም አንዳንድ መረጃዎች ጋር ሞዴልን ለመግጠም ዘዴ
+      ፡፡
 
+      '
 - slug: long_identifier_git
   ref:
-    - short_identifier_git
+  - short_identifier_git
   en:
-    term: "long identifier (of commit)"
-    def: >
-      See [full identifier](#full_identifier_git).
+    term: long identifier (of commit)
+    def: 'See [full identifier](#full_identifier_git).
 
+      '
   am:
     term: ረጅም መለያ (የቁርጠኝነት)
-    def: >
-      ይመልከቱ [ሙሉ መለያ](#full_identifier_git)።
+    def: 'ይመልከቱ [ሙሉ መለያ](#full_identifier_git)።
 
+      '
 - slug: long_option
   ref:
-    - short_option
+  - short_option
   en:
-    term: "long option"
-    def: >
-      A full-word identifier for a [command-line argument](#command_line_argument).
+    term: long option
+    def: 'A full-word identifier for a [command-line argument](#command_line_argument).
       While most common flags are a single letter preceded by a dash, such as `-v`,
       long options typically use two dashes and a readable name, such as `--verbose`.
 
+      '
   am:
     term: ረጅም አማራጭ
-    def: >
-      ለ [የትእዛዝ መስመር ክርክር](#command_line_argument)። ምንም እንኳን ብዙ የተለመዱ ባንዲራዎች እንደ--V ያሉ እንደ ሰረዝ የቀደመ አንድ ነጠላ ፊደል ናቸው ፣ ረዥም አማራጮች በተለምዶ ሁለት ዳሽዎችን እና የሚነበብ ስም ይጠቀማሉ ፣ ለምሳሌ - - ‹bobose ›፡፡
+    def: 'ለ [የትእዛዝ መስመር ክርክር](#command_line_argument)። ምንም እንኳን ብዙ የተለመዱ ባንዲራዎች እንደ--V
+      ያሉ እንደ ሰረዝ የቀደመ አንድ ነጠላ ፊደል ናቸው ፣ ረዥም አማራጮች በተለምዶ ሁለት ዳሽዎችን እና የሚነበብ ስም ይጠቀማሉ
+      ፣ ለምሳሌ - - ‹bobose ›፡፡
 
+      '
 - slug: loop
   ref:
-    - for_loop
-    - while_loop
-    - infinite_loop
-    - loop_body
+  - for_loop
+  - while_loop
+  - infinite_loop
+  - loop_body
   en:
-    term: "loop"
-    def: >
-      A structure that repeatedly executes a section of code until a specific exit condition is met.
-  es:
-    term: "ciclo"
-    def: >
-      También conocido como bucle. Estructura que ejecuta un bloque de código repetidamente hasta
-      que se cumple una condición de salida o fin.
-  uk:
-    term: "цикл"
-    def: >
-      Структура у програмі, яка повторно виконує фрагмент коду, доки не буде виконана умова виходу.
+    term: loop
+    def: 'A structure that repeatedly executes a section of code until a specific
+      exit condition is met.
 
+      '
+  es:
+    term: ciclo
+    def: 'También conocido como bucle. Estructura que ejecuta un bloque de código
+      repetidamente hasta que se cumple una condición de salida o fin.
+
+      '
+  uk:
+    term: цикл
+    def: 'Структура у програмі, яка повторно виконує фрагмент коду, доки не буде виконана
+      умова виходу.
+
+      '
 - slug: loop_body
   en:
-    term: "loop body"
-    def: >
-      The statement or statements executed by a loop.
+    term: loop body
+    def: 'The statement or statements executed by a loop.
+
+      '
   am:
     term: የሉፍ አካል
-    def: >
-      በሉፕ የተተገበረው መግለጫ ወይም መግለጫዎች።
+    def: 'በሉፕ የተተገበረው መግለጫ ወይም መግለጫዎች።
 
+      '
+- slug: loss_function
+  ref:
+  - machine_learning
+  - neural_network
+  en:
+    term: loss function
+    def: 'A function that measures how well a [machine learning](#machine_learning)
+      model''s predictions match the actual values. The goal of training is to minimize
+      the loss function. Also called a cost function or objective function.
+
+      '
 - slug: lsof
   en:
-    term: "lsof"
-    def: >
-      UNIX command to see the list of open files being used by [processes](#process).
-  es:
-    term: "lsof"
-    def: >
-      Comando en UNIX para ver la lista de archivos abiertos siendo utilizados por [procesos](#process).
+    term: lsof
+    def: 'UNIX command to see the list of open files being used by [processes](#process).
 
+      '
+  es:
+    term: lsof
+    def: 'Comando en UNIX para ver la lista de archivos abiertos siendo utilizados
+      por [procesos](#process).
+
+      '
+- slug: lstm
+  ref:
+  - recurrent_neural_network
+  - neural_network
+  - deep_learning
+  en:
+    term: Long Short-Term Memory
+    acronym: LSTM
+    def: 'A type of [recurrent neural network](#recurrent_neural_network) architecture
+      designed to handle long-term dependencies in sequential data. LSTMs use gates
+      to control information flow, helping to avoid the vanishing gradient problem.
+
+      '
 - slug: machine_learning
   en:
-    term: "machine learning"
-    def: >
-      The study or use of algorithms whose performance improves as they are given more
-      data. Machine learning algorithms often use [training data](#training_data) to
-      build a [model](#model). Their performance is then measured by how well they
+    term: machine learning
+    def: 'The study or use of algorithms whose performance improves as they are given
+      more data. Machine learning algorithms often use [training data](#training_data)
+      to build a [model](#model). Their performance is then measured by how well they
       predict the properties of [test data](#test_data).
 
+      '
   am:
     term: ማሽን መማር
-    def: >
-      የበለጠ ሲሰጣቸው አፈፃፀማቸው የሚሻሻል ስልተ ቀመር ጥናት ወይም አጠቃቀም መረጃ የማሽን መማሪያ ስልተ ቀመሮች ብዙውን ጊዜ [የሥልጠና መረጃ](#training_data) እስከ ይጠቀማሉ አንድ ግንባታ (ሞዴል) (#model)። የእነሱ አፈፃፀም የሚለካው እነሱ በጥሩነታቸው ነው የ [የሙከራ ውሂብ](#test_data) ባህሪያትን ይተነብይ ።
-  uk:
-    term: "машинне навчання"
-    def: >
-      Дослідження або використання алгоритмів, продуктивність яких покращується із 
-      зростанням кількості оброблених даних. Алгоритми машинного навчання часто використовують
-      [навчальні дані](#training_data) для побудови [моделі](#model). Їх ефективність 
-      вимірюється здатністю прогнозувати властивості [тестових даних](#test_data).
+    def: 'የበለጠ ሲሰጣቸው አፈፃፀማቸው የሚሻሻል ስልተ ቀመር ጥናት ወይም አጠቃቀም መረጃ የማሽን መማሪያ ስልተ ቀመሮች ብዙውን
+      ጊዜ [የሥልጠና መረጃ](#training_data) እስከ ይጠቀማሉ አንድ ግንባታ (ሞዴል) (#model)። የእነሱ አፈፃፀም
+      የሚለካው እነሱ በጥሩነታቸው ነው የ [የሙከራ ውሂብ](#test_data) ባህሪያትን ይተነብይ ።
 
+      '
+  uk:
+    term: машинне навчання
+    def: 'Дослідження або використання алгоритмів, продуктивність яких покращується
+      із  зростанням кількості оброблених даних. Алгоритми машинного навчання часто
+      використовують [навчальні дані](#training_data) для побудови [моделі](#model).
+      Їх ефективність  вимірюється здатністю прогнозувати властивості [тестових даних](#test_data).
+
+      '
 - slug: magic_number
   en:
-    term: "magic number"
-    def: >
-      An unnamed numerical constant that appears in a program without explanation.
+    term: magic number
+    def: 'An unnamed numerical constant that appears in a program without explanation.
 
+      '
   am:
     term: አስማት ቁጥር
-    def: >
-      ያለምንም ማብራሪያ በፕሮግራም ውስጥ የሚታየውን ያልተሰየመ የቁጥር ቋት ፡፡
+    def: 'ያለምንም ማብራሪያ በፕሮግራም ውስጥ የሚታየውን ያልተሰየመ የቁጥር ቋት ፡፡
 
+      '
 - slug: make
   en:
-    term: "Make"
-    def: >
-      The original [build manager](#build_manager) for Unix, still in daily use after
-      more than forty years.
+    term: Make
+    def: 'The original [build manager](#build_manager) for Unix, still in daily use
+      after more than forty years.
 
+      '
   am:
     term: አድርግ
-    def: >
-      ለዩኒክስ የመጀመሪያው [የግንባታ ሥራ አስኪያጅ](#build_manager) ፣ አሁንም በኋላ በየቀኑ ጥቅም ላይ ይውላል ከአርባ ዓመት በላይ ፡፡
+    def: 'ለዩኒክስ የመጀመሪያው [የግንባታ ሥራ አስኪያጅ](#build_manager) ፣ አሁንም በኋላ በየቀኑ ጥቅም ላይ ይውላል
+      ከአርባ ዓመት በላይ ፡፡
 
+      '
 - slug: makefile
   en:
-    term: "Makefile"
-    def: >
-      A file containing commands for [Make](#make), often actually called `Makefile`.
+    term: Makefile
+    def: 'A file containing commands for [Make](#make), often actually called `Makefile`.
 
+      '
   am:
     term: የመገለጫ ጽሑፍ
-    def: >
-      ለ "Make" (#make) ትዕዛዞችን የያዘ ፋይል ፣ ብዙውን ጊዜ በትክክል "Makefile`" ተብሎ ይጠራል።
+    def: 'ለ "Make" (#make) ትዕዛዞችን የያዘ ፋይል ፣ ብዙውን ጊዜ በትክክል "Makefile`" ተብሎ ይጠራል።
 
+      '
 - slug: markdown
   en:
-    term: "Markdown"
-    def: >
-      A [markup language](#markup_language) with a simple syntax intended as a replacement for [HTML](#html).
-      Markdown is often used for README files, and is the basis for [R markdown](#r_markdown).
+    term: Markdown
+    def: 'A [markup language](#markup_language) with a simple syntax intended as a
+      replacement for [HTML](#html). Markdown is often used for README files, and
+      is the basis for [R markdown](#r_markdown).
+
+      '
   de:
-    term: "Markdown"
-    def: >
-      Eine [Auszeichnungssprache](#markup_language) mit einfacher Syntax, die als Ersatz für [HTML](#html)
-      vorgesehen ist. Markdown wird oft für README (lies mich) Dateien verwendet und ist die Basis von
-      [R Markdown](#r_markdown).
+    term: Markdown
+    def: 'Eine [Auszeichnungssprache](#markup_language) mit einfacher Syntax, die
+      als Ersatz für [HTML](#html) vorgesehen ist. Markdown wird oft für README (lies
+      mich) Dateien verwendet und ist die Basis von [R Markdown](#r_markdown).
+
+      '
   fr:
-    term: "Markdown"
-    def: >
-      Un [langage de balisage](#markup_language) à la syntaxe simple visant à remplacer [HTML](#html).
-      Markdown est souvent utilisé dans les fichiers LISEZ MOI (README), et forme la base du
-      [R markdown](#r_markdown).
+    term: Markdown
+    def: 'Un [langage de balisage](#markup_language) à la syntaxe simple visant à
+      remplacer [HTML](#html). Markdown est souvent utilisé dans les fichiers LISEZ
+      MOI (README), et forme la base du [R markdown](#r_markdown).
+
+      '
   uk:
-    term: "Markdown"
-    def: >
-      [Мова розмітки](#markup_language) для полегшення написання та читання тексту у
-      структурованому форматі. Markdown також дозволяє легко конвертувати текст у [HTML](#html).
-      Markdown має простий синтаксис, та часто використовується для файлів README, а також є 
-      основою для [R markdown](#r_markdown).
+    term: Markdown
+    def: '[Мова розмітки](#markup_language) для полегшення написання та читання тексту
+      у структурованому форматі. Markdown також дозволяє легко конвертувати текст
+      у [HTML](#html). Markdown має простий синтаксис, та часто використовується для
+      файлів README, а також є  основою для [R markdown](#r_markdown).
+
+      '
   am:
     term: ምልክት ማድረጊያ
-    def: >
-      ለ [HTML](#html) ምትክ ተብሎ የታቀደ ቀለል ያለ አገባብ ያለው አንድ [የምልክት ቋንቋ](#markup_language) ምልክት ማድረጊያ ብዙውን ጊዜ ለ README ፋይሎች ጥቅም ላይ ይውላል ፣ እና ለ [R markdown](#r_markdown) መሠረት ነው።
+    def: 'ለ [HTML](#html) ምትክ ተብሎ የታቀደ ቀለል ያለ አገባብ ያለው አንድ [የምልክት ቋንቋ](#markup_language)
+      ምልክት ማድረጊያ ብዙውን ጊዜ ለ README ፋይሎች ጥቅም ላይ ይውላል ፣ እና ለ [R markdown](#r_markdown)
+      መሠረት ነው።
 
+      '
 - slug: markov_chain
   ref:
-    - bayesian_network
-    - monte_carlo
+  - bayesian_network
+  - monte_carlo
   en:
-    term: "Markov Chain"
-    def: >
-      Any [model](#model) describing a series of events in which the
-      probability of each event depends only on the current state, not on the path
-      taken to reach that state.
+    term: Markov Chain
+    def: 'Any [model](#model) describing a series of events in which the probability
+      of each event depends only on the current state, not on the path taken to reach
+      that state.
 
+      '
   am:
     term: የማርኮቭ ሰንሰለት
-    def: >
-      የተከታታይ ክስተቶችን የሚገልጽ ማንኛውም [ሞዴል](#model) የእያንዳንዱ ክስተት ዕድል የሚወሰነው አሁን ባለው ሁኔታ ላይ ብቻ ነው ፣ ወደዚያ ሁኔታ ለመድረስ በሚወስደው መንገድ ላይ አይደለም ፡፡
+    def: 'የተከታታይ ክስተቶችን የሚገልጽ ማንኛውም [ሞዴል](#model) የእያንዳንዱ ክስተት ዕድል የሚወሰነው አሁን ባለው
+      ሁኔታ ላይ ብቻ ነው ፣ ወደዚያ ሁኔታ ለመድረስ በሚወስደው መንገድ ላይ አይደለም ፡፡
 
+      '
 - slug: markup_language
   ref:
-    - latex
-    - xml
+  - latex
+  - xml
   en:
-    term: "markup language"
-    def: >
-      A set of rules for annotating text to define its meaning or how it should be
-      displayed. The markup is usually not displayed, but instead controls how the
-      underlying text is interpreted or shown. [Markdown](#markdown) and [HTML](#html)
+    term: markup language
+    def: 'A set of rules for annotating text to define its meaning or how it should
+      be displayed. The markup is usually not displayed, but instead controls how
+      the underlying text is interpreted or shown. [Markdown](#markdown) and [HTML](#html)
       are widely-used markup languages for web pages.
+
+      '
   de:
-    term: "Auszeichnungssprache"
-    def: >
-      Ein Regelwerk zur Annotation von Text, um zu definieren, was er bedeutet oder wie er
-      dargestellt werden soll. Die Textauszeichnung wird in der Regel nicht dargestellt, sondern
-      kontrolliert wie der zu Grunde liegende Text interpretiert oder angezeigt wird. [Markdown](#markdown)
-      und [HTML](#html) sind weit verbreitete Auszeichnungssprachen für Internetseiten.
+    term: Auszeichnungssprache
+    def: 'Ein Regelwerk zur Annotation von Text, um zu definieren, was er bedeutet
+      oder wie er dargestellt werden soll. Die Textauszeichnung wird in der Regel
+      nicht dargestellt, sondern kontrolliert wie der zu Grunde liegende Text interpretiert
+      oder angezeigt wird. [Markdown](#markdown) und [HTML](#html) sind weit verbreitete
+      Auszeichnungssprachen für Internetseiten.
+
+      '
   fr:
-    term: "langage de balisage"
-    def: >
-      Un ensemble de règles pour annoter un texte afin d'en définir la structure ou d'en modifier
-      l'affichage. Des balises déterminent comment le texte
-      qu'elles délimitent doit être interprété ou affiché. Le [Markdown](#markdown) et [HTML](#html)
+    term: langage de balisage
+    def: 'Un ensemble de règles pour annoter un texte afin d''en définir la structure
+      ou d''en modifier l''affichage. Des balises déterminent comment le texte qu''elles
+      délimitent doit être interprété ou affiché. Le [Markdown](#markdown) et [HTML](#html)
       sont des exemples de langages de balisage utilisés pour des pages web.
 
+      '
   am:
     term: ምልክት ማድረጊያ ቋንቋ
-    def: >
-      ትርጉሙን ወይም እንዴት መሆን እንዳለበት ለመግለጽ ጽሑፍን ለማብራራት የደንብ ስብስብ ታይቷል ምልክቱ ብዙውን ጊዜ አይታይም ፣ ግን ይልቁንስ እንዴት እንደሚቆጣጠር መሰረታዊ ጽሑፍ ተተርጉሟል ወይም ታይቷል። [Markdown](#markdown) እና [HTML](#html) ለድረ-ገፆች በሰፊው ጥቅም ላይ የዋሉ የማውጫ ቋንቋዎች ናቸው ፡፡
+    def: 'ትርጉሙን ወይም እንዴት መሆን እንዳለበት ለመግለጽ ጽሑፍን ለማብራራት የደንብ ስብስብ ታይቷል ምልክቱ ብዙውን ጊዜ
+      አይታይም ፣ ግን ይልቁንስ እንዴት እንደሚቆጣጠር መሰረታዊ ጽሑፍ ተተርጉሟል ወይም ታይቷል። [Markdown](#markdown)
+      እና [HTML](#html) ለድረ-ገፆች በሰፊው ጥቅም ላይ የዋሉ የማውጫ ቋንቋዎች ናቸው ፡፡
 
+      '
 - slug: marthas_rules
   en:
-    term: "Martha's Rules"
-    def: >
-      A simple set of rules for making decisions in small groups.
+    term: Martha's Rules
+    def: 'A simple set of rules for making decisions in small groups.
 
+      '
   am:
     term: የማርት ደንቦች
-    def: >
-      በትንሽ ቡድኖች ውስጥ ውሳኔዎችን የማድረግ ቀላል የህጎች ስብስብ።
+    def: 'በትንሽ ቡድኖች ውስጥ ውሳኔዎችን የማድረግ ቀላል የህጎች ስብስብ።
 
+      '
 - slug: masking
   en:
-    term: "Masking"
-    def: >
-      [TODO] to be defined
+    term: Masking
+    def: '[TODO] to be defined
 
-
+      '
 - slug: master_branch
   ref:
-    - feature_branch
+  - feature_branch
   en:
-    term: "master branch"
-    def: >
-      A dedicated, permanent, central [branch](#branch) which should contain a "ready product".
-      After a new feature is developed on a separate branch to avoid breaking the main
-      code, it can be [merged](#git_merge) into the master branch.
+    term: master branch
+    def: 'A dedicated, permanent, central [branch](#branch) which should contain a
+      "ready product". After a new feature is developed on a separate branch to avoid
+      breaking the main code, it can be [merged](#git_merge) into the master branch.
 
+      '
   am:
     term: ዋና ቅርንጫፍ
-    def: >
-      "ዝግጁ ምርት" መያዝ ያለበት ራሱን የወሰነ ፣ ቋሚ ፣ ማዕከላዊ [ቅርንጫፍ](#branch)። ዋናውን ኮድ ላለማፍረስ በተለየ አካል ላይ አዲስ ባህሪ ከተሰራ በኋላ ወደ ዋናው ቅርንጫፍ ውስጥ [ሊዋሃድ](#git_merge) ሊሆን ይችላል ፡፡
+    def: '"ዝግጁ ምርት" መያዝ ያለበት ራሱን የወሰነ ፣ ቋሚ ፣ ማዕከላዊ [ቅርንጫፍ](#branch)። ዋናውን ኮድ ላለማፍረስ
+      በተለየ አካል ላይ አዲስ ባህሪ ከተሰራ በኋላ ወደ ዋናው ቅርንጫፍ ውስጥ [ሊዋሃድ](#git_merge) ሊሆን ይችላል ፡፡
 
+      '
 - slug: maximum_likelihood_estimation
   en:
-    term: "maximum likelihood estimation"
-    def: >
-      To choose the [parameters](#parameter) for a [probability
-      distribution](#probability_distribution) in order to maximize the likelihood of
-      obtaining observed data.
+    term: maximum likelihood estimation
+    def: 'To choose the [parameters](#parameter) for a [probability distribution](#probability_distribution)
+      in order to maximize the likelihood of obtaining observed data.
+
+      '
   af:
-    term: "maksimumaanneemlikheidsberaming"
-    def: >
-      Om die parameters vir 'n [waarskynlikheids verdeling](#probability_distribution)
+    term: maksimumaanneemlikheidsberaming
+    def: 'Om die parameters vir ''n [waarskynlikheids verdeling](#probability_distribution)
       te verkry, te maksimeer.
 
+      '
   am:
     term: ከፍተኛ የእድል ግምት
-    def: >
-      ለ [ፕሮባቢሊቲ] [መለኪያዎች](#parameter) ለመምረጥ የመሆን እድልን ከፍ ለማድረግ (#ፕሮባቢሊቲ_ ስርጭት) የታየ መረጃን ማግኘት ፡፡
+    def: 'ለ [ፕሮባቢሊቲ] [መለኪያዎች](#parameter) ለመምረጥ የመሆን እድልን ከፍ ለማድረግ (#ፕሮባቢሊቲ_ ስርጭት)
+      የታየ መረጃን ማግኘት ፡፡
 
+      '
 - slug: mean
   ref:
-    - median
-    - mode
+  - median
+  - mode
   en:
-    term: "mean"
-    def: >
-      The average value of a dataset, more properly known as the [arithmetic
-      mean](#arithmetic_mean) to distinguish it from the [geometric](#geometric_mean)
-      and [harmonic](#harmonic_mean) means.
+    term: mean
+    def: 'The average value of a dataset, more properly known as the [arithmetic mean](#arithmetic_mean)
+      to distinguish it from the [geometric](#geometric_mean) and [harmonic](#harmonic_mean)
+      means.
+
+      '
   de:
-    term: "Mittelwert"
-    def: >
-      Der Durchschnitt eines Datensatzes, genauer auch bezeichnet als [arithmetischer
+    term: Mittelwert
+    def: 'Der Durchschnitt eines Datensatzes, genauer auch bezeichnet als [arithmetischer
       Mittelwert](#arithmetic_mean), um ihn zu unterscheiden vom [geometrischen](#geometric_mean)
       und [harmonischen](#harmonic_mean) Mittelwert.
+
+      '
   it:
-    term: "media"
-    def: >
-      Rapporto tra la somma dei valori e il numero di valori. Chiamata anche [media aritmetica](#arithmetic_mean)
-      per distinguerla dalla [media geometrica](#geometric_mean) e dalla [media armonica](#harmonic_mean).
+    term: media
+    def: 'Rapporto tra la somma dei valori e il numero di valori. Chiamata anche [media
+      aritmetica](#arithmetic_mean) per distinguerla dalla [media geometrica](#geometric_mean)
+      e dalla [media armonica](#harmonic_mean).
+
+      '
   af:
-    term: "gemiddeld"
-    def: >
-      Die gemiddelde waarde van 'n datastel, beter bekend as die
-      [rekenkundige gemiddeld](#arithmetic_mean) om dit van die [meetkundige](#geometric_mean)
-      en die [harmoniese](#harmonic_mean) gemiddelde te onderskei.
+    term: gemiddeld
+    def: 'Die gemiddelde waarde van ''n datastel, beter bekend as die [rekenkundige
+      gemiddeld](#arithmetic_mean) om dit van die [meetkundige](#geometric_mean) en
+      die [harmoniese](#harmonic_mean) gemiddelde te onderskei.
+
+      '
   pt:
-    term: "média"
-    def: >
-      O valor médio de um conjunto de dados, mais apropriadamente conhecido como
-      [média aritmética](#arithmetic_mean) para que seja distinguido da média
-      [geométrica](#geometric_mean) e da [harmônica](#harmonic_mean).
+    term: média
+    def: 'O valor médio de um conjunto de dados, mais apropriadamente conhecido como
+      [média aritmética](#arithmetic_mean) para que seja distinguido da média [geométrica](#geometric_mean)
+      e da [harmônica](#harmonic_mean).
+
+      '
   am:
     term: ማለት
-    def: >
-      የውሂብ ስብስብ አማካይ ዋጋ ፣ ይበልጥ በትክክል በትክክል "ሂሳብ" ተብሎ ይጠራል ከ [ጂኦሜትሪክ](#arithmetic_mean) ለመለየት[የሂሳብ_ማለት]#geometric_mean) እና [harmonic](#harmonic_mean) ማለት ነው።
-  sw:
-    term: "wastani"
-    def: >
-      Namba ya katikati kwa data.  Kuikokotoa, jumla nambari halafu gawana na nambari
-      za nambari.
-  uk:
-    term: "середнє значення"
-    def: >
-      Середнє значення набору даних, більш відоме як [арифметичне середнє](#arithmetic_mean), що
-      відрізняється від [геометричного](#geometric_mean) та [гармонічного](#harmonic_mean) середнього.
+    def: 'የውሂብ ስብስብ አማካይ ዋጋ ፣ ይበልጥ በትክክል በትክክል "ሂሳብ" ተብሎ ይጠራል ከ [ጂኦሜትሪክ](#arithmetic_mean)
+      ለመለየት[የሂሳብ_ማለት]#geometric_mean) እና [harmonic](#harmonic_mean) ማለት ነው።
 
+      '
+  sw:
+    term: wastani
+    def: 'Namba ya katikati kwa data.  Kuikokotoa, jumla nambari halafu gawana na
+      nambari za nambari.
+
+      '
+  uk:
+    term: середнє значення
+    def: 'Середнє значення набору даних, більш відоме як [арифметичне середнє](#arithmetic_mean),
+      що відрізняється від [геометричного](#geometric_mean) та [гармонічного](#harmonic_mean)
+      середнього.
+
+      '
 - slug: mean_absolute_error
   ref:
-    - mean_squared_error
-    - root_mean_squared_error
+  - mean_squared_error
+  - root_mean_squared_error
   en:
-    term: "mean absolute error"
-    def: >
-      The average error of all predicted values compared with actual values.
+    term: mean absolute error
+    def: 'The average error of all predicted values compared with actual values.
+
+      '
   es:
-    term: "error absoluto medio"
-    def: >
-      El error promedio de todos los valores predichos en comparación con los
+    term: error absoluto medio
+    def: 'El error promedio de todos los valores predichos en comparación con los
       valores reales.
+
+      '
   am:
     term: ፍፁም ስህተት ማለት ነው።
-    def: >
-      ከእውነተኛ እሴቶች ጋር ሲነፃፀር የሁሉም የተነበዩ እሴቶች አማካይ ስህተት።
+    def: 'ከእውነተኛ እሴቶች ጋር ሲነፃፀር የሁሉም የተነበዩ እሴቶች አማካይ ስህተት።
 
+      '
 - slug: mean_squared_error
   ref:
-    - root_mean_squared_error
+  - root_mean_squared_error
   en:
-    term: "mean squared error"
-    def: >
-      The average of the squares of all the errors of all predicted values compared
-      with actual values. Squaring makes larger errors count for more,
-      and transforms negative errors into positive values, making this a
-      more popular measure than [mean absolute error](#mean_absolute_error).
-  es:
-    term: "error cuadrático medio"
-    def: >
-      El promedio de los cuadrados de todos los errores de todos los valores
-      predichos comparados con valores reales. El cuadrado hace que los errores
-      más grandes cuenten más, haciendo esta medida más popular que el
-      [error absoluto medio](#mean_absolute_error).
+    term: mean squared error
+    def: 'The average of the squares of all the errors of all predicted values compared
+      with actual values. Squaring makes larger errors count for more, and transforms
+      negative errors into positive values, making this a more popular measure than
+      [mean absolute error](#mean_absolute_error).
 
+      '
+  es:
+    term: error cuadrático medio
+    def: 'El promedio de los cuadrados de todos los errores de todos los valores predichos
+      comparados con valores reales. El cuadrado hace que los errores más grandes
+      cuenten más, haciendo esta medida más popular que el [error absoluto medio](#mean_absolute_error).
+
+      '
   am:
     term: አማካይ ስኩዌር ስህተት
-    def: >
-      የሁሉም ትንበያ እሴቶች ሁሉ ስህተቶች አደባባዮች አማካይ ሲነፃፀሩ ከትክክለኛ ዋጋዎች ጋር. መቧጨር ትላልቅ ስህተቶች ለተጨማሪ እንዲቆጠሩ ያደርጋቸዋል ፣ እና አሉታዊ ስህተቶችን ወደ አወንታዊ እሴቶች ይቀይረዋል ፣ ይህም ሀ ከ [ፍጹም ፍፁም ስህተት] የበለጠ ታዋቂ ልኬት (#mean_absolute_error)።
+    def: 'የሁሉም ትንበያ እሴቶች ሁሉ ስህተቶች አደባባዮች አማካይ ሲነፃፀሩ ከትክክለኛ ዋጋዎች ጋር. መቧጨር ትላልቅ ስህተቶች
+      ለተጨማሪ እንዲቆጠሩ ያደርጋቸዋል ፣ እና አሉታዊ ስህተቶችን ወደ አወንታዊ እሴቶች ይቀይረዋል ፣ ይህም ሀ ከ [ፍጹም ፍፁም
+      ስህተት] የበለጠ ታዋቂ ልኬት (#mean_absolute_error)።
 
+      '
 - slug: median
   ref:
-    - mode
+  - mode
   en:
-    term: "median"
-    def: >
-      A value separating the upper and lower halves of a sorted dataset. The median
-      often gives a better idea of what is typical of the dataset than the
-      [mean](#mean), which can be influenced by a small number of extreme [outliers](#outlier).
-      If the dataset contains an even number of elements, this is the average of the
+    term: median
+    def: 'A value separating the upper and lower halves of a sorted dataset. The median
+      often gives a better idea of what is typical of the dataset than the [mean](#mean),
+      which can be influenced by a small number of extreme [outliers](#outlier). If
+      the dataset contains an even number of elements, this is the average of the
       two central elements.
-  es:
-    term: "mediana"
-    def: >
-      Un valor que separa las mitades superior e inferior de un conjunto de datos ordenado.
-      Frecuentemente, la mediana da una idea mejor de lo que es característico del conjunto de
-      datos que la [media](#mean), que puede estar influenciada por un pequeño número de [valores
-      atípicos](#outlier). Si el conjunto de datos contiene un número par de elementos, este es el
-      promedio de los dos elementos centrales.
-  af:
-    term: "mediaan"
-    def: >
-      'n Waarde wat die boonste en onderste helfte van 'n gesorteerde datastel skei. Die mediaan
-      gee dikwels 'n beter idee van wat tipies is vir die datastel as die
-      [mediaan](#mean), wat beïnvloed kan word deur 'n klein aantal ekstreme uitskieters.
-  uk:
-    term: "медіана"
-    def: >
-      Значення, що розділяє верхню та нижню половини відсортованого набору даних.
-      Медіана часто дає краще уявлення про те, що є типовим для набору даних, ніж [середнє](#mean),
-      на яке може впливати невелика кількість екстремальних значень. Якщо набір даних
-      містить парну кількість елементів, це є середнім значенням двох центральних елементів.
 
+      '
+  es:
+    term: mediana
+    def: 'Un valor que separa las mitades superior e inferior de un conjunto de datos
+      ordenado. Frecuentemente, la mediana da una idea mejor de lo que es característico
+      del conjunto de datos que la [media](#mean), que puede estar influenciada por
+      un pequeño número de [valores atípicos](#outlier). Si el conjunto de datos contiene
+      un número par de elementos, este es el promedio de los dos elementos centrales.
+
+      '
+  af:
+    term: mediaan
+    def: '''n Waarde wat die boonste en onderste helfte van ''n gesorteerde datastel
+      skei. Die mediaan gee dikwels ''n beter idee van wat tipies is vir die datastel
+      as die [mediaan](#mean), wat beïnvloed kan word deur ''n klein aantal ekstreme
+      uitskieters.
+
+      '
+  uk:
+    term: медіана
+    def: 'Значення, що розділяє верхню та нижню половини відсортованого набору даних.
+      Медіана часто дає краще уявлення про те, що є типовим для набору даних, ніж
+      [середнє](#mean), на яке може впливати невелика кількість екстремальних значень.
+      Якщо набір даних містить парну кількість елементів, це є середнім значенням
+      двох центральних елементів.
+
+      '
   am:
     term: መካከለኛ
-    def: >
-      የተስተካከለ የውሂብ ስብስብ የላይኛው እና የታችኛው ግማሾችን የሚለይ እሴት። መካከለኛ ብዙውን ጊዜ ከ ‹ዳታ› ስብስቡ ምን ዓይነት እንደሚሆን የተሻለ ሀሳብ ይሰጣል (አማካይ)(#mean) ፣ በትንሽ ቁጥር ጽንፈኛ [አውጪዎች](#outlier) ተጽዕኖ ሊኖረው ይችላል። የውሂብ ስብስቡ አንድ እንኳን ብዛት ያላቸውን ንጥረ ነገሮችን ከያዘ ይህ የሁለቱ ማዕከላዊ አካላት አማካይ ነው።
+    def: 'የተስተካከለ የውሂብ ስብስብ የላይኛው እና የታችኛው ግማሾችን የሚለይ እሴት። መካከለኛ ብዙውን ጊዜ ከ ‹ዳታ› ስብስቡ
+      ምን ዓይነት እንደሚሆን የተሻለ ሀሳብ ይሰጣል (አማካይ)(#mean) ፣ በትንሽ ቁጥር ጽንፈኛ [አውጪዎች](#outlier)
+      ተጽዕኖ ሊኖረው ይችላል። የውሂብ ስብስቡ አንድ እንኳን ብዛት ያላቸውን ንጥረ ነገሮችን ከያዘ ይህ የሁለቱ ማዕከላዊ አካላት
+      አማካይ ነው።
 
+      '
+- slug: memoization
+  ref:
+  - dynamic_programming
+  en:
+    term: memoization
+    def: 'An optimization technique that stores the results of expensive function
+      calls and returns the cached result when the same inputs occur again. Commonly
+      used in [dynamic programming](#dynamic_programming).
+
+      '
 - slug: merge_git
   en:
-    term: "merge (Git)"
-    def: >
-      See [Git merge](#git_merge)
+    term: merge (Git)
+    def: 'See [Git merge](#git_merge)
 
+      '
   am:
     term: ማዋሃድ (ጌት)
-    def: >
-      ይመልከቱ [Git merge](#git_merge)
+    def: 'ይመልከቱ [Git merge](#git_merge)
 
+      '
 - slug: method
   en:
-    term: "method"
-    def: >
-      An implementation of a [generic function](#generic_function) that handles
+    term: method
+    def: 'An implementation of a [generic function](#generic_function) that handles
       objects of a specific class.
-  es:
-    term: "método"
-    def: >
-      Una implementación de una [función genérica](#generic_function) que
-      manipula objetos de una clase específica.
 
+      '
+  es:
+    term: método
+    def: 'Una implementación de una [función genérica](#generic_function) que manipula
+      objetos de una clase específica.
+
+      '
   am:
     term: ዘዴ
-    def: >
-      የሚያስተናግደው የ [አጠቃላይ ተግባር](#generic_function) የአንድ የተወሰነ ክፍል ዕቃዎች።
+    def: 'የሚያስተናግደው የ [አጠቃላይ ተግባር](#generic_function) የአንድ የተወሰነ ክፍል ዕቃዎች።
 
+      '
 - slug: milestone
   en:
-    term: "milestone"
-    def: >
-      A target that a project is trying to meet, often represented as a set of
+    term: milestone
+    def: 'A target that a project is trying to meet, often represented as a set of
       [issues](#issue) that all have to be resolved by a certain time.
-  af:
-    term: "mylpaal"
-    def: >
-      'n Teiken wat 'n projek probeer bereik, dikwels voorgestel as 'n stel [kwessies](#issue)
-      wat almal teen 'n sekere tyd opgelos moet wees.
 
+      '
+  af:
+    term: mylpaal
+    def: '''n Teiken wat ''n projek probeer bereik, dikwels voorgestel as ''n stel
+      [kwessies](#issue) wat almal teen ''n sekere tyd opgelos moet wees.
+
+      '
   am:
     term: ወሳኝ ምዕራፍ
-    def: >
-      አንድ ፕሮጀክት ሊያሟላ እየሞከረ ያለው ዒላማ ፣ ብዙውን ጊዜ እንደ ስብስብ ይወከላል [ጉዳዮች](#issue) ሁሉም በተወሰነ ጊዜ መፍታት አለባቸው ፡፡
+    def: 'አንድ ፕሮጀክት ሊያሟላ እየሞከረ ያለው ዒላማ ፣ ብዙውን ጊዜ እንደ ስብስብ ይወከላል [ጉዳዮች](#issue) ሁሉም
+      በተወሰነ ጊዜ መፍታት አለባቸው ፡፡
 
+      '
 - slug: mime_type
   en:
-    term: "MIME type"
-    def: >
-      A standard way to identify the contents of files on the internet. The term is an
-      acronym of "multi-purpose Internet mail extension", and MIME types are often
-      identified by [filename extensions](#filename_extension), such as `.png` for
-      PNG-formatted images.
+    term: MIME type
+    def: 'A standard way to identify the contents of files on the internet. The term
+      is an acronym of "multi-purpose Internet mail extension", and MIME types are
+      often identified by [filename extensions](#filename_extension), such as `.png`
+      for PNG-formatted images.
 
+      '
   am:
     term: MIME ዓይነት
-    def: >
-      በይነመረቡ ላይ የፋይሎችን ይዘት ለመለየት መደበኛ መንገድ። ቃሉ አንድ ነው የ "ሁለገብ በይነመረብ መልእክት ማራዘሚያ" ምህፃረ ቃል ፣ እና MIME ዓይነቶች ብዙ ጊዜ ናቸው እንደ".png` ለ"በ [የፋይል ስም ቅጥያዎች](#filename_extension) ተለይቷል በ PNG የተቀረጹ ምስሎች።
+    def: 'በይነመረቡ ላይ የፋይሎችን ይዘት ለመለየት መደበኛ መንገድ። ቃሉ አንድ ነው የ "ሁለገብ በይነመረብ መልእክት ማራዘሚያ"
+      ምህፃረ ቃል ፣ እና MIME ዓይነቶች ብዙ ጊዜ ናቸው እንደ".png` ለ"በ [የፋይል ስም ቅጥያዎች](#filename_extension)
+      ተለይቷል በ PNG የተቀረጹ ምስሎች።
 
+      '
 - slug: minimum_spanning_tree
   en:
-    term: "minimum spanning tree"
-    acronym: "MST"
-    def: >
-      A minimum spanning tree is a data structure that describes the unique set of [edges](#edge) that connect all of the [nodes](#node) in a [graph](#graph) while minimizing the weights of all included [edges](#edge). The minimum spanning tree may refer to either the algorithm to calculate the structure or the resulting structure itself.
+    term: minimum spanning tree
+    acronym: MST
+    def: 'A minimum spanning tree is a data structure that describes the unique set
+      of [edges](#edge) that connect all of the [nodes](#node) in a [graph](#graph)
+      while minimizing the weights of all included [edges](#edge). The minimum spanning
+      tree may refer to either the algorithm to calculate the structure or the resulting
+      structure itself.
 
+      '
+- slug: missing_data
+  ref:
+  - data_cleaning
+  - na
+  - null
+  en:
+    term: missing data
+    def: 'Values that are absent from a [dataset](#dataset), often represented as
+      [NA](#na), [null](#null), or NaN. Handling missing data is a crucial part of
+      [data cleaning](#data_cleaning) and may involve imputation, deletion, or special
+      modeling.
+
+      '
 - slug: missing_value
   en:
-    term: "missing value"
-    def: >
-      A special value such as [null](#null) or [NA](#na) used to indicate the absence
-      of data. Missing values can signal that data was not collected or that the data
-      did not exist in the first place (e.g., the middle name of someone who does not
-      have one).
+    term: missing value
+    def: 'A special value such as [null](#null) or [NA](#na) used to indicate the
+      absence of data. Missing values can signal that data was not collected or that
+      the data did not exist in the first place (e.g., the middle name of someone
+      who does not have one).
 
+      '
   am:
     term: የጠፋ እሴት
-    def: >
-      መቅረቱን ለማመልከት ጥቅም ላይ የዋለው እንደ [null](#null) ወይም [NA](#na) ያሉ ልዩ እሴት የውሂብ. የጠፋ እሴቶች መረጃው እንዳልተሰበሰበ ወይም እንደዚያ መረጃ ሊያመለክቱ ይችላሉ በመጀመሪያ ደረጃ አልነበረም (ለምሳሌ ፣ የሌለ ሰው መካከለኛ ስም) አንድ አለኝ) ፡፡
+    def: 'መቅረቱን ለማመልከት ጥቅም ላይ የዋለው እንደ [null](#null) ወይም [NA](#na) ያሉ ልዩ እሴት የውሂብ.
+      የጠፋ እሴቶች መረጃው እንዳልተሰበሰበ ወይም እንደዚያ መረጃ ሊያመለክቱ ይችላሉ በመጀመሪያ ደረጃ አልነበረም (ለምሳሌ ፣
+      የሌለ ሰው መካከለኛ ስም) አንድ አለኝ) ፡፡
 
+      '
 - slug: mit_license
   en:
-    term: "MIT License"
-    def: >
-      A [license](#license) that allows people to re-use software with no restrictions.
+    term: MIT License
+    def: 'A [license](#license) that allows people to re-use software with no restrictions.
 
+      '
   am:
     term: MIT ፈቃድ
-    def: >
-      ሰዎች ያለምንም ገደብ ሶፍትዌሮችን እንደገና እንዲጠቀሙ የሚያስችል (ፈቃድ)(#license)።
+    def: 'ሰዎች ያለምንም ገደብ ሶፍትዌሮችን እንደገና እንዲጠቀሙ የሚያስችል (ፈቃድ)(#license)።
 
+      '
 - slug: mock_object
   en:
-    term: "mock object"
-    def: >
-      A simplified replacement for part of a program whose behavior is easy to control
-      and predict. Mock objects are used in [unit tests](#unit_test) to simulate
+    term: mock object
+    def: 'A simplified replacement for part of a program whose behavior is easy to
+      control and predict. Mock objects are used in [unit tests](#unit_test) to simulate
       databases, web services, and other complex systems.
 
+      '
   am:
     term: አስቂኝ ነገር
-    def: >
-      ባህሪያቱን ለመቆጣጠር ቀላል የሆነ የፕሮግራም አካል ቀለል ያለ ምትክ እና መተንበይ. አስቂኝ ነገሮች በ [ዩኒት ሙከራዎች](#unit_test) ውስጥ ለማስመሰል ያገለግላሉ የመረጃ ቋቶች ፣ የድር አገልግሎቶች እና ሌሎች ውስብስብ ስርዓቶች።
+    def: 'ባህሪያቱን ለመቆጣጠር ቀላል የሆነ የፕሮግራም አካል ቀለል ያለ ምትክ እና መተንበይ. አስቂኝ ነገሮች በ [ዩኒት ሙከራዎች](#unit_test)
+      ውስጥ ለማስመሰል ያገለግላሉ የመረጃ ቋቶች ፣ የድር አገልግሎቶች እና ሌሎች ውስብስብ ስርዓቶች።
 
+      '
 - slug: mode
   ref:
-    - mean
-    - median
+  - mean
+  - median
   en:
-    term: "mode"
-    def: >
-      The value, or values, that occurs most frequently in a dataset.
+    term: mode
+    def: 'The value, or values, that occurs most frequently in a dataset.
+
+      '
   es:
-    term: "moda"
-    def: >
-      El valor que ocurre con más frecuencia en un conjunto de datos.
+    term: moda
+    def: 'El valor que ocurre con más frecuencia en un conjunto de datos.
+
+      '
   af:
-    term: "modus"
-    def: >
-      Die waarde wat die meeste in 'n datastel voorkom.
+    term: modus
+    def: 'Die waarde wat die meeste in ''n datastel voorkom.
+
+      '
   de:
-    term: "Modus"
-    def: >
-      Auch Modalwert genannt. Gibt den Wert oder die Werte an, die am häufigsten in einem Datensatz vorkommen.
+    term: Modus
+    def: 'Auch Modalwert genannt. Gibt den Wert oder die Werte an, die am häufigsten
+      in einem Datensatz vorkommen.
+
+      '
   ar:
-    term: "المنوال"
-    def: >
-      القيمة أو القيم الأكثر تكراراً في مجموعة البيانات.
+    term: المنوال
+    def: 'القيمة أو القيم الأكثر تكراراً في مجموعة البيانات.
+
+      '
   uk:
-    term: "мода"
-    def: >
-      Мода - одне чи декілька значень, які найчастіше зустрічаються в наборі даних.
+    term: мода
+    def: 'Мода - одне чи декілька значень, які найчастіше зустрічаються в наборі даних.
       Якщо декілька значень мають однакову найвищу частоту, то набір має декілька
       мод, і такий розподіл називається мультимодальним.
 
+      '
 - slug: model
   en:
-    term: "model"
-    def: >
-      A specification of the mathematical relationship between different variables.
+    term: model
+    def: 'A specification of the mathematical relationship between different variables.
+
+      '
   af:
-    term: "model"
-    def: >
-      'n Spesifikasie van'n wiskundige verband tussen verskillende veranderlikes.
+    term: model
+    def: '''n Spesifikasie van''n wiskundige verband tussen verskillende veranderlikes.
 
+      '
+- slug: model_evaluation
+  ref:
+  - machine_learning
+  - test_data
+  - validation_set
+  en:
+    term: model evaluation
+    def: 'The process of assessing how well a [machine learning](#machine_learning)
+      model performs on unseen data, typically using [test data](#test_data) or a
+      [validation set](#validation_set). Involves metrics like accuracy, [precision](#precision),
+      [recall](#recall), and [F1 score](#f1_score).
 
+      '
+- slug: model_training
+  ref:
+  - machine_learning
+  - training_data
+  - supervised_learning
+  en:
+    term: model training
+    def: 'The process of teaching a [machine learning](#machine_learning) model to
+      make predictions by feeding it [training data](#training_data) and adjusting
+      its parameters to minimize the [loss function](#loss_function).
+
+      '
 - slug: module
   en:
-    term: "module"
-    def: >
-      A reusable software [package](#package), also often called a [library](#library).
+    term: module
+    def: 'A reusable software [package](#package), also often called a [library](#library).
+
+      '
   es:
-    term: "módulo"
-    def: >
-      un paquete de software reutilizable, también se llama una [biblioteca](#library).
+    term: módulo
+    def: 'un paquete de software reutilizable, también se llama una [biblioteca](#library).
+
+      '
   fr:
-    term: "module"
-    def: >
-      Un [paquet](#package) logiciel réutilisable, parfois aussi appelé [bibliothèque](#library).
+    term: module
+    def: 'Un [paquet](#package) logiciel réutilisable, parfois aussi appelé [bibliothèque](#library).
+
+      '
   xh:
-    term: "Imodyuli"
-    def: >
-      [Iphakheji yesoftware](#package) enokuphinda isebenze, ekwabizwa ngokuba [yilayibrari](#library)
+    term: Imodyuli
+    def: '[Iphakheji yesoftware](#package) enokuphinda isebenze, ekwabizwa ngokuba
+      [yilayibrari](#library)
+
+      '
   af:
-    term: "module"
-    def: >
-     'n Herbruikbare [sagtewarepakket](#package), ook dikwels 'n [biblioteek](#library) genoem.
+    term: module
+    def: '''n Herbruikbare [sagtewarepakket](#package), ook dikwels ''n [biblioteek](#library)
+      genoem.
 
-
+      '
 - slug: monte_carlo
   ref:
-    - markov_chain
+  - markov_chain
   en:
-    term: "Monte Carlo method"
-    def: >
-      Any method or algorithm that relies on artificially-injected randomness.
+    term: Monte Carlo method
+    def: 'Any method or algorithm that relies on artificially-injected randomness.
 
-
+      '
 - slug: moving_average
   en:
-    term: "moving average"
-    def: >
-      The [mean](#mean) of each set of several consecutive values from [time
-      series](#time_series) data.
+    term: moving average
+    def: 'The [mean](#mean) of each set of several consecutive values from [time series](#time_series)
+      data.
 
-
+      '
 - slug: multi_threaded
   en:
-    term: "multi-threaded"
-    def: >
-      Capable of performing several operations simultaneously. Multi-threaded programs
-      are usually more efficient than [single-threaded](#single_threaded) ones, but
-      also harder to understand and [debug](#debug).
+    term: multi-threaded
+    def: 'Capable of performing several operations simultaneously. Multi-threaded
+      programs are usually more efficient than [single-threaded](#single_threaded)
+      ones, but also harder to understand and [debug](#debug).
 
-
+      '
 - slug: mutable_type
   en:
-    term: "mutable type"
-    def: >
-      An object of this type may be changed and its state can be modified after it is created.
+    term: mutable type
+    def: 'An object of this type may be changed and its state can be modified after
+      it is created.
 
+      '
 - slug: mutation
   en:
-    term: "mutation"
-    def: >
-      Changing data in place, such as modifying an element of an array or adding a
-      record to a database.
+    term: mutation
+    def: 'Changing data in place, such as modifying an element of an array or adding
+      a record to a database.
 
-
+      '
 - slug: n_gram
   en:
-    term: "n-gram"
-    def: >
-      A sequence of $N$ items, typically words in natural language. For example, a
-      trigram is a sequence of three words. N-grams are often used as input in
-      [computational linguistics](#computational_linguistics).
+    term: n-gram
+    def: 'A sequence of $N$ items, typically words in natural language. For example,
+      a trigram is a sequence of three words. N-grams are often used as input in [computational
+      linguistics](#computational_linguistics).
 
-
+      '
 - slug: na
   ref:
-    - "null"
+  - 'null'
   en:
-    term: "NA"
-    def: >
-      A special value used to represent data that is not available.
+    term: NA
+    def: 'A special value used to represent data that is not available.
+
+      '
   fr:
-    term: "NA"
-    def: >
-      Une valeur spéciale utilisée pour représenter des données qui ne sont pas disponibles.
+    term: NA
+    def: 'Une valeur spéciale utilisée pour représenter des données qui ne sont pas
+      disponibles.
+
+      '
   af:
-    term: "NA"
-    def: >
-      'n Spesiale waarde wat gebruik word om data wat nie beskikbaar is nie, voor te stel.
+    term: NA
+    def: '''n Spesiale waarde wat gebruik word om data wat nie beskikbaar is nie,
+      voor te stel.
+
+      '
   ar:
-    term: "لاشيء"
-    def: >
-      هو رمز مميز يٌمثِل حرفاً بلا قيمة أو قيمة مفقودة أي انه يرمز إلى عدم وجود أي
-      قيمة على الإطلاق.
+    term: لاشيء
+    def: 'هو رمز مميز يٌمثِل حرفاً بلا قيمة أو قيمة مفقودة أي انه يرمز إلى عدم وجود
+      أي قيمة على الإطلاق.
 
-
+      '
 - slug: naive_bayes_classifier
   en:
-    term: "naive Bayes classifier"
-    def: >
-      Any [classification](#classification) algorithm based on [Bayes'
-      Theorem](#bayes_theorem) that assumes every [feature](#feature_data) being
-      classified is independent of every other feature.
+    term: naive Bayes classifier
+    def: 'Any [classification](#classification) algorithm based on [Bayes'' Theorem](#bayes_theorem)
+      that assumes every [feature](#feature_data) being classified is independent
+      of every other feature.
 
-
+      '
 - slug: name_collision
   ref:
-    - call_stack
-    - fully_qualified_name
+  - call_stack
+  - fully_qualified_name
   en:
-    term: "name collision"
-    def: >
-      The ambiguity that arises when two or more things in a program that have the
-      same name are active at the same time. Most languages use
-      [namespaces](#namespace) to prevent such collisions.
+    term: name collision
+    def: 'The ambiguity that arises when two or more things in a program that have
+      the same name are active at the same time. Most languages use [namespaces](#namespace)
+      to prevent such collisions.
 
-
+      '
 - slug: named_argument
   ref:
-    - keyword_argument
-    - variable_arguments
+  - keyword_argument
+  - variable_arguments
   en:
-    term: "named argument"
-    def: >
-      A function [parameter](#parameter) that is given a value by explicitly naming it in a function call.
+    term: named argument
+    def: 'A function [parameter](#parameter) that is given a value by explicitly naming
+      it in a function call.
 
-
+      '
 - slug: namespace
   ref:
-    - name_collision
-    - scope
+  - name_collision
+  - scope
   en:
-    term: "namespace"
-    def: >
-      A collection of names in a program that exists in isolation from other
-      namespaces. Each function, [object](#object), [class](#class), or
-      [module](#module) in a program typically has its own namespace so that
-      references to "X" in one part of a program do not accidentally refer to
-      something called "X" in another part of the program. Scope is a distinct, but related, concept.
+    term: namespace
+    def: 'A collection of names in a program that exists in isolation from other namespaces.
+      Each function, [object](#object), [class](#class), or [module](#module) in a
+      program typically has its own namespace so that references to "X" in one part
+      of a program do not accidentally refer to something called "X" in another part
+      of the program. Scope is a distinct, but related, concept.
 
-
+      '
 - slug: nano_editor
   en:
-    term: "Nano (editor)"
-    def: >
-      A very simple text editor found on most Unix systems.
-  uk:
-    term: "Nano (редактор)"
-    def: >
-      Простий текстовий редактор, який можна знайти у багатьох системах Unix.
+    term: Nano (editor)
+    def: 'A very simple text editor found on most Unix systems.
 
+      '
+  uk:
+    term: Nano (редактор)
+    def: 'Простий текстовий редактор, який можна знайти у багатьох системах Unix.
+
+      '
 - slug: negative_selection
   en:
-    term: "negative selection"
-    def: >
-      To specify the [elements](#element) of a [vector](#vector) or other data structure that are not desired
-      by negating their indices.
+    term: negative selection
+    def: 'To specify the [elements](#element) of a [vector](#vector) or other data
+      structure that are not desired by negating their indices.
 
-
+      '
 - slug: neural_network
   ref:
-    - deep_learning
-    - backpropagation
-    - perceptron
+  - deep_learning
+  - backpropagation
+  - perceptron
   en:
-    term: "neural network"
-    def: >
-      One of a large family of algorithms for identifying patterns in data by
+    term: neural network
+    def: 'One of a large family of algorithms for identifying patterns in data by
       mimicking the way neurons interact. A neural network consists of one or more
-      layers of [nodes](#node), each of which is connected to nodes in the preceding and
-      subsequent layer. If enough of a node's inputs are active, that node activates
+      layers of [nodes](#node), each of which is connected to nodes in the preceding
+      and subsequent layer. If enough of a node''s inputs are active, that node activates
       as well.
+
+      '
   es:
-    term: "red neuronal"
-    def: >
-      Uno de los algoritmo de una gran familia de algoritmos usados para identificar 
-      patrones en los datos imitando la forma en que interactúan las neuronas del cerebro. 
-      Una red neuronal consta de una o más capas de [nodos](#node), cada uno de los cuales está 
-      conectado a nodos en la capa anterior y en la capa siguiente. Si suficientes entradas de un nodo están activas, 
-      dicho nodo también se activa.
+    term: red neuronal
+    def: 'Uno de los algoritmo de una gran familia de algoritmos usados para identificar  patrones
+      en los datos imitando la forma en que interactúan las neuronas del cerebro.  Una
+      red neuronal consta de una o más capas de [nodos](#node), cada uno de los cuales
+      está  conectado a nodos en la capa anterior y en la capa siguiente. Si suficientes
+      entradas de un nodo están activas,  dicho nodo también se activa.
 
-
+      '
 - slug: nlp
   en:
-    term: "natural language processing"
-    acronym: "NLP"
-    def: >
-      See [computational linguistics](#computational_linguistics).
+    term: natural language processing
+    acronym: NLP
+    def: 'See [computational linguistics](#computational_linguistics).
+
+      '
   es:
-    term: "procesamiento de lenguaje natural"
+    term: procesamiento de lenguaje natural
     acronym: PLN
-    def: >
-      Ver [lingüística computacional](#computational_linguistics).
+    def: 'Ver [lingüística computacional](#computational_linguistics).
 
-
+      '
 - slug: node
   en:
-    term: "node"
-    def: >
-      An element of a [graph](#graph) that is connected to other nodes by
-      [edges](#edge). Nodes typically have data associated with them, such as names or weights.
-  af:
-    term: "node, nodus"
-    def: >
-      'n Element in 'n [grafiese voorstelling](#graph), soos 'n grafiek of 'n netwerk, wat
-      deur ander 'n node/nodus met 'n [skakel](#edge) verbind is. Nodes/Nodusse het spesifieke data,
-      soos byvoorbeeld name of gewigte, gekoppel.
-      
-  es:
-    term: "nodo"
-    def: >
-      Un elemento de un grafo que está conectado a otros nodos por aristas. 
-      Los nodos usualmente tienen datos asociados con ellos, como nombres o pesos.
+    term: node
+    def: 'An element of a [graph](#graph) that is connected to other nodes by [edges](#edge).
+      Nodes typically have data associated with them, such as names or weights.
 
+      '
+  af:
+    term: node, nodus
+    def: '''n Element in ''n [grafiese voorstelling](#graph), soos ''n grafiek of
+      ''n netwerk, wat deur ander ''n node/nodus met ''n [skakel](#edge) verbind is.
+      Nodes/Nodusse het spesifieke data, soos byvoorbeeld name of gewigte, gekoppel.
+
+      '
+  es:
+    term: nodo
+    def: 'Un elemento de un grafo que está conectado a otros nodos por aristas.  Los
+      nodos usualmente tienen datos asociados con ellos, como nombres o pesos.
+
+      '
 - slug: non_blocking_execution
   en:
-    term: "non-blocking execution"
-    def: >
-      To allow a program to continue running while an operation is in progress. For
-      example, many systems support non-blocking execution for file I/O so that the
-      program can continue doing work while it waits for data to be read from or
-      written to the [filesystem](#filesystem) (which is typically much slower than
-      the CPU).
+    term: non-blocking execution
+    def: 'To allow a program to continue running while an operation is in progress.
+      For example, many systems support non-blocking execution for file I/O so that
+      the program can continue doing work while it waits for data to be read from
+      or written to the [filesystem](#filesystem) (which is typically much slower
+      than the CPU).
 
+      '
+- slug: nonparametric_statistics
+  ref:
+  - parametric_statistics
+  en:
+    term: non-parametric (statistics)
+    def: 'A branch of statistical tests which do not assume a known distribution of
+      the population which the samples were taken from (Kruskal-Wallis and Dunn test
+      are examples of non-parametric tests).
 
+      '
 - slug: normal_distribution
   en:
-    term: "normal distribution"
-    def: >
-      A continuous random distribution with a symmetric bell-curve shape. As datasets
+    term: normal distribution
+    def: 'A continuous random distribution with a symmetric bell-curve shape. As datasets
       get larger, some of their most important statistical properties can be modeled
       using a normal distribution.
 
-
+      '
 - slug: nosql_database
   en:
-    term: "NoSQL database"
-    def: >
-      Any database that does not use the [relational](#relational_database) model. The name comes from
-      the fact that such databases do not use [SQL](#sql) as a query language.
+    term: NoSQL database
+    def: 'Any database that does not use the [relational](#relational_database) model.
+      The name comes from the fact that such databases do not use [SQL](#sql) as a
+      query language.
+
+      '
   fr:
-    term: "base de données NoSQL"
-    def: >
-      Une base de données qui ne suit pas le modèle [relationnel](#relational_database), ainsi nommée car
-      n'utilisant en principe pas le langage de requête [SQL](#sql).
+    term: base de données NoSQL
+    def: 'Une base de données qui ne suit pas le modèle [relationnel](#relational_database),
+      ainsi nommée car n''utilisant en principe pas le langage de requête [SQL](#sql).
 
-
-- slug: "null"
+      '
+- slug: 'null'
   en:
-    term: "null"
-    def: >
-      A special value used to represent a missing object. Null is not the same as [NA](#na),
-      and neither is it the same as an [empty vector](#empty_vector).
+    term: 'null'
+    def: 'A special value used to represent a missing object. Null is not the same
+      as [NA](#na), and neither is it the same as an [empty vector](#empty_vector).
+
+      '
   fr:
-    term: "null"
-    def: >
-      Une valeur spéciale utilisée pour représenter l'absence de valeur. Null n'est pas équivalent à [NA](#na),
-      ni à un [vecteur vide](#empty_vector).
+    term: 'null'
+    def: 'Une valeur spéciale utilisée pour représenter l''absence de valeur. Null
+      n''est pas équivalent à [NA](#na), ni à un [vecteur vide](#empty_vector).
+
+      '
   af:
-    term: "nul"
-    def: >
-     'n Spesiale waarde wat gebruik word om 'n vermiste voorwerp voor te stel. Nul is nie dieselfde as [NA](#na) nie,
-     en dit is ook nie dieselfde as 'n [leë vektor](#empty_vector) nie.
+    term: nul
+    def: '''n Spesiale waarde wat gebruik word om ''n vermiste voorwerp voor te stel.
+      Nul is nie dieselfde as [NA](#na) nie, en dit is ook nie dieselfde as ''n [leë
+      vektor](#empty_vector) nie.
 
-
+      '
 - slug: null_hypothesis
   ref:
-    - p_value
+  - p_value
   en:
-    term: "null hypothesis"
-    def: >
-      The claim that any patterns seen in data are entirely due to chance. Other
-      claims (e.g., "X causes Y") must be much more likely than the null hypothesis in
-      order to be substantiated.
+    term: null hypothesis
+    def: 'The claim that any patterns seen in data are entirely due to chance. Other
+      claims (e.g., "X causes Y") must be much more likely than the null hypothesis
+      in order to be substantiated.
+
+      '
   pt:
-    term: "hipótese nula"
-    def: >
-      A afirmação de que quaisquer padrões observados nos dados foram gerados
+    term: hipótese nula
+    def: 'A afirmação de que quaisquer padrões observados nos dados foram gerados
       inteiramente ao acaso. Outras afirmações (por exemplo, "X causa Y") devem ser
       mais prováveis de acontecer do que a hipótese nula para que possam ser sustentadas.
 
-
+      '
 - slug: nullary_expression
   ref:
-    - binary_expression
-    - ternary_expression
-    - unary_expression
+  - binary_expression
+  - ternary_expression
+  - unary_expression
   en:
-    term: "nullary expression"
-    def: >
-      An "expression" with no arguments, such as the value 3.
+    term: nullary expression
+    def: 'An "expression" with no arguments, such as the value 3.
 
-
+      '
 - slug: numpy
   ref:
-    - python
+  - python
   en:
-    term: "numpy"
-    def: >
-      An open source Python package that works with arrays, vectors and matrices of dimension N,
-      in a comparable method and with a syntax similar at Matlab software. You can find functions and
-      sophisticated operations, focused in multidimensional arrays, linear algebra, Fourrier transform and
-      generation of random values.
+    term: numpy
+    def: 'An open source Python package that works with arrays, vectors and matrices
+      of dimension N, in a comparable method and with a syntax similar at Matlab software.
+      You can find functions and sophisticated operations, focused in multidimensional
+      arrays, linear algebra, Fourrier transform and generation of random values.
+
+      '
   es:
-    term: "numpy"
-    def: >
-      Es un paquete Python de código abierto que le permite trabajar con arreglos, vectores y matrices de
-      dimensión N, en un método comparable y con una sintaxis similar al software Matlab. Puede encontrar
-      funciones y operaciones sofisticadas, enfocadas en matrices multidimensionales, álgebra lineal,
-      transformada de Fourrier y generación de valores aleatorios.
+    term: numpy
+    def: 'Es un paquete Python de código abierto que le permite trabajar con arreglos,
+      vectores y matrices de dimensión N, en un método comparable y con una sintaxis
+      similar al software Matlab. Puede encontrar funciones y operaciones sofisticadas,
+      enfocadas en matrices multidimensionales, álgebra lineal, transformada de Fourrier
+      y generación de valores aleatorios.
+
+      '
   pt:
-    term: "numpy"
-    def: >
-      É um pacote Python de código aberto que permite trabalhar com arrays, vetores e matrizes de dimensão N,
-      em um método comparável e com uma sintaxe semelhante ao software Matlab. Você pode encontrar funções
-      e operações sofisticadas, focadas em arrays multidimensionais, álgebra linear, transformada de Fourrier
-      e geração de valores aleatórios.
+    term: numpy
+    def: 'É um pacote Python de código aberto que permite trabalhar com arrays, vetores
+      e matrizes de dimensão N, em um método comparável e com uma sintaxe semelhante
+      ao software Matlab. Você pode encontrar funções e operações sofisticadas, focadas
+      em arrays multidimensionais, álgebra linear, transformada de Fourrier e geração
+      de valores aleatórios.
 
-
+      '
 - slug: object
   en:
-    term: "object"
-    def: >
-      In [object-oriented programming](#oop), a structure that contains the data
-      for a specific instance of a [class](#class). The operations the object is
-      capable of are defined by the class's [methods](#method).
+    term: object
+    def: 'In [object-oriented programming](#oop), a structure that contains the data
+      for a specific instance of a [class](#class). The operations the object is capable
+      of are defined by the class''s [methods](#method).
+
+      '
   es:
-    term: "objeto"
-    def: >
-      En [programación orientada a objetos](#oop), es una estructura que contiene
-      los datos de una instancia específica de una [clase](#class). Las
-      operaciones que son capaces de realizar estos objetos están definidas
-      por los [métodos](#method) de la clase.
+    term: objeto
+    def: 'En [programación orientada a objetos](#oop), es una estructura que contiene
+      los datos de una instancia específica de una [clase](#class). Las operaciones
+      que son capaces de realizar estos objetos están definidas por los [métodos](#method)
+      de la clase.
 
-
+      '
 - slug: objective_function
   ref:
-    - gradient_descent
+  - gradient_descent
   en:
-    term: "objective function"
-    def: >
-      A function of one or more variables used to measure or compare the goodness of
-      different solutions in an optimization problem.
+    term: objective function
+    def: 'A function of one or more variables used to measure or compare the goodness
+      of different solutions in an optimization problem.
 
-
+      '
 - slug: observation
   en:
-    term: "observation"
-    def: >
-      A value or property of a specific member of a population.
+    term: observation
+    def: 'A value or property of a specific member of a population.
+
+      '
   fr:
-    term: "observation"
-    def: >
-      Une valeur ou une propriété associée à un membre spécifique d'une population.
+    term: observation
+    def: 'Une valeur ou une propriété associée à un membre spécifique d''une population.
 
-
+      '
 - slug: off_by_one_error
   en:
-    term: "off-by-one error"
-    def: >
-      A common error in programming in which the program refers to element `i` of a
-      structure when it should refer to element `i-1` or `i+1`, or processes `N`
-      elements when it should process `N-1` or `N+1`.
+    term: off-by-one error
+    def: 'A common error in programming in which the program refers to element `i`
+      of a structure when it should refer to element `i-1` or `i+1`, or processes
+      `N` elements when it should process `N-1` or `N+1`.
 
-
+      '
 - slug: oop
   en:
-    term: "object-oriented programming"
-    acronym: "OOP"
-    def: >
-      A style of programming in which functions and data are bound together in
-      [objects](#object) that only interact with each other through well-defined
-      interfaces.
-  es:
-    term: "programación orientada a objetos"
-    acronym: "POO"
-    def: >
-      Un paradigma de programación en el cual los datos (atributos) y funciones
-      (métodos) se agrupan en objetos que interactúan entre sí a través de
-      interfaces bien definidas.
-  pt:
-    term: "programação orientada a objetos"
-    acronym: "POO"
-    def: >
-      Um paradigma de programação no qual dados (atributos) e funções (métodos)
-      são encapsulados em objetos que interagem entre si por meio de
-      interfaces bem definidas.
-  uk:
-    term: "об'єктно-орієнтоване програмування"
-    acronym: "ООП"
-    def: >
-      Стиль програмування, в якому функції та дані об'єднуються разом в 
-      [об'єкти](#object), які взаємодіють між собою тільки через 
-      чітко визначені інтерфейси.
+    term: object-oriented programming
+    acronym: OOP
+    def: 'A style of programming in which functions and data are bound together in
+      [objects](#object) that only interact with each other through well-defined interfaces.
 
+      '
+  es:
+    term: programación orientada a objetos
+    acronym: POO
+    def: 'Un paradigma de programación en el cual los datos (atributos) y funciones
+      (métodos) se agrupan en objetos que interactúan entre sí a través de interfaces
+      bien definidas.
+
+      '
+  pt:
+    term: programação orientada a objetos
+    acronym: POO
+    def: 'Um paradigma de programação no qual dados (atributos) e funções (métodos)
+      são encapsulados em objetos que interagem entre si por meio de interfaces bem
+      definidas.
+
+      '
+  uk:
+    term: об'єктно-орієнтоване програмування
+    acronym: ООП
+    def: 'Стиль програмування, в якому функції та дані об''єднуються разом в  [об''єкти](#object),
+      які взаємодіють між собою тільки через  чітко визначені інтерфейси.
+
+      '
 - slug: open_license
   en:
-    term: "open license"
-    def: >
-      A [license](#license) that permits general re-use, such as the [MIT
-      License](#mit_license) or [GPL](#gpl) for software and [CC-BY](#cc_by) or
-      [CC-0](#cc_0) for data, prose, or other creative outputs.
-  es:
-    term: "licencia abierta"
-    def: >
-      Una [licencia](#license) que permite reuso en general, tal como la [Licencia MIT](#mit_license)
-      o [GPL](#gpl) para software y [CC-BY](#cc_by) o
-      [CC-0](#cc_0) para datos, prosas u otros productos creativos.
-  uk:
-    term: "відкрита ліцензія"
-    def: >
-      [Ліцензія](#license), що дозволяє загальне повторне використання творів,
-      наприклад, ліцензії [MIT](#mit_license), [GPL](#gpl) для програмного
-      забезпечення або [CC-BY](#cc_by), [CC-0](#cc_0) для даних чи будь-яких
-      творчих результатів, що виражені в матеріальній формі.
-      чи інших творчих результатів.
+    term: open license
+    def: 'A [license](#license) that permits general re-use, such as the [MIT License](#mit_license)
+      or [GPL](#gpl) for software and [CC-BY](#cc_by) or [CC-0](#cc_0) for data, prose,
+      or other creative outputs.
 
+      '
+  es:
+    term: licencia abierta
+    def: 'Una [licencia](#license) que permite reuso en general, tal como la [Licencia
+      MIT](#mit_license) o [GPL](#gpl) para software y [CC-BY](#cc_by) o [CC-0](#cc_0)
+      para datos, prosas u otros productos creativos.
+
+      '
+  uk:
+    term: відкрита ліцензія
+    def: '[Ліцензія](#license), що дозволяє загальне повторне використання творів,
+      наприклад, ліцензії [MIT](#mit_license), [GPL](#gpl) для програмного забезпечення
+      або [CC-BY](#cc_by), [CC-0](#cc_0) для даних чи будь-яких творчих результатів,
+      що виражені в матеріальній формі. чи інших творчих результатів.
+
+      '
 - slug: open_science
   en:
-    term: "open science"
-    def: >
-      A generic term for making scientific software, data, and publications generally available.
+    term: open science
+    def: 'A generic term for making scientific software, data, and publications generally
+      available.
+
+      '
   af:
-    term: "oop wetenskap"
-    def: >
-     'n Generiese term om wetenskaplike sagteware, data en publikasies toegangklik te maak.
+    term: oop wetenskap
+    def: '''n Generiese term om wetenskaplike sagteware, data en publikasies toegangklik
+      te maak.
+
+      '
   uk:
-    term: "відкрита наука"
-    def: >
-      Підхід до створення наукового програмного забезпечення, даних та публікацій, який 
-      забезпечує їх наявність у відкритому доступі.
-     
+    term: відкрита наука
+    def: 'Підхід до створення наукового програмного забезпечення, даних та публікацій,
+      який  забезпечує їх наявність у відкритому доступі.
+
+      '
 - slug: openrefine
   ref:
-    - tidy_data
+  - tidy_data
   en:
-    term: "OpenRefine"
-    def: >
-     A standalone, open source desktop application for data cleanup and transformations, also know as data wrangling.
+    term: OpenRefine
+    def: 'A standalone, open source desktop application for data cleanup and transformations,
+      also know as data wrangling.
 
-
+      '
 - slug: operating_system
   en:
-    term: "operating system"
-    def: >
-      A program that provides a standard interface to whatever hardware it is running
-      on. Theoretically, any program that only interacts with the operating system
-      should run on any computer that operating system runs on.
+    term: operating system
+    def: 'A program that provides a standard interface to whatever hardware it is
+      running on. Theoretically, any program that only interacts with the operating
+      system should run on any computer that operating system runs on.
+
+      '
   de:
-    term: "Betriebssystem"
-    def: >
-      Ein Programm, das eine Standard-Oberfläche zu der Hardware, auf der es läuft,
+    term: Betriebssystem
+    def: 'Ein Programm, das eine Standard-Oberfläche zu der Hardware, auf der es läuft,
       zur Verfügung stellt. Theoretisch sollte ein Programm, dass nur mit dem Betriebssystem
       interagiert, auf jedem Computer laufen, der dieses Betriebssystem nutzt
+
+      '
   ja:
-    term: "オペレーティングシステム"
-    def: >
-      動作させるハードウェアがどのようなものであっても標準的なインターフェイスを提供するプログラム。
-      理論的には、オペレーティングシステムとしかやりとりを行わないプログラムはどれでも、
+    term: オペレーティングシステム
+    def: '動作させるハードウェアがどのようなものであっても標準的なインターフェイスを提供するプログラム。 理論的には、オペレーティングシステムとしかやりとりを行わないプログラムはどれでも、
       そのオペレーティングシステムが搭載されているいかなるコンピューター上でも動作するはずである。
 
-
+      '
 - slug: optional_parameter
   en:
-    term: "optional_parameter"
-    def: >
-      A [parameter](#parameter) that does not have to be given a value when a function
-      is called. Most programming languages require programmers to define [default
-      values](#default_value) for optional parameters, or assign them a special value automatically.
-      Arguments passed to optional parameters will often be specified using [keyword
-      arguments](#keyword_argument).
+    term: optional_parameter
+    def: 'A [parameter](#parameter) that does not have to be given a value when a
+      function is called. Most programming languages require programmers to define
+      [default values](#default_value) for optional parameters, or assign them a special
+      value automatically. Arguments passed to optional parameters will often be specified
+      using [keyword arguments](#keyword_argument).
 
-
+      '
 - slug: orcid
   en:
-    term: "ORCID"
-    def: >
-      An Open Researcher and Contributor ID that uniquely and persistently identifies
-      an author of scholarly works. ORCIDs are for people what [DOIs](#doi) are for documents.
-  uk:
-    term: "ORCID (Open Researcher and Contributor ID)"
-    def: > 
-      Відкритий ідентифікатор
-      дослідника і співавтора, що унікально ідентифікує автора наукових праць. ORCID
-      для науковців є еквівалентом [DOI](#doi) для документів.
+    term: ORCID
+    def: 'An Open Researcher and Contributor ID that uniquely and persistently identifies
+      an author of scholarly works. ORCIDs are for people what [DOIs](#doi) are for
+      documents.
 
+      '
+  uk:
+    term: ORCID (Open Researcher and Contributor ID)
+    def: 'Відкритий ідентифікатор дослідника і співавтора, що унікально ідентифікує
+      автора наукових праць. ORCID для науковців є еквівалентом [DOI](#doi) для документів.
+
+      '
 - slug: orthogonality
   en:
-    term: "orthogonality"
-    def: >
-      The ability to use various features of software in any order or combination. Orthogonal
-      systems tend to be easier to understand, since features can be combined without
-      worrying about unexpected interactions.
+    term: orthogonality
+    def: 'The ability to use various features of software in any order or combination.
+      Orthogonal systems tend to be easier to understand, since features can be combined
+      without worrying about unexpected interactions.
 
-
+      '
 - slug: outlier
   ref:
-    - overfitting
+  - overfitting
   en:
-    term: "outlier"
-    def: >
-      Extreme values that might be measurement or recording errors, or might actually
+    term: outlier
+    def: 'Extreme values that might be measurement or recording errors, or might actually
       be rare events. Outliers are sometimes ignored when doing statistics, or handled
       or visualized separately.
+
+      '
   af:
     term: uitskietter
-    def: >
-      Uiterste waardes wat moontlik meet- of opnamefoute kan wees, of wat werklik seldsame gebeurtenisse kan wees. Uitstekers word soms geïgnoreer wanneer statistiek gedoen word, of afsonderlik hanteer of gevisualiseer.
+    def: 'Uiterste waardes wat moontlik meet- of opnamefoute kan wees, of wat werklik
+      seldsame gebeurtenisse kan wees. Uitstekers word soms geïgnoreer wanneer statistiek
+      gedoen word, of afsonderlik hanteer of gevisualiseer.
 
-
+      '
 - slug: overfitting
   ref:
-    - outlier
+  - outlier
   en:
-    term: "overfitting"
-    def: >
-      Fitting a [model](#model) so closely to one dataset that it does not generalize
+    term: overfitting
+    def: 'Fitting a [model](#model) so closely to one dataset that it does not generalize
       to others.
 
-
+      '
 - slug: p_value
   en:
-    term: "p value"
-    def: >
-      The probability of obtaining a result at least as strong as the one observed if
-      the [null_hypothesis](#null_hypothesis) is [true](#true) (i.e., if variation is purely
-      due to chance). The lower the p-value, the more likely it is that something
-      other than chance is having an effect.
+    term: p value
+    def: 'The probability of obtaining a result at least as strong as the one observed
+      if the [null_hypothesis](#null_hypothesis) is [true](#true) (i.e., if variation
+      is purely due to chance). The lower the p-value, the more likely it is that
+      something other than chance is having an effect.
 
-
+      '
 - slug: package
   en:
-    term: "package"
-    def: >
-      A collection of code, data, and documentation that can be distributed and
+    term: package
+    def: 'A collection of code, data, and documentation that can be distributed and
       re-used. Also referred to in some languages as a [library](#library) or [module](#module).
+
+      '
   fr:
-    term: "paquet (logiciel)"
-    def: >
-      Un ensemble de code, données et documentation qui peut être distribué et réutilisé.
-      Est aussi appelé [bibliothèque](#library) ou [module](#module) dans certains langages.
+    term: paquet (logiciel)
+    def: 'Un ensemble de code, données et documentation qui peut être distribué et
+      réutilisé. Est aussi appelé [bibliothèque](#library) ou [module](#module) dans
+      certains langages.
+
+      '
   ja:
-    term: "パッケージ"
-    def: >
-      配布や再利用が可能なコード、データおよびソフトウェアドキュメンテーションの集合体。
-      プログラミング言語によっては、「[ライブラリー](#library)」や「[モジュール](#module)」と呼ぶこともある。
+    term: パッケージ
+    def: '配布や再利用が可能なコード、データおよびソフトウェアドキュメンテーションの集合体。 プログラミング言語によっては、「[ライブラリー](#library)」や「[モジュール](#module)」と呼ぶこともある。
 
-
+      '
 - slug: package_manager
   en:
-    term: "package manager"
-    def: >
-      A program that does its best to keep track of the different software
-      installed on a computer and their dependencies on one another.
+    term: package manager
+    def: 'A program that does its best to keep track of the different software installed
+      on a computer and their dependencies on one another.
 
-
+      '
 - slug: pager
   en:
-    term: "pager"
-    def: >
-      A program that displays a few lines of text at a time.
+    term: pager
+    def: 'A program that displays a few lines of text at a time.
 
+      '
 - slug: pandas
   ref:
-    - python
+  - python
   en:
-    term: "pandas"
-    def: >
-      An open source Python package that offers fast, flexible, and expressive data
-      structures to make working with structured data, and time series easy and intuitive. It is
-      a powerful tool for data analysis and data manipulation.
-  es:
-    term: "pandas"
-    def: >
-      Es un paquete de Python de código abierto que ofrece estructuras de datos rápidas,
-      flexibles y expresivas para que trabajar con series de tiempo estructuradas sea fácil
-      e intuitivo. Se utiliza como una poderosa herramienta para el análisis y la manipulación
-      de datos.
-  pt:
-    term: "pandas"
-    def: >
-      É um pacote Python de código aberto que oferece estruturas de dados rápidas, flexíveis
-      e expressivas para tornar o trabalho com dados estruturados e séries temporais fácil e
-      intuitivo. É usado como uma ferramenta poderosa para análise e manipulação de dados.
-  uk:
-    term: "pandas"
-    def: >
-      Бібліотека з відкритим вихідним кодом для мови Python, призначена для обробки та аналізу даних. 
-      Вона надає такі структури даних, як Series та DataFrame. 
-      Series представляє собою одновимірний масив (список) з індексами, а DataFrame — двовимірну таблицю, 
-      подібну до електронної таблиці або бази даних, з рядками та стовпцями.
-      Ця бібліотека дозволяє легко та інтуїтивно працювати зі структурованими даними та часовими рядами.
+    term: pandas
+    def: 'An open source Python package that offers fast, flexible, and expressive
+      data structures to make working with structured data, and time series easy and
+      intuitive. It is a powerful tool for data analysis and data manipulation.
 
+      '
+  es:
+    term: pandas
+    def: 'Es un paquete de Python de código abierto que ofrece estructuras de datos
+      rápidas, flexibles y expresivas para que trabajar con series de tiempo estructuradas
+      sea fácil e intuitivo. Se utiliza como una poderosa herramienta para el análisis
+      y la manipulación de datos.
+
+      '
+  pt:
+    term: pandas
+    def: 'É um pacote Python de código aberto que oferece estruturas de dados rápidas,
+      flexíveis e expressivas para tornar o trabalho com dados estruturados e séries
+      temporais fácil e intuitivo. É usado como uma ferramenta poderosa para análise
+      e manipulação de dados.
+
+      '
+  uk:
+    term: pandas
+    def: 'Бібліотека з відкритим вихідним кодом для мови Python, призначена для обробки
+      та аналізу даних.  Вона надає такі структури даних, як Series та DataFrame.  Series
+      представляє собою одновимірний масив (список) з індексами, а DataFrame — двовимірну
+      таблицю,  подібну до електронної таблиці або бази даних, з рядками та стовпцями.
+      Ця бібліотека дозволяє легко та інтуїтивно працювати зі структурованими даними
+      та часовими рядами.
+
+      '
 - slug: parameter
   en:
-    term: "parameter"
-    def: >
-      A variable specified in a function definition whose value is passed to the function
-      when the function is called. Parameters and arguments are distinct, but related concepts.
-      Parameters are variables and [arguments](#argument) are the values assigned to those variables.
-  fr:
-    term: "paramètre"
-    def: >
-      Une variable spécifiée dans la définition d'une fonction, dont la valeur est passée à
-      la fonction lorsque celle-ci est appelée.
-      À ne pas confondre avec le terme [argument](#argument). Un paramètre est une variable,
-      un argument est une valeur assignée à cette variable.
-  de:
-    term: "Parameter"
-    def: >
-      Die Parameter sind die Namen der Eingangswerte einer Funktion, welche beim Aufruf übergeben
-      werden. Parameter und Argumente sind verwandt aber nicht identisch. Ein Parameter ist eine
-      Variable und ein [Argument](#argument) ist dem der Variable zugewiesene Wert.
-  pt:
-    term: "parâmetro"
-    def: >
-      Uma variável especificada na definição de uma função, cujo valor é passado para a função quando
-      ela é invocada. O parâmetro é a variável, enquanto seu valor dentro da função é
-      um [argumento](#argument). Parâmetro e argumento são termos relacionados, mas diferentes.
-  uk:
-    term: "параметр"
-    def: >
-      Змінна, визначена в оголошенні функції та значення якої функція отримає під час її виклику.
-      Параметри та [аргументи](#argument) — це різні, але пов'язані поняття. Параметри — це змінні,
-      а аргументи — це значення, які призначаються цим змінним.
+    term: parameter
+    def: 'A variable specified in a function definition whose value is passed to the
+      function when the function is called. Parameters and arguments are distinct,
+      but related concepts. Parameters are variables and [arguments](#argument) are
+      the values assigned to those variables.
 
+      '
+  fr:
+    term: paramètre
+    def: 'Une variable spécifiée dans la définition d''une fonction, dont la valeur
+      est passée à la fonction lorsque celle-ci est appelée. À ne pas confondre avec
+      le terme [argument](#argument). Un paramètre est une variable, un argument est
+      une valeur assignée à cette variable.
+
+      '
+  de:
+    term: Parameter
+    def: 'Die Parameter sind die Namen der Eingangswerte einer Funktion, welche beim
+      Aufruf übergeben werden. Parameter und Argumente sind verwandt aber nicht identisch.
+      Ein Parameter ist eine Variable und ein [Argument](#argument) ist dem der Variable
+      zugewiesene Wert.
+
+      '
+  pt:
+    term: parâmetro
+    def: 'Uma variável especificada na definição de uma função, cujo valor é passado
+      para a função quando ela é invocada. O parâmetro é a variável, enquanto seu
+      valor dentro da função é um [argumento](#argument). Parâmetro e argumento são
+      termos relacionados, mas diferentes.
+
+      '
+  uk:
+    term: параметр
+    def: 'Змінна, визначена в оголошенні функції та значення якої функція отримає
+      під час її виклику. Параметри та [аргументи](#argument) — це різні, але пов''язані
+      поняття. Параметри — це змінні, а аргументи — це значення, які призначаються
+      цим змінним.
+
+      '
+- slug: parametric_statistics
+  ref:
+  - nonparametric_statistics
+  en:
+    term: parametric (statistics)
+    def: 'A branch of statistical tests which assume a known distribution of the population
+      which the samples were taken from (ANOVA and Student’s t-tests are examples
+      of parametric tests).
+
+      '
 - slug: parent_class
   en:
-    term: "parent class"
-    def: >
-      In [object-oriented programming](#oop), the [class](#class) from which a sub
-      class (called the [child class](#child_class)) is derived.
-  es:
-    term: "superclase"
-    def: >
-      En [programación orientada a objetos](#oop), es la clase a partir de
-      la cual se derivan otras clases (denominadas [subclases](#child_class)).
-  pt:
-    term: "classe base"
-    def: >
-      Em [programação orientada a objetos](#oop), a classe a partir da qual outra
-      classe (chamada [classe derivada](#child_class)) é produzida.
-  uk:
-    term: "базовий клас"
-    def: >
-      У [об'єктно-орієнтованому програмуванні](#oop) клас, від якого походить [дочірній клас](#child_class).
+    term: parent class
+    def: 'In [object-oriented programming](#oop), the [class](#class) from which a
+      sub class (called the [child class](#child_class)) is derived.
 
+      '
+  es:
+    term: superclase
+    def: 'En [programación orientada a objetos](#oop), es la clase a partir de la
+      cual se derivan otras clases (denominadas [subclases](#child_class)).
+
+      '
+  pt:
+    term: classe base
+    def: 'Em [programação orientada a objetos](#oop), a classe a partir da qual outra
+      classe (chamada [classe derivada](#child_class)) é produzida.
+
+      '
+  uk:
+    term: базовий клас
+    def: 'У [об''єктно-орієнтованому програмуванні](#oop) клас, від якого походить
+      [дочірній клас](#child_class).
+
+      '
 - slug: parent_directory
   ref:
-    - subdirectory
+  - subdirectory
   en:
-    term: "parent directory"
-    def: >
-      The [directory](#directory) that contains another directory of interest. Going from a
-      directory to its parent, then its parent, and so on eventually leads to the
-      [root directory](#root_directory) of the [filesystem](#filesystem).
+    term: parent directory
+    def: 'The [directory](#directory) that contains another directory of interest.
+      Going from a directory to its parent, then its parent, and so on eventually
+      leads to the [root directory](#root_directory) of the [filesystem](#filesystem).
 
-
+      '
 - slug: parent_tree
   en:
-    term: "parent (in a tree)"
-    def: >
-      A [node](#node) in a [tree](#node) that is above another node (call a
-      [child](#child_tree)). Every node in a tree except the [root node](#root_tree)
-      has a single parent.
+    term: parent (in a tree)
+    def: 'A [node](#node) in a [tree](#node) that is above another node (call a [child](#child_tree)).
+      Every node in a tree except the [root node](#root_tree) has a single parent.
 
-
+      '
 - slug: parse
   en:
-    term: "parse"
-    def: >
-      To translate the text of a program or web page into a data structure in memory
-      that the program can then manipulate.
+    term: parse
+    def: 'To translate the text of a program or web page into a data structure in
+      memory that the program can then manipulate.
 
-
+      '
 - slug: pass_test
   ref:
-    - fail_test
+  - fail_test
   en:
-    term: "pass (a test)"
-    def: >
-      A test passes if the [actual result](#actual_result) matches the [expected result](#expected_result).
-  es:
-    term: "pasar (una prueba)"
-    def: >
-      Una prueba pasa si el [resultado real](#actual_result) coincide con el [resultado esperado](#expected_result).
+    term: pass (a test)
+    def: 'A test passes if the [actual result](#actual_result) matches the [expected
+      result](#expected_result).
 
+      '
+  es:
+    term: pasar (una prueba)
+    def: 'Una prueba pasa si el [resultado real](#actual_result) coincide con el [resultado
+      esperado](#expected_result).
+
+      '
 - slug: patch
   en:
-    term: "patch"
-    def: >
-      A single file containing a set of changes to a set of files, separated by markers
-      that indicate where each individual change should be applied.
+    term: patch
+    def: 'A single file containing a set of changes to a set of files, separated by
+      markers that indicate where each individual change should be applied.
 
-
+      '
 - slug: path
   ref:
-    - absolute_path
-    - relative_path
+  - absolute_path
+  - relative_path
   en:
-    term: "path (in filesystem)"
-    def: >
-      A [string](#string) that specifies a location in a [filesystem](#filesystem). In Unix, the
-      [directories](#directory) in a path are joined using `/`.
+    term: path (in filesystem)
+    def: 'A [string](#string) that specifies a location in a [filesystem](#filesystem).
+      In Unix, the [directories](#directory) in a path are joined using `/`.
 
-
+      '
 - slug: pattern_rule
   en:
-    term: "pattern rule"
-    def: >
-      A generic [build rule](#build_rule) that describes how to update any file whose
-      name matches a pattern. Pattern rules often use [automatic
-      variables](#automatic_variable) to represent the actual filenames.
+    term: pattern rule
+    def: 'A generic [build rule](#build_rule) that describes how to update any file
+      whose name matches a pattern. Pattern rules often use [automatic variables](#automatic_variable)
+      to represent the actual filenames.
 
+      '
+- slug: pca
+  ref:
+  - dimensionality_reduction
+  - machine_learning
+  en:
+    term: Principal Component Analysis
+    acronym: PCA
+    def: 'A statistical technique for [dimensionality reduction](#dimension_reduction)
+      that transforms data into a new coordinate system where the greatest variance
+      lies on the first coordinate (principal component), the second greatest on the
+      second coordinate, and so on.
 
+      '
 - slug: peanuts
   en:
-    term: "Peanuts"
-    def: >
-      An American comic strip by Charles M. Schulz which has inspired the names of [R](#r_language) versions.
+    term: Peanuts
+    def: 'An American comic strip by Charles M. Schulz which has inspired the names
+      of [R](#r_language) versions.
 
-
+      '
 - slug: perceptron
   en:
-    term: "perceptron"
-    def: >
-      The simplest kind of [neural network])(#neural_network), which approximates a
-      single neuron with _N_ binary inputs by computing a weighted sum of its inputs and
-      firing if that value is zero or greater.
+    term: perceptron
+    def: 'The simplest kind of [neural network])(#neural_network), which approximates
+      a single neuron with _N_ binary inputs by computing a weighted sum of its inputs
+      and firing if that value is zero or greater.
+
+      '
   es:
-    term: "perceptrón"
-    def: >
-      El tipo más simple de [red neuronal](#neural_network), que aproxima una sola neurona 
-      con _N_ entradas binarias al calcular una suma ponderada de sus entradas, y se activa 
-      si dicho valor es mayor o igual a cero.
+    term: perceptrón
+    def: 'El tipo más simple de [red neuronal](#neural_network), que aproxima una
+      sola neurona  con _N_ entradas binarias al calcular una suma ponderada de sus
+      entradas, y se activa  si dicho valor es mayor o igual a cero.
 
-
+      '
 - slug: permalink
   en:
-    term: "permalink"
-    def: >
-      Short for "permanent link", a URL that is intended to last forever.
+    term: permalink
+    def: 'Short for "permanent link", a URL that is intended to last forever.
+
+      '
   es:
-    term: "permalink"
-    def: >
-      Abreviatura de "enlace permanente", una URL que se pretende que dure para siempre.
+    term: permalink
+    def: 'Abreviatura de "enlace permanente", una URL que se pretende que dure para
+      siempre.
 
-
+      '
 - slug: phony_target
   en:
-    term: "phony target"
-    def: >
-      A [build target](#build_target) that does not correspond to an actual file.
+    term: phony target
+    def: 'A [build target](#build_target) that does not correspond to an actual file.
       Phony targets are often used to store commonly used commands in a [Makefile](#makefile).
 
-
+      '
 - slug: pip
   ref:
-    - pypi
+  - pypi
   en:
-    term: "Pip Install Packages"
-    acronym: "PIP"
-    def: >
-      The standard [package manager](#package_manager) for [Python](#python). pip enables
-      the download and installation of Python packages not included in the standard library.
+    term: Pip Install Packages
+    acronym: PIP
+    def: 'The standard [package manager](#package_manager) for [Python](#python).
+      pip enables the download and installation of Python packages not included in
+      the standard library.
 
-
+      '
 - slug: pipe_operator
   en:
-    term: "pipe operator"
-    def: >
-      The `%>%` used to make the output of one function the input of the next.
+    term: pipe operator
+    def: 'The `%>%` used to make the output of one function the input of the next.
 
-
+      '
 - slug: pipe_shell
   en:
-    term: "pipe (in the Unix shell)"
-    def: >
-      The `|` used to make the output of one command the input of the next.
+    term: pipe (in the Unix shell)
+    def: 'The `|` used to make the output of one command the input of the next.
 
-
+      '
 - slug: pivot_table
   en:
-    term: "pivot table"
-    def: >
-      A technique for summarizing tabular data in which each cell represents the sum,
-      average, or other function of the subset of the original data identified by the
-      cell's row and column heading.
+    term: pivot table
+    def: 'A technique for summarizing tabular data in which each cell represents the
+      sum, average, or other function of the subset of the original data identified
+      by the cell''s row and column heading.
 
-
+      '
 - slug: plus_one
   de:
-    term: "+1"
-    def: >
-      Eine Zustimmung zu etwas.
-  en:
-    term: "+1"
-    def: >
-      A vote in favor of something.
-  fr:
-    term: "+1"
-    def: >
-      Un vote en faveur de quelque chose.
-  es:
-    term: "+1"
-    def: >
-      Un voto a favor de alguna cosa.
-  af:
-    term: "+1"
-    def: >
-      Om ten gunste van iets te stem.
+    term: '+1'
+    def: 'Eine Zustimmung zu etwas.
 
+      '
+  en:
+    term: '+1'
+    def: 'A vote in favor of something.
+
+      '
+  fr:
+    term: '+1'
+    def: 'Un vote en faveur de quelque chose.
+
+      '
+  es:
+    term: '+1'
+    def: 'Un voto a favor de alguna cosa.
+
+      '
+  af:
+    term: '+1'
+    def: 'Om ten gunste van iets te stem.
+
+      '
 - slug: pointcloud
   en:
-    term: "pointcloud"
-    def: >
-      A set of discrete data points in three-dimensional space.
+    term: pointcloud
+    def: 'A set of discrete data points in three-dimensional space.
 
+      '
 - slug: poisson_distribution
   en:
-    term: "Poisson distribution"
-    def: >
-      A [discrete random distribution](#discrete_random_variable) that expresses the
-      probability of $N$ events occurring in a fixed time interval if the events occur
-      at a constant rate, independent of the time since the last event.
+    term: Poisson distribution
+    def: 'A [discrete random distribution](#discrete_random_variable) that expresses
+      the probability of $N$ events occurring in a fixed time interval if the events
+      occur at a constant rate, independent of the time since the last event.
 
-
-- slug: positional_argument
-  ref:
-    - keyword_argument
-    - named_argument
-  en:
-    term: "positional argument"
-    def: >
-      An argument to a function that gets its value according to its place in the
-      function's definition, as opposed to a named argument that is
-      explicitly matched by name.
-
-
-- slug: posterior_distribution
-  ref:
-    - bayes_theorem
-  en:
-    term: "posterior distribution"
-    def: >
-      Probability distribution summarizing the [prior distribution](#prior_distribution) and the likelihood function.
-
-
+      '
 - slug: pop
   ref:
-    - imap
-    - smtp
+  - imap
+  - smtp
   en:
-    term: "Post Office Protocol"
-    acronym: "POP"
-    def: >
-      A standard internet protocol used by email clients to retrieve messages from an email server.
-      Messages are generally downloaded and deleted from the server, making it difficult to access
-      messages from multiple email clients. POP3 (version 3) is the version of POP in common use.
+    term: Post Office Protocol
+    acronym: POP
+    def: 'A standard internet protocol used by email clients to retrieve messages
+      from an email server. Messages are generally downloaded and deleted from the
+      server, making it difficult to access messages from multiple email clients.
+      POP3 (version 3) is the version of POP in common use.
 
+      '
+- slug: positional_argument
+  ref:
+  - keyword_argument
+  - named_argument
+  en:
+    term: positional argument
+    def: 'An argument to a function that gets its value according to its place in
+      the function''s definition, as opposed to a named argument that is explicitly
+      matched by name.
 
+      '
+- slug: posterior_distribution
+  ref:
+  - bayes_theorem
+  en:
+    term: posterior distribution
+    def: 'Probability distribution summarizing the [prior distribution](#prior_distribution)
+      and the likelihood function.
+
+      '
 - slug: pothole_case
   ref:
-    - camel_case
-    - kebab_case
+  - camel_case
+  - kebab_case
   en:
-    term: "pothole case"
-    def: >
-      A naming style that separates the parts of a name with underscores, as in `first_second_third`.
+    term: pothole case
+    def: 'A naming style that separates the parts of a name with underscores, as in
+      `first_second_third`.
 
+      '
 - slug: preamble
   ref:
-    - latex
+  - latex
   en:
-    term: "preamble"
-    def: >
-      A series of commands, either placed in the main document, or kept in a separate document,
-      that are included prior to the \begin{document} command. The preamble defines the type of
-      the document, along with other formatting attributes and parameters. This is also the section
-      of the document where packages are added using the command \usepackage{} to enable
-      additional functionalities, and where custom commands can be defined.
+    term: preamble
+    def: 'A series of commands, either placed in the main document, or kept in a separate
+      document, that are included prior to the \begin{document} command. The preamble
+      defines the type of the document, along with other formatting attributes and
+      parameters. This is also the section of the document where packages are added
+      using the command \usepackage{} to enable additional functionalities, and where
+      custom commands can be defined.
 
+      '
+- slug: precision
+  ref:
+  - recall
+  - f1_score
+  - classification
+  en:
+    term: precision
+    def: 'In [classification](#classification), the fraction of predicted positive
+      cases that are actually positive. Calculated as true positives / (true positives
+      + false positives). High precision means few false positives.
 
+      '
 - slug: prerequisite
   ref:
-    - dependency
+  - dependency
   en:
-    term: "prerequisite"
-    def: >
-      Something that a [build target](#build_target) depends on.
+    term: prerequisite
+    def: 'Something that a [build target](#build_target) depends on.
+
+      '
   uk:
-    term: "передумова"
-    def: >
-      Умова, від якої залежить [мета](#build_target) у [менеджері збірок](#build_manager).
+    term: передумова
+    def: 'Умова, від якої залежить [мета](#build_target) у [менеджері збірок](#build_manager).
 
-
+      '
 - slug: principal_component_analysis
   ref:
-    - dimension_reduction
+  - dimension_reduction
   en:
-    term: "principal component analysis"
-    acronym: "PCA"
-    def: >
-      An algorithm that find the axis along which data varies most, then the axis that
-      accounts for the largest part of the remaining variation, and so on.
+    term: principal component analysis
+    acronym: PCA
+    def: 'An algorithm that find the axis along which data varies most, then the axis
+      that accounts for the largest part of the remaining variation, and so on.
 
-
+      '
 - slug: prior_distribution
   en:
-    term: "prior distribution"
-    def: >
-      The [probability distribution](#probability_distribution) that is assumed as a
-      starting point when using [Bayes' Theorem](#bayes_theorem) and used to construct
-      a more accurate [posterior_distribution](#posterior_distribution).
+    term: prior distribution
+    def: 'The [probability distribution](#probability_distribution) that is assumed
+      as a starting point when using [Bayes'' Theorem](#bayes_theorem) and used to
+      construct a more accurate [posterior_distribution](#posterior_distribution).
 
-
+      '
 - slug: prng
   ref:
-    - seed
+  - seed
   en:
-    term: "pseudo-random number generator"
-    acronym: "PRNG"
-    def: >
-      A function that can generate [pseudo-random numbers](#pseudo_random_number).
+    term: pseudo-random number generator
+    acronym: PRNG
+    def: 'A function that can generate [pseudo-random numbers](#pseudo_random_number).
+
+      '
   af:
-    term: "pseudolukrakenommergenereerder"
-    acronym: "PLNG"
-    def: >
-      'n Funksie wat [pseudo- lukrake nommers](#pseudo_random_number) kan genereer.
+    term: pseudolukrakenommergenereerder
+    acronym: PLNG
+    def: '''n Funksie wat [pseudo- lukrake nommers](#pseudo_random_number) kan genereer.
 
+      '
+- slug: probability
+  ref:
+  - statistics
+  - bayesian_statistics
+  en:
+    term: probability
+    def: 'A measure of the likelihood that an event will occur, expressed as a number
+      between 0 (impossible) and 1 (certain). The foundation of statistical inference
+      and [Bayesian statistics](#bayesian_statistics).
 
+      '
 - slug: probability_distribution
   en:
-    term: "probability distribution"
-    def: >
-      A mathematical description of all possible outcomes of a random event, and the
-      probability of each occurring.
+    term: probability distribution
+    def: 'A mathematical description of all possible outcomes of a random event, and
+      the probability of each occurring.
 
-
+      '
 - slug: procedural_generation
   en:
-    term: "procedural generation"
-    def: >
-      A method of generating data algorithmically rather than manually. Typically
-      this is done to reduce file sizes, increase the overall amount of content, and/or incorporate
-      randomness at the expense of processing power.
+    term: procedural generation
+    def: 'A method of generating data algorithmically rather than manually. Typically
+      this is done to reduce file sizes, increase the overall amount of content, and/or
+      incorporate randomness at the expense of processing power.
 
-
+      '
 - slug: procedural_programming
   en:
-    term: "procedural programming"
-    def: >
-      A style of programming in which functions operate on data that is passed into
-      them. The term is used in contrast to other programming styles, such as
+    term: procedural programming
+    def: 'A style of programming in which functions operate on data that is passed
+      into them. The term is used in contrast to other programming styles, such as
       [object-oriented programming](#oop) and [functional programming](#functional_programming).
 
-
+      '
 - slug: process
   en:
-    term: "process"
-    def: >
-      An [operating system](#operating_system)'s representation of a running program.
-      A process typically has some memory, the identity of the user who is running it,
-      and a set of connections to open files.
+    term: process
+    def: 'An [operating system](#operating_system)''s representation of a running
+      program. A process typically has some memory, the identity of the user who is
+      running it, and a set of connections to open files.
 
-
+      '
 - slug: product_manager
   en:
-    term: "product manager"
-    def: >
-      The person responsible for defining what features a product should have.
+    term: product manager
+    def: 'The person responsible for defining what features a product should have.
 
-
+      '
 - slug: production_code
   en:
-    term: "production code"
-    def: >
-      Software that is delivered to an end user. The term is used to distinguish such
-      code from test code, deployment infrastructure, and everything else that
+    term: production code
+    def: 'Software that is delivered to an end user. The term is used to distinguish
+      such code from test code, deployment infrastructure, and everything else that
       programmers write along the way.
 
+      '
 - slug: profiling
   en:
-    term: "profiling"
-    def: >
-      The process of measuring where run time is spent in the code (e.g. in which function or associated with which line number).
-      Memory profiling looks at the amount of data moved from and to memory. 
-
-
+    term: profiling
+    def: "The process of measuring where run time is spent in the code (e.g. in which\
+      \ function or associated with which line number). Memory profiling looks at\
+      \ the amount of data moved from and to memory. \n"
 - slug: project_manager
   en:
-    term: "project manager"
-    def: >
-      The person responsible for ensuring that a project moves forward.
+    term: project manager
+    def: 'The person responsible for ensuring that a project moves forward.
 
-
+      '
 - slug: prompt
   ref:
-    - continuation_prompt
+  - continuation_prompt
   en:
-    term: "prompt"
-    def: >
-      The text printed by an [REPL](#repl) or [shell](#shell) that indicates it is
-      ready to accept another command. The default prompt in the Unix shell is usually
-      `$`, while in [Python](#python) it is `>>>`, and in [R](#r_language) it is `>`.
+    term: prompt
+    def: 'The text printed by an [REPL](#repl) or [shell](#shell) that indicates it
+      is ready to accept another command. The default prompt in the Unix shell is
+      usually `$`, while in [Python](#python) it is `>>>`, and in [R](#r_language)
+      it is `>`.
 
-
+      '
 - slug: protocol
   en:
-    term: "protocol"
-    def: >
-      Any standard specifying how two pieces of software interact. A network protocol
-      such as [HTTP](#http) defines the messages that [clients](#client) and
-      [servers](#server) exchange on the World-Wide Web; [object-oriented](#oop)
-      programs often define protocols for interactions between [objects](#object) of
-      different [classes](#class).
+    term: protocol
+    def: 'Any standard specifying how two pieces of software interact. A network protocol
+      such as [HTTP](#http) defines the messages that [clients](#client) and [servers](#server)
+      exchange on the World-Wide Web; [object-oriented](#oop) programs often define
+      protocols for interactions between [objects](#object) of different [classes](#class).
 
-
+      '
 - slug: provenance
   en:
-    term: "provenance"
-    def: >
-      A record of where data originally came from and what was done to process it.
+    term: provenance
+    def: 'A record of where data originally came from and what was done to process
+      it.
 
-
+      '
 - slug: pseudo_random_number
   en:
-    term: "pseudo-random number"
-    def: >
-      A value generated in a repeatable way that resembles the [true](#true) randomness of the
-      universe well enough to fool observers.
+    term: pseudo-random number
+    def: 'A value generated in a repeatable way that resembles the [true](#true) randomness
+      of the universe well enough to fool observers.
+
+      '
   es:
-    term: "número pseudo-aleatorio"
-    def: >
-      Un valor generado de forma repetible que refleja suficientemente bien a la
-      verdadera aleatoriedad del universo como para engañar a simples observadores mortales.
+    term: número pseudo-aleatorio
+    def: 'Un valor generado de forma repetible que refleja suficientemente bien a
+      la verdadera aleatoriedad del universo como para engañar a simples observadores
+      mortales.
+
+      '
   af:
-    term: "pseudo- lukrake nommer"
-    def: >
-      'n Waarde wat op so 'n wyse gegenereer is dat dit lyk op die [ware](#true) lukraakheid van die heelal, tot so 'n mate dat dit waarnemers fop.
+    term: pseudo- lukrake nommer
+    def: '''n Waarde wat op so ''n wyse gegenereer is dat dit lyk op die [ware](#true)
+      lukraakheid van die heelal, tot so ''n mate dat dit waarnemers fop.
 
-
+      '
 - slug: psf
   en:
-    term: "Python Software Foundation"
-    acronym: "PSF"
-    def: >
-      A non-profit organization that oversees and promotes the development and use of [Python](#python).
+    term: Python Software Foundation
+    acronym: PSF
+    def: 'A non-profit organization that oversees and promotes the development and
+      use of [Python](#python).
 
-
+      '
 - slug: pull_indexing
   ref:
-    - push_indexing
+  - push_indexing
   en:
-    term: "pull indexing"
-    def: >
-      Vectorized indexing in which the value at location `i` in the index [vector](#vector)
-      specifies which [element](#element) of the source vector is being pulled into that location
-      in the result vector, i.e., `result[i] = source[index[i]]`.
+    term: pull indexing
+    def: 'Vectorized indexing in which the value at location `i` in the index [vector](#vector)
+      specifies which [element](#element) of the source vector is being pulled into
+      that location in the result vector, i.e., `result[i] = source[index[i]]`.
 
-
+      '
 - slug: pull_request
   en:
-    term: "pull request"
-    def: >
-      The request to merge a new feature or correction created on a user's [fork](#fork) of a
-      [Git](#git) [repository](#repository) into the [upstream repository](#upstream_repository).
-      The developer will be notified of the change, review it, make or suggest changes, and potentially
-      [merge](#git_merge) it.
+    term: pull request
+    def: 'The request to merge a new feature or correction created on a user''s [fork](#fork)
+      of a [Git](#git) [repository](#repository) into the [upstream repository](#upstream_repository).
+      The developer will be notified of the change, review it, make or suggest changes,
+      and potentially [merge](#git_merge) it.
 
-
+      '
 - slug: push_indexing
   ref:
-    - pull_indexing
+  - pull_indexing
   en:
-    term: "push indexing"
-    def: >
-      Vectorized indexing in which the value at location `i` in the index [vector](#vector)
-      specifies an [element](#element) of the result vector that gets the corresponding element of
-      the source vector, i.e., `result[index[i]] = source[i]`. Push indexing can
-      easily produce gaps and collisions.
+    term: push indexing
+    def: 'Vectorized indexing in which the value at location `i` in the index [vector](#vector)
+      specifies an [element](#element) of the result vector that gets the corresponding
+      element of the source vector, i.e., `result[index[i]] = source[i]`. Push indexing
+      can easily produce gaps and collisions.
 
-
+      '
 - slug: pypi
   ref:
-    - pip
+  - pip
   en:
-    term: "Python Package Index"
-    acronym: "PyPI"
-    def: >
-      The official third-party software repository for [Python](#python). Anyone can upload
-      a [package](#package) to PyPI. PyPI packages may install via executed scripts or
-      pre-compiled, system-specific wheels.
+    term: Python Package Index
+    acronym: PyPI
+    def: 'The official third-party software repository for [Python](#python). Anyone
+      can upload a [package](#package) to PyPI. PyPI packages may install via executed
+      scripts or pre-compiled, system-specific wheels.
 
-
+      '
 - slug: python
   en:
-    term: "Python"
-    def: >
-      A popular interpreted open-source programming language that relies on
-      indentation to define control structure.
+    term: Python
+    def: 'A popular interpreted open-source programming language that relies on indentation
+      to define control structure.
+
+      '
   es:
-    term: "Python"
-    def: >
-      Un lenguaje de programación de código abierto interpretado popular que
-      se basa en la sangría para definir la estructura de control.
+    term: Python
+    def: 'Un lenguaje de programación de código abierto interpretado popular que se
+      basa en la sangría para definir la estructura de control.
+
+      '
   fr:
-    term: "Python"
-    def: >
-      Un langage de programmation open-source interprété populaire qui utilise l'indentation pour
-      définir les structures de contrôle.
+    term: Python
+    def: 'Un langage de programmation open-source interprété populaire qui utilise
+      l''indentation pour définir les structures de contrôle.
+
+      '
   pt:
-    term: "Python"
-    def: >
-      Uma popular linguagem de programação interpretada, de código aberto,  que
+    term: Python
+    def: 'Uma popular linguagem de programação interpretada, de código aberto,  que
       depende de indentação para definir a estrutura de controle.
+
+      '
   it:
-    term: "Python"
-    def: >
-      Un linguaggio di programmazione open-source (pubblicamente accessibile), orientato a oggetti, interpretato (non necessita di compilazione) e
-      che utlizza l'indentazione per definire le strutture di controllo.
+    term: Python
+    def: 'Un linguaggio di programmazione open-source (pubblicamente accessibile),
+      orientato a oggetti, interpretato (non necessita di compilazione) e che utlizza
+      l''indentazione per definire le strutture di controllo.
 
-
+      '
 - slug: quantile
   en:
-    term: "quantile"
-    def: >
-      If a set of sorted values are divided into groups of each size, each group is
-      called a quantile. For example, if there are five groups, each is called a
-      *quintile*; the bottom quintile contains the lowest 20% of the values, while the
-      top quintile contains the highest 20%.
+    term: quantile
+    def: 'If a set of sorted values are divided into groups of each size, each group
+      is called a quantile. For example, if there are five groups, each is called
+      a *quintile*; the bottom quintile contains the lowest 20% of the values, while
+      the top quintile contains the highest 20%.
+
+      '
   uk:
-    term: "квантиль"
-    def: >
-      Квантиль - це загальний термін для значень, що ділять відсортований
-      набір даних на рівні частини. При поділі на чотири групи використовують
-      квартилі, на п’ять - квінтилі, на десять - децилі. Нижній квінтиль,
-      наприклад, містить найнижчі 20% значень.
+    term: квантиль
+    def: 'Квантиль - це загальний термін для значень, що ділять відсортований набір
+      даних на рівні частини. При поділі на чотири групи використовують квартилі,
+      на п’ять - квінтилі, на десять - децилі. Нижній квінтиль, наприклад, містить
+      найнижчі 20% значень.
+
+      '
 - slug: query_string
   en:
-    term: "query string"
-    def: >
-      The portion of a [URL](#url) after the question mark `?` that specifies extra
-      parameters for the [HTTP request](#http_request) as name-value pairs.
+    term: query string
+    def: 'The portion of a [URL](#url) after the question mark `?` that specifies
+      extra parameters for the [HTTP request](#http_request) as name-value pairs.
 
+      '
+- slug: queue
+  ref:
+  - data_structure
+  - stack
+  en:
+    term: queue
+    def: 'A data structure that follows the First-In-First-Out (FIFO) principle, where
+      elements are added at the back and removed from the front. Like a line of people
+      waiting for service.
 
+      '
 - slug: quosure
   en:
-    term: "quosure"
-    def: >
-      A data structure containing an unevaluated expression and its environment.
+    term: quosure
+    def: 'A data structure containing an unevaluated expression and its environment.
 
-
+      '
 - slug: quoting_function
   en:
-    term: "quoting function"
-    def: >
-      A function that is passed expressions rather than the values of those expressions.
+    term: quoting function
+    def: 'A function that is passed expressions rather than the values of those expressions.
 
-
+      '
 - slug: r_consortium
   en:
-    term: "R Consortium"
-    def: >
-      A group that supports the worldwide community of users, maintainers and
+    term: R Consortium
+    def: 'A group that supports the worldwide community of users, maintainers and
       developers of [R](#r_language). Its members include leading institutions and
       companies dedicated to the use, development, and growth of R.
 
-
+      '
 - slug: r_foundation
   en:
-    term: "R Foundation"
-    def: >
-      A non-profit founded by the R development core team providing support for [R](#r_language). It
-      is a member of the [R Consortium](#r_consortium).
+    term: R Foundation
+    def: 'A non-profit founded by the R development core team providing support for
+      [R](#r_language). It is a member of the [R Consortium](#r_consortium).
 
-
+      '
 - slug: r_hub
   en:
-    term: "R Hub"
-    def: >
-      A free platform available to check an [R](#r_language) [package](#package) on several different platforms
-      in preparation for the CRAN submission process.
+    term: R Hub
+    def: 'A free platform available to check an [R](#r_language) [package](#package)
+      on several different platforms in preparation for the CRAN submission process.
 
-
+      '
 - slug: r_language
   en:
-    term: "R (programming language)"
-    def: >
-      A popular open-source programming language used primarily for data science.
-  fr:
-    term: "R (langage de programmation)"
-    def: >
-      Un langage de programmation et logiciel libre principalement utilisé en statistique et en science des données.
-  pt:
-    term: "R (linguagem de programação)"
-    def: >
-      Uma linguagem de programação de código aberto usada principalmente para ciência de dados.
+    term: R (programming language)
+    def: 'A popular open-source programming language used primarily for data science.
 
+      '
+  fr:
+    term: R (langage de programmation)
+    def: 'Un langage de programmation et logiciel libre principalement utilisé en
+      statistique et en science des données.
+
+      '
+  pt:
+    term: R (linguagem de programação)
+    def: 'Uma linguagem de programação de código aberto usada principalmente para
+      ciência de dados.
+
+      '
 - slug: r_markdown
   ref:
-    - computational_notebook
-    - literate_programming
+  - computational_notebook
+  - literate_programming
   en:
-    term: "R Markdown"
-    def: >
-      A dialect of [Markdown](#markdown) that allows authors to mix prose and code (usually written in
-      [R](#r_language)) in a single document.
+    term: R Markdown
+    def: 'A dialect of [Markdown](#markdown) that allows authors to mix prose and
+      code (usually written in [R](#r_language)) in a single document.
+
+      '
   es:
-    term: "R Markdown"
-    def: >
-      Un dialecto de [Markdown](#markdown) que permite a sus autores mezclar prosa y
-      código (usualmente escrito en [R](#r_language)) en un mismo documento.
+    term: R Markdown
+    def: 'Un dialecto de [Markdown](#markdown) que permite a sus autores mezclar prosa
+      y código (usualmente escrito en [R](#r_language)) en un mismo documento.
+
+      '
   fr:
-    term: "R Markdown"
-    def: >
-      Un dialecte de [Markdown](#markdown) qui permet à ses auteurs de mélanger langage naturel et code
-      (habituellement écrit en langage [R](#r_language)) dans un même document.
+    term: R Markdown
+    def: 'Un dialecte de [Markdown](#markdown) qui permet à ses auteurs de mélanger
+      langage naturel et code (habituellement écrit en langage [R](#r_language)) dans
+      un même document.
 
-
+      '
 - slug: raise_exception
   ref:
-    - throw_exception
+  - throw_exception
   en:
-    term: "raise (an exception)"
-    def: >
-      To signal that something unexpected or unusual has happened in a program by
-      creating an [exception](#exception) and handing it to the [error-handling](#error_handling) system,
-      which then tries to find a point in the program that will
-      [catch](#catch_exception) it.
+    term: raise (an exception)
+    def: 'To signal that something unexpected or unusual has happened in a program
+      by creating an [exception](#exception) and handing it to the [error-handling](#error_handling)
+      system, which then tries to find a point in the program that will [catch](#catch_exception)
+      it.
 
-
+      '
 - slug: random_forests
   en:
-    term: "random forests"
-    def: >
-      An algorithm used for regression or [classification](#classification) that uses a collection of
-      [decision trees](#decision_tree), called a forest. Each tree votes for a classification, and the
-      algorithm chooses the classification having the most votes over all the trees in the forest.
+    term: random forests
+    def: 'An algorithm used for regression or [classification](#classification) that
+      uses a collection of [decision trees](#decision_tree), called a forest. Each
+      tree votes for a classification, and the algorithm chooses the classification
+      having the most votes over all the trees in the forest.
 
-
+      '
 - slug: raster_image
   en:
-    term: "raster image"
-    def: >
-      An image stored as a matrix of pixels.
+    term: raster image
+    def: 'An image stored as a matrix of pixels.
+
+      '
   es:
-    term: "imagen rasterizada"
-    def: >
-      Una imagen almacenada como una matriz de píxeles.
+    term: imagen rasterizada
+    def: 'Una imagen almacenada como una matriz de píxeles.
 
-
+      '
 - slug: reactive_programming
   en:
-    term: "reactive programming"
-    def: >
-      A style of programming in which actions are triggered by external events.
+    term: reactive programming
+    def: 'A style of programming in which actions are triggered by external events.
 
-
+      '
 - slug: reactive_variable
   en:
-    term: "reactive variable"
-    def: >
-      A variable whose value is automatically updated when some other value or values
-      change. Reactive variables are used extensively in [Shiny](#shiny).
+    term: reactive variable
+    def: 'A variable whose value is automatically updated when some other value or
+      values change. Reactive variables are used extensively in [Shiny](#shiny).
 
+      '
 - slug: readme
   ref:
-    - markdown
-    - vignette
+  - markdown
+  - vignette
   en:
-    term: "README"
-    def: >
-      A plain text file containing important information about a project or software package.
-  uk:
-    term: "README (прочитай мене)"
-    def: >
-      Файл у текстовому форматі, який містить важливу інформацію стосовно проєкту або пакета програмного забезпечення.
+    term: README
+    def: 'A plain text file containing important information about a project or software
+      package.
 
+      '
+  uk:
+    term: README (прочитай мене)
+    def: 'Файл у текстовому форматі, який містить важливу інформацію стосовно проєкту
+      або пакета програмного забезпечення.
+
+      '
+- slug: recall
+  ref:
+  - precision
+  - f1_score
+  - classification
+  en:
+    term: recall
+    def: 'In [classification](#classification), the fraction of actual positive cases
+      that were correctly identified. Calculated as true positives / (true positives
+      + false negatives). High recall means few false negatives. Also called sensitivity
+      or true positive rate.
+
+      '
 - slug: reciprocal
   en:
     term: reciprocal
-    def: >
-      The reciprocal of a number x is 1 / x, or alternatively x raised to the
+    def: 'The reciprocal of a number x is 1 / x, or alternatively x raised to the
       power of -1.
-  uk:
-    term: "обернене число"
-    def: >
-      Обернене число для числа x дорівнює 1 / x, або, еквівалентно, x в степені -1.
 
+      '
+  uk:
+    term: обернене число
+    def: 'Обернене число для числа x дорівнює 1 / x, або, еквівалентно, x в степені
+      -1.
+
+      '
 - slug: record
   en:
-    term: "record"
-    def: >
-      A group of related values that are stored together. A record may be represented
+    term: record
+    def: 'A group of related values that are stored together. A record may be represented
       as a [tuple](#tuple) or as a row in a [table](#table); in the latter case, every
       record in the table has the same [fields](#field).
+
+      '
   fr:
-    term: "entrée"
-    def: >
-      Un groupe de valeurs liées qui sont enregistrées ensemble. Une entrée peut être
-      représentée comme un [tuple](#tuple) ou une ligne dans une [table](#table); dans
-      ce dernier cas, chaque entrée dans la table comporte les mêmes [champs](#field).
+    term: entrée
+    def: 'Un groupe de valeurs liées qui sont enregistrées ensemble. Une entrée peut
+      être représentée comme un [tuple](#tuple) ou une ligne dans une [table](#table);
+      dans ce dernier cas, chaque entrée dans la table comporte les mêmes [champs](#field).
 
+      '
+- slug: recurrent_neural_network
+  ref:
+  - neural_network
+  - lstm
+  - deep_learning
+  en:
+    term: Recurrent Neural Network
+    acronym: RNN
+    def: 'A type of [neural network](#neural_network) designed for sequential data,
+      where connections between nodes form cycles, allowing information to persist.
+      RNNs are used for tasks like language modeling and time series prediction. See
+      also [LSTM](#lstm).
 
+      '
 - slug: recursion
   en:
-    term: "recursion"
-    def: >
-      Calling a function from within a call to that function, or defining a term using
-      a simpler version of the same term.
+    term: recursion
+    def: 'Calling a function from within a call to that function, or defining a term
+      using a simpler version of the same term.
+
+      '
   fr:
-    term: "récursion"
-    def: >
-      Faire appel à une fonction au sein de cette même fonction, ou définir un terme
-      en utilisant une version simplifiée du même terme.
+    term: récursion
+    def: 'Faire appel à une fonction au sein de cette même fonction, ou définir un
+      terme en utilisant une version simplifiée du même terme.
 
-
+      '
 - slug: recycle
   en:
-    term: "recycle"
-    def: >
-      To re-use values from a shorter [vector](#vector) in order to generate a sequence of the
-      same length as a longer one. In [Python](#python) NumPy, this is called broadcasting.
+    term: recycle
+    def: 'To re-use values from a shorter [vector](#vector) in order to generate a
+      sequence of the same length as a longer one. In [Python](#python) NumPy, this
+      is called broadcasting.
+
+      '
   es:
-    term: "reciclar"
-    def: >
-      Reutilizar valores de un vector más corto con el fin de generar una secuencia
+    term: reciclar
+    def: 'Reutilizar valores de un vector más corto con el fin de generar una secuencia
       del mismo largo que el vector más largo.
 
-
+      '
 - slug: redirection
   en:
-    term: "redirection"
-    def: >
-      To send a request for a web page or web service to a different page or service.
+    term: redirection
+    def: 'To send a request for a web page or web service to a different page or service.
 
-
+      '
 - slug: refactoring
   en:
-    term: "refactoring"
-    def: >
-      Reorganizing software without changing its behavior.
+    term: refactoring
+    def: 'Reorganizing software without changing its behavior.
 
+      '
+- slug: regression
+  ref:
+  - machine_learning
+  - supervised_learning
+  - linear_regression
+  en:
+    term: regression
+    def: 'A [supervised learning](#supervised_learning) task where the goal is to
+      predict a continuous numerical value rather than a discrete class. [Linear regression](#linear_regression)
+      is a common example.
 
+      '
 - slug: regression_testing
   en:
-    term: "regression testing"
-    def: >
-      Testing software to ensure that things which used to work have not been broken.
+    term: regression testing
+    def: 'Testing software to ensure that things which used to work have not been
+      broken.
 
-
+      '
 - slug: regular_expression
   en:
-    term: "regular expression"
-    def: >
-      A pattern for matching text, written as text itself. Regular expressions are
-      sometimes called "regexp", "regex", or "RE", and are powerful tools for working with text.
+    term: regular expression
+    def: 'A pattern for matching text, written as text itself. Regular expressions
+      are sometimes called "regexp", "regex", or "RE", and are powerful tools for
+      working with text.
+
+      '
   es:
-    term: "expresión regular"
-    def: >
-      Un patrón para buscar coincidencias en texto, que están a su vez escritas como
-      texto. Las expresiones regulares a veces son llamadas "regexp", "regex", o "RE",
-      y son poderosas.
+    term: expresión regular
+    def: 'Un patrón para buscar coincidencias en texto, que están a su vez escritas
+      como texto. Las expresiones regulares a veces son llamadas "regexp", "regex",
+      o "RE", y son poderosas.
 
-
+      '
 - slug: reinforcement_learning
   ref:
-    - supervised_learning
-    - unsupervised_learning
+  - supervised_learning
+  - unsupervised_learning
   en:
-    term: "reinforcement learning"
-    def: >
-      Any [machine learning](#machine_learning) algorithm which is not given specific
-      goals to meet, but instead is given feedback on whether or not it is making progress.
+    term: reinforcement learning
+    def: 'Any [machine learning](#machine_learning) algorithm which is not given specific
+      goals to meet, but instead is given feedback on whether or not it is making
+      progress.
 
-
+      '
 - slug: relational_database
   ref:
-    - sql
+  - sql
   en:
-    term: "relational database"
-    def: >
-      A database that organizes information into [tables](#table), each of which has a fixed set
-      of named [fields](#field) (shown as columns) and a variable number of [records](#record) (shown as rows).
-  es:
-    term: "base de datos relacional"
-    def: >
-      Una base de datos que organiza la información en [tablas](#table), cada una de las cuales
-      tiene un set fijo de [campos](#field) con nombre (que se muestran como columnas) y un
-      número variable de [registros](#record) (que se muestran como filas).
-  fr:
-    term: "base de données relationnelle"
-    def: >
-      Une base de données dont le contenu est organisé sous forme de [tables](#table),
-      chacune avec un ensemble déterminé de [champs](#field) (représentés sous forme de colonnes)
-      et un nombre variable d'[entrées](#record) (représentées sous forme de lignes).
-  sw:
-    term: "hifadhidata ya uhusiano"
-    def: >
-      Hifadhidata ambayo hupanga habari katika majedwali, ambayo kila moja ina seti isiyobadilika
-      ya sehemu zilizotajwa (zinazoonyeshwa kama safu wima) na idadi tofauti ya rekodi (zinazoonyeshwa
-      kama safu mlalo).
+    term: relational database
+    def: 'A database that organizes information into [tables](#table), each of which
+      has a fixed set of named [fields](#field) (shown as columns) and a variable
+      number of [records](#record) (shown as rows).
 
+      '
+  es:
+    term: base de datos relacional
+    def: 'Una base de datos que organiza la información en [tablas](#table), cada
+      una de las cuales tiene un set fijo de [campos](#field) con nombre (que se muestran
+      como columnas) y un número variable de [registros](#record) (que se muestran
+      como filas).
+
+      '
+  fr:
+    term: base de données relationnelle
+    def: 'Une base de données dont le contenu est organisé sous forme de [tables](#table),
+      chacune avec un ensemble déterminé de [champs](#field) (représentés sous forme
+      de colonnes) et un nombre variable d''[entrées](#record) (représentées sous
+      forme de lignes).
+
+      '
+  sw:
+    term: hifadhidata ya uhusiano
+    def: 'Hifadhidata ambayo hupanga habari katika majedwali, ambayo kila moja ina
+      seti isiyobadilika ya sehemu zilizotajwa (zinazoonyeshwa kama safu wima) na
+      idadi tofauti ya rekodi (zinazoonyeshwa kama safu mlalo).
+
+      '
 - slug: relative_error
   en:
-    term: "relative error"
-    def: >
-      The absolute value of the difference between the actual and correct value
+    term: relative error
+    def: 'The absolute value of the difference between the actual and correct value
       divided by the correct value. For example, if the actual value is 9 and the
       correct value is 10, the relative error is 0.1. Relative error is usually more
       useful than [absolute error](#absolute_error).
+
+      '
   it:
-    term: "errore relativo"
-    def: >
-      Errore assoluto diviso il valore assoluto del valore corretto. Ad esempio, se il
-      valore osservato è 9 e il valore corretto è 10, l'errore relativo è 0,1. L'errore
-      relativo è spesso più utile dell'[errore assoluto](#absolute_error).
+    term: errore relativo
+    def: 'Errore assoluto diviso il valore assoluto del valore corretto. Ad esempio,
+      se il valore osservato è 9 e il valore corretto è 10, l''errore relativo è 0,1.
+      L''errore relativo è spesso più utile dell''[errore assoluto](#absolute_error).
+
+      '
   es:
-    term: "error relativo"
-    def: >
-      El valor absoluto de la diferencia entre el valor observado y el valor correcto,
+    term: error relativo
+    def: 'El valor absoluto de la diferencia entre el valor observado y el valor correcto,
       dividido por el valor deseado. Por ejemplo, si el valor observado es 9 y el
-      valor correcto es 10, el error relativo es 0.1. El error relativo suele ser más
-      útil que el [error absoluto](#absolute_error).
+      valor correcto es 10, el error relativo es 0.1. El error relativo suele ser
+      más útil que el [error absoluto](#absolute_error).
+
+      '
   pt:
-    term: "erro relativo"
-    def: >
-      O valor absoluto da diferença entre um valor observado e o valor correto,
-      dividido pelo vaor correto. Por exemplo, se o valor observado é 9 e o correto é
-      10, o erro relativo é 0.1. Erro relativo é normalmente mais útil do que o [erro absoluto](#absolute_error).
+    term: erro relativo
+    def: 'O valor absoluto da diferença entre um valor observado e o valor correto,
+      dividido pelo vaor correto. Por exemplo, se o valor observado é 9 e o correto
+      é 10, o erro relativo é 0.1. Erro relativo é normalmente mais útil do que o
+      [erro absoluto](#absolute_error).
+
+      '
   fr:
-    term: "erreur relative"
-    def: >
-      La valeur absolue de la différence entre la valeur observée et la valeur correcte,
-      divisée par la valeur correcte. Par exemple, si la valeur observée est 9 et la valeur
-      correcte est 10, l'erreur relative est 0.1. L'erreur relative est généralement
-      plus utile que [l'erreur absolue](#absolute_error).
+    term: erreur relative
+    def: 'La valeur absolue de la différence entre la valeur observée et la valeur
+      correcte, divisée par la valeur correcte. Par exemple, si la valeur observée
+      est 9 et la valeur correcte est 10, l''erreur relative est 0.1. L''erreur relative
+      est généralement plus utile que [l''erreur absolue](#absolute_error).
 
-
+      '
 - slug: relative_path
   ref:
-    - absolute_path
+  - absolute_path
   en:
-    term: "relative path"
-    def: >
-      A path whose destination is interpreted relative to some other location, such as
-      the [current working directory](#current_working_directory). A relative path is
-      the equivalent of giving directions using terms like "straight" and "left".
+    term: relative path
+    def: 'A path whose destination is interpreted relative to some other location,
+      such as the [current working directory](#current_working_directory). A relative
+      path is the equivalent of giving directions using terms like "straight" and
+      "left".
+
+      '
   pt:
-    term: "caminho relativo"
-    def: >
-      Um caminho cujo destino é interpretado de maneira relativa a outro local, como o
-      [diretório de trabalho](#current_working_directory). Um caminho relativo é o
-      equivalente a indicar um destino com termos como "siga em frente" e "vire a esquerda".
+    term: caminho relativo
+    def: 'Um caminho cujo destino é interpretado de maneira relativa a outro local,
+      como o [diretório de trabalho](#current_working_directory). Um caminho relativo
+      é o equivalente a indicar um destino com termos como "siga em frente" e "vire
+      a esquerda".
+
+      '
   fr:
-    term: "chemin d'accès relatif"
-    def: >
-      Un chemin d'accès dont la destination est définie relativement à un autre emplacement,
-      par exemple le [répertoire de travail actuel](#current_working_directory). Utiliser
-      un chemin relatif équivaut à se déplacer à l'aide d'instructions telles que "tout droit"
-      ou "tourner à gauche".
+    term: chemin d'accès relatif
+    def: 'Un chemin d''accès dont la destination est définie relativement à un autre
+      emplacement, par exemple le [répertoire de travail actuel](#current_working_directory).
+      Utiliser un chemin relatif équivaut à se déplacer à l''aide d''instructions
+      telles que "tout droit" ou "tourner à gauche".
 
-
+      '
 - slug: relative_row_number
   en:
-    term: "relative row number"
-    def: >
-      The index of a row in a displayed portion of a table, which may or may not be
-      the same as the [absolute row number](#absolute_row_number) within the table.
+    term: relative row number
+    def: 'The index of a row in a displayed portion of a table, which may or may not
+      be the same as the [absolute row number](#absolute_row_number) within the table.
+
+      '
   pt:
-    term: "número de linha relativo"
-    def: >
-      O índice de uma linha em uma parte da tabela em exibição, que pode ou não ser
-      igual ao [número de linha absoluto](#absolute_row_number) na tabela.
+    term: número de linha relativo
+    def: 'O índice de uma linha em uma parte da tabela em exibição, que pode ou não
+      ser igual ao [número de linha absoluto](#absolute_row_number) na tabela.
 
-
+      '
 - slug: remote_login
   en:
-    term: "remote login"
-    def: >
-      Starting an interactive session on one computer from another computer, e.g., by
-      using [SSH](#ssh).
+    term: remote login
+    def: 'Starting an interactive session on one computer from another computer, e.g.,
+      by using [SSH](#ssh).
+
+      '
   tn:
-    term: "kgolagano kgakala"
-    def: >
-      Seemo sa go simolola tirisano le kgolagano ya dibalamakgolo sekai, fa o dirisa [SSH](#ssh).
+    term: kgolagano kgakala
+    def: 'Seemo sa go simolola tirisano le kgolagano ya dibalamakgolo sekai, fa o
+      dirisa [SSH](#ssh).
+
+      '
   uk:
-    term: "віддалений вхід"
-    def: >
-      Початок інтерактивного сеансу роботи на одному комп'ютері з іншого комп'ютера,
+    term: віддалений вхід
+    def: 'Початок інтерактивного сеансу роботи на одному комп''ютері з іншого комп''ютера,
       наприклад, за допомогою [SSH](#ssh).
-  
+
+      '
 - slug: remote_repository
   en:
-    term: "remote repository"
-    def: >
-      A [repository](#repository) located on another computer. Tools such as [Git](#git) are
-      designed to synchronize changes between local and remote
-      repositories in order to share work.
-  uk:
-    term: "віддалений репозиторій"
-    def: >
-      [Репозиторій](#repository), розташований на іншому сервері або пристрої. За допомогою 
-      системи контролю версій, такої як Git, можна синхронізувати локальні та віддалені 
-      репозиторії, що дозволяє спільну роботу над їх вмістом.
+    term: remote repository
+    def: 'A [repository](#repository) located on another computer. Tools such as [Git](#git)
+      are designed to synchronize changes between local and remote repositories in
+      order to share work.
 
+      '
+  uk:
+    term: віддалений репозиторій
+    def: '[Репозиторій](#repository), розташований на іншому сервері або пристрої.
+      За допомогою  системи контролю версій, такої як Git, можна синхронізувати локальні
+      та віддалені  репозиторії, що дозволяє спільну роботу над їх вмістом.
+
+      '
 - slug: repl
   ref:
-    - ide
+  - ide
   en:
-    term: "read-eval-print loop"
-    acronym: "REPL"
-    def: >
-      An interactive program that reads a command typed in by a user, executes it,
-      prints the result, and then waits patiently for the next command. REPLs are
-      often used to explore new ideas, or for [debugging](#debug).
+    term: read-eval-print loop
+    acronym: REPL
+    def: 'An interactive program that reads a command typed in by a user, executes
+      it, prints the result, and then waits patiently for the next command. REPLs
+      are often used to explore new ideas, or for [debugging](#debug).
 
-
+      '
 - slug: repository
   ref:
-    - git
-    - github
+  - git
+  - github
   en:
-    term: "repository"
-    def: >
-      A place where a [version control system](#version_control_system) stores the
-      files that make up a project and the metadata that describes their history.
+    term: repository
+    def: 'A place where a [version control system](#version_control_system) stores
+      the files that make up a project and the metadata that describes their history.
+
+      '
   es:
-    term: "repositorio"
-    def: >
-      Lugar en el que un [sistema de control de versión](#version_control_system)
-      guarda los archivos que conforman un proyecto y los metadatos que describen su historia.
+    term: repositorio
+    def: 'Lugar en el que un [sistema de control de versión](#version_control_system)
+      guarda los archivos que conforman un proyecto y los metadatos que describen
+      su historia.
+
+      '
   pt:
-    term: "repositório"
-    def: >
-      Um local onde um [sistema de controle de versão](#version_control_system)
-      armazena os arquivos que compõem um projeto e os metadados que descrevem sua história.
+    term: repositório
+    def: 'Um local onde um [sistema de controle de versão](#version_control_system)
+      armazena os arquivos que compõem um projeto e os metadados que descrevem sua
+      história.
+
+      '
   ja:
-    term: "リポジトリ"
-    def: >
-       [バージョン管理システム](#version_control_system)において、管理対象となるプロジェクトを構成するファイルとその履歴を説明するメタデータを保存する場所。
+    term: リポジトリ
+    def: '[バージョン管理システム](#version_control_system)において、管理対象となるプロジェクトを構成するファイルとその履歴を説明するメタデータを保存する場所。
+
+      '
   uk:
-    term: "репозиторій"
-    def: >
-      Місце, де [система контролю версій](#version_control_system) зберігає файли,
+    term: репозиторій
+    def: 'Місце, де [система контролю версій](#version_control_system) зберігає файли,
       що складають проект, та метадані, які описують їхню історію.
 
+      '
 - slug: reprex
   en:
-    term: "reprex"
-    def: >
-      A reproducible example. When asking questions about coding problems online or
-      filing issues on [GitHub](#github), you should always include a reprex so others can
-      reproduce your problem and help. The [reprex](https://github.com/tidyverse/reprex)
+    term: reprex
+    def: 'A reproducible example. When asking questions about coding problems online
+      or filing issues on [GitHub](#github), you should always include a reprex so
+      others can reproduce your problem and help. The [reprex](https://github.com/tidyverse/reprex)
       package can help!
 
-
+      '
 - slug: reproducible_example
   en:
-    term: "reproducible example"
-    def: >
-      See [reprex](#reprex).
+    term: reproducible example
+    def: 'See [reprex](#reprex).
 
-
+      '
 - slug: reproducible_research
   en:
-    term: "reproducible research"
-    def: >
-      The practice of describing and documenting research results in such a way that
-      another researcher or person can re-run the analysis code on the same data to
-      obtain the same result.
-  pt:
-    term: "pesquisa reprodutível"
-    def: >
-      A prática de escrever e documentar resultados de pesquisa de forma que outras
-      pessoas pesquisadoras possam executar novamente o código de análise com os
-      mesmos dados para obter os mesmos resultados.
+    term: reproducible research
+    def: 'The practice of describing and documenting research results in such a way
+      that another researcher or person can re-run the analysis code on the same data
+      to obtain the same result.
 
+      '
+  pt:
+    term: pesquisa reprodutível
+    def: 'A prática de escrever e documentar resultados de pesquisa de forma que outras
+      pessoas pesquisadoras possam executar novamente o código de análise com os mesmos
+      dados para obter os mesmos resultados.
+
+      '
 - slug: reserved_word
   en:
-    term: "reserved word"
-    def: >
-      A word (character string) with a distinct meaning for a programming or scripting language.
-      Typically, reserved words cannot be used as names for variables or constants, as this would
-      confuse the compiler or interpreter.
+    term: reserved word
+    def: 'A word (character string) with a distinct meaning for a programming or scripting
+      language. Typically, reserved words cannot be used as names for variables or
+      constants, as this would confuse the compiler or interpreter.
 
+      '
 - slug: restructured_text
   ref:
-    - markdown
+  - markdown
   en:
-    term: "reStructured Text"
-    acronym: "reST"
-    def: >
-      A plaintext [markup](#markup_language) format used primarily in [Python](#python) documentation.
+    term: reStructured Text
+    acronym: reST
+    def: 'A plaintext [markup](#markup_language) format used primarily in [Python](#python)
+      documentation.
 
-
+      '
 - slug: revision
   en:
-    term: "revision"
-    def: >
-      See [commit](#commit).
+    term: revision
+    def: 'See [commit](#commit).
 
-
+      '
 - slug: right_join
   ref:
-    - anti_join
-    - cross_join
-    - full_join
-    - inner_join
-    - left_join
-    - right_join
-    - self_join
+  - anti_join
+  - cross_join
+  - full_join
+  - inner_join
+  - left_join
+  - right_join
+  - self_join
   en:
-    term: "right join"
-    def: >
-      A [join](#join) that combines data from two tables, A and B. Where [keys](#key) in table
-      A match keys in table B, [fields](#field) are concatenated. Where a key in table
-      B does *not* match a key in table A, columns from table A are filled with
-      [null](#null), [NA](#na), or some other [missing value](#missing_value) signifier.
-      Keys from table A that do not exist in table B are dropped.
+    term: right join
+    def: 'A [join](#join) that combines data from two tables, A and B. Where [keys](#key)
+      in table A match keys in table B, [fields](#field) are concatenated. Where a
+      key in table B does *not* match a key in table A, columns from table A are filled
+      with [null](#null), [NA](#na), or some other [missing value](#missing_value)
+      signifier. Keys from table A that do not exist in table B are dropped.
 
+      '
+- slug: rnn
+  ref:
+  - deep_learning
+  - backpropagation
+  - perceptron
+  - neural_network
+  - machine_learning
+  en:
+    term: recurrent neural network
+    def: 'A class of [artificial neural networks](#neural_network) where connections
+      between nodes can create a cycle. This allows the network to exhibit behavior
+      that is dynamic over time. This type of network is applicable to tasks like
+      speech and handwriting recognition.
 
+      '
+- slug: roc_curve
+  ref:
+  - machine_learning
+  - classification
+  en:
+    term: ROC Curve
+    def: 'A ROC curve (Receiver Operating Characteristic curve) is a graph that displays
+      the performance of a binary classifier at different [classification](#classification)
+      thresholds. The curve is obtained by plotting the True Positive Rate (also known
+      as Recall or [Sensitivity](#sensitivity)) along the vertical axis and the False
+      Positive Rate along the horizontal axis.
+
+      '
+  es:
+    term: Curva ROC
+    def: 'Una curva ROC (acrónimo de Receiver Operating Characteristic, o Característica
+      Operativa del Receptor)  es un gráfico que muestra el desempeño de un clasificador
+      binario con diferentes umbrales de [clasificación](#classification) La curva
+      se obtiene graficando la tasa de verdaderos positivos (también conocida como
+      Recall o [Sensibilidad](#sensitivity)) a lo largo del eje vertical y la taza
+      de falsos positivos a lo largo del eje horizontal.
+
+      '
 - slug: root_directory
   en:
-    term: "root directory"
-    def: >
-      The [directory](#directory) that contains everything else, either directly or indirectly. The root
-      directory is written `/` (a bare forward slash).
+    term: root directory
+    def: 'The [directory](#directory) that contains everything else, either directly
+      or indirectly. The root directory is written `/` (a bare forward slash).
 
-
+      '
 - slug: root_math
   ref:
-    - square_root
+  - square_root
   en:
     term: n-th root
-    def: >
-      The n-th root of a positive number x is the number that when multiplied by
-      itself n times produces x. This can commonly be calculated by raising x to
+    def: 'The n-th root of a positive number x is the number that when multiplied
+      by itself n times produces x. This can commonly be calculated by raising x to
       the power of the [reciprocal](#reciprocal) of n.
 
-
+      '
 - slug: root_mean_squared_error
   ref:
-    - mean_absolute_error
+  - mean_absolute_error
   en:
-    term: "root mean squared error"
-    acronym: "RMSE"
-    def: >
-      The [square root](#square_root) of the [mean squared error](#mean_squared_error). Like the
-      [standard deviation](#standard_deviation), it is in the same units as the
-      original data.
+    term: root mean squared error
+    acronym: RMSE
+    def: 'The [square root](#square_root) of the [mean squared error](#mean_squared_error).
+      Like the [standard deviation](#standard_deviation), it is in the same units
+      as the original data.
+
+      '
   es:
-    term: "raíz del error cuadrático medio"
+    term: raíz del error cuadrático medio
     acronym: RECM
-    def: >
-      La raíz cuadrada del [error cuadrático medio](#mean_squared_error). Como la
-      [desviación estándar](#standard_deviation), está en las mismas unidades que
+    def: 'La raíz cuadrada del [error cuadrático medio](#mean_squared_error). Como
+      la [desviación estándar](#standard_deviation), está en las mismas unidades que
       los datos originales.
 
-
+      '
 - slug: root_tree
   en:
-    term: "root (in a tree)"
-    def: >
-      The [node](#node) in a [tree](#tree) of which all other nodes are direct or indirect
-      [children](#child_tree), or equivalently the only node in the tree that has no [parent](#parent_tree).
+    term: root (in a tree)
+    def: 'The [node](#node) in a [tree](#tree) of which all other nodes are direct
+      or indirect [children](#child_tree), or equivalently the only node in the tree
+      that has no [parent](#parent_tree).
 
-
+      '
 - slug: rotating_file
   en:
-    term: "rotating file"
-    def: >
-      A set of files used to store recent information. For example, there might be one
-      file with results for each day of the week, so that results from last Tuesday
-      are overwritten this Tuesday.
+    term: rotating file
+    def: 'A set of files used to store recent information. For example, there might
+      be one file with results for each day of the week, so that results from last
+      Tuesday are overwritten this Tuesday.
 
-
+      '
 - slug: rse
   en:
-    term: "research software engineer"
-    acronym: "RSE"
-    def: >
-      Someone whose primary responsibility is to build the specialized software that
-      other researchers depend on.
+    term: research software engineer
+    acronym: RSE
+    def: 'Someone whose primary responsibility is to build the specialized software
+      that other researchers depend on.
 
-
+      '
 - slug: rseng
   en:
-    term: "research software engineering"
-    acronym: "RSEng"
-    def: >
-      The practice of and methods for building the specialized software that
-      other researchers depend on.
+    term: research software engineering
+    acronym: RSEng
+    def: 'The practice of and methods for building the specialized software that other
+      researchers depend on.
 
-
+      '
 - slug: s3
   en:
-    term: "S3"
-    def: >
-      A framework for [object-oriented programming](#oop) in [R](#r_language).
+    term: S3
+    def: 'A framework for [object-oriented programming](#oop) in [R](#r_language).
+
+      '
   es:
-    term: "S3"
-    def: >
-      Un entorno para la [programación orientada a objetos](#oop) en [R](#r_language).
+    term: S3
+    def: 'Un entorno para la [programación orientada a objetos](#oop) en [R](#r_language).
 
-
+      '
 - slug: s4
   en:
-    term: "S4"
-    def: >
-      A framework for [object-oriented programming](#oop) in [R](#r_language).
+    term: S4
+    def: 'A framework for [object-oriented programming](#oop) in [R](#r_language).
 
-
+      '
 - slug: s_language
   en:
-    term: "S"
-    def: >
-      A language originally developed in Bell Labs for data analysis, statistical
+    term: S
+    def: 'A language originally developed in Bell Labs for data analysis, statistical
       modeling, and graphics. [R](#r_language) is a dialect of S.
+
+      '
   es:
-    term: "S"
-    def: >
-      Un lenguaje para análisis de datos, modelado estadístico y gráficos desarrollado
+    term: S
+    def: 'Un lenguaje para análisis de datos, modelado estadístico y gráficos desarrollado
       originalmente en los Laboratorios Bell. [R](#r_language) es un dialecto de S.
 
-
+      '
 - slug: sandbox
   en:
-    term: "sandbox"
-    def: >
-      A testing environment that is separate from the production system, or an
+    term: sandbox
+    def: 'A testing environment that is separate from the production system, or an
       environment that is only allowed to perform a restricted set of operations for
       security reasons.
 
+      '
 - slug: sanity_check
   en:
-    term: "sanity check"
-    def: >
-      A basic test to see if the outcome of a calculation, script or analysis makes sense or is true.
-      This can be performed by visualisation or by simply inspecting the outcome.
+    term: sanity check
+    def: 'A basic test to see if the outcome of a calculation, script or analysis
+      makes sense or is true. This can be performed by visualisation or by simply
+      inspecting the outcome.
 
+      '
 - slug: scalar
   en:
-    term: "scalar"
-    def: >
-      A single value of a particular type, such as 1 or "a". Scalars exist in most languages, but do not really
-      exist in [R](#r_language); in R, values that appear to be scalars are actually [vectors](#vector) of unit length.
+    term: scalar
+    def: 'A single value of a particular type, such as 1 or "a". Scalars exist in
+      most languages, but do not really exist in [R](#r_language); in R, values that
+      appear to be scalars are actually [vectors](#vector) of unit length.
+
+      '
   es:
-    term: "escalar"
-    def: >
-      Un único valor de un tipo particular, como 1 o "a". Los escalares realmente no
-      existen en [R](#r_language); los valores que parecen ser escalares son en realidad vectores de
-      largo uno.
+    term: escalar
+    def: 'Un único valor de un tipo particular, como 1 o "a". Los escalares realmente
+      no existen en [R](#r_language); los valores que parecen ser escalares son en
+      realidad vectores de largo uno.
 
-
+      '
 - slug: schema
   en:
-    term: "schema"
-    def: >
-      A specification of the format of a dataset, including the name, format, and
-      content of each [table](#table).
+    term: schema
+    def: 'A specification of the format of a dataset, including the name, format,
+      and content of each [table](#table).
+
+      '
   fr:
-    term: "schéma"
-    def: >
-      Spécification du format d'un ensemble de données qui inclut le nom, format et
-      contenu de chaque [table](#table).
+    term: schéma
+    def: 'Spécification du format d''un ensemble de données qui inclut le nom, format
+      et contenu de chaque [table](#table).
 
-
+      '
 - slug: scope
   ref:
-    - namespace
+  - namespace
   en:
-    term: "scope"
-    def: >
-      The portion of a program within which a definition can be seen and used. See
-      [closure](#closure), [global variable](#global_variable), and [local variable](#local_variable).
+    term: scope
+    def: 'The portion of a program within which a definition can be seen and used.
+      See [closure](#closure), [global variable](#global_variable), and [local variable](#local_variable).
 
-
+      '
 - slug: script
   en:
-    term: "script"
-    def: >
-      Originally, a program written in a language too user-friendly for "real" programmers to
-      take seriously; the term is now synonymous with program.
+    term: script
+    def: 'Originally, a program written in a language too user-friendly for "real"
+      programmers to take seriously; the term is now synonymous with program.
 
-
+      '
 - slug: search_path
   en:
-    term: "search path"
-    def: >
-      The list of directories that a program searches to find something. For example,
-      the Unix [shell](#shell) uses the search path stored in the `PATH` variable when
-      trying to find a program whose name it has been given.
+    term: search path
+    def: 'The list of directories that a program searches to find something. For example,
+      the Unix [shell](#shell) uses the search path stored in the `PATH` variable
+      when trying to find a program whose name it has been given.
 
+      '
+- slug: searching
+  ref:
+  - algorithm
+  - binary_search
+  en:
+    term: searching
+    def: 'The algorithmic process of finding a specific element or value within a
+      data structure. Common search algorithms include linear search, [binary search](#binary_search),
+      and [depth-first search](#depth_first).
 
+      '
 - slug: seed
   en:
-    term: "seed"
-    def: >
-      A value used to initialize a [pseudo-random number generator](#prng).
-  af:
-    term: "saadjie"
-    def: >
-      'n Waarde wat gebruik word om 'n [pseudolukrakenommergenereerder](#prng) te begin.
-  es:
-    term: "semilla"
-    def: >
-      Un valor utilizado para inicializar un [generador de números pseudoaleatorios](#prng).
+    term: seed
+    def: 'A value used to initialize a [pseudo-random number generator](#prng).
 
+      '
+  af:
+    term: saadjie
+    def: '''n Waarde wat gebruik word om ''n [pseudolukrakenommergenereerder](#prng)
+      te begin.
+
+      '
+  es:
+    term: semilla
+    def: 'Un valor utilizado para inicializar un [generador de números pseudoaleatorios](#prng).
+
+      '
 - slug: select
   en:
-    term: "select"
-    def: >
-      To choose entire columns or rows from a table by name or location.
-  af:
-    term: "kies"
-    def: >
-      Om volledige kolomme of rye in 'n tabel volgens naam of plek te kies (selekteer).
+    term: select
+    def: 'To choose entire columns or rows from a table by name or location.
 
+      '
+  af:
+    term: kies
+    def: 'Om volledige kolomme of rye in ''n tabel volgens naam of plek te kies (selekteer).
+
+      '
 - slug: selecting_on_the_dependent_variable_bias
   en:
-    term: "selecting on the dependent variable bias"
-    def: >
-      A study that only includes cases where the dependent variable shows the same value, instead of cases with different values in the dependent variable, is a study affected by selecting on the dependent variable bias.
+    term: selecting on the dependent variable bias
+    def: 'A study that only includes cases where the dependent variable shows the
+      same value, instead of cases with different values in the dependent variable,
+      is a study affected by selecting on the dependent variable bias.
+
+      '
   es:
-    term: "sesgo de selección en la variable dependiente"
-    def: >
-     Un estudio que solamente incluye casos en los que la variable dependiente tiene el mismo valor, en lugar de casos con variación en la variable dependiente, es un estudio con sesgo de selección en la variable dependiente.
+    term: sesgo de selección en la variable dependiente
+    def: 'Un estudio que solamente incluye casos en los que la variable dependiente
+      tiene el mismo valor, en lugar de casos con variación en la variable dependiente,
+      es un estudio con sesgo de selección en la variable dependiente.
 
-
+      '
 - slug: self_join
   ref:
-    - anti_join
-    - cross_join
-    - full_join
-    - inner_join
-    - left_join
-    - right_join
-    - self_join
+  - anti_join
+  - cross_join
+  - full_join
+  - inner_join
+  - left_join
+  - right_join
+  - self_join
   en:
-    term: "self join"
-    def: >
-      A [join](#join) that combines a table with itself.
+    term: self join
+    def: 'A [join](#join) that combines a table with itself.
 
-
+      '
 - slug: semantic_versioning
   en:
-    term: "semantic versioning"
-    def: >
-      A standard for identifying software releases. In the version identifier
-      `major.minor.patch`, `major` changes when a new version of software is
-      incompatible with old versions, `minor` changes when new features are added to
-      an existing version, and `patch` changes when small [bugs](#bug) are fixed.
+    term: semantic versioning
+    def: 'A standard for identifying software releases. In the version identifier
+      `major.minor.patch`, `major` changes when a new version of software is incompatible
+      with old versions, `minor` changes when new features are added to an existing
+      version, and `patch` changes when small [bugs](#bug) are fixed.
 
-
+      '
 - slug: sense_vote
   ref:
-    - marthas_rules
+  - marthas_rules
   en:
-    term: "sense vote"
-    def: >
-      A preliminary vote used to determine whether further discussion is needed in a meeting.
+    term: sense vote
+    def: 'A preliminary vote used to determine whether further discussion is needed
+      in a meeting.
 
+      '
 - slug: sensitivity
   en:
-    term: "sensitivity"
-    def: >
-      Statistical measure of a classification model which gives the True Positive rate. For
-      example, the proportion of people who have a disease that test positive. Calculated
-      as Sensitivity = TP/(TP+FN).
+    term: sensitivity
+    def: 'Statistical measure of a classification model which gives the True Positive
+      rate. For example, the proportion of people who have a disease that test positive.
+      Calculated as Sensitivity = TP/(TP+FN).
 
+      '
 - slug: sequential_data
   en:
-    term: "sequential data"
-    def: >
-      Any list of data items where the order is an inherent property of the list. Often the next item in the list is dependent on the previous item or items.
+    term: sequential data
+    def: 'Any list of data items where the order is an inherent property of the list.
+      Often the next item in the list is dependent on the previous item or items.
 
+      '
 - slug: server
   en:
-    term: "server"
-    def: >
-      Typically, a program such as a database manager or web server that provides data
-      to a [client](#client) upon request.
-  af:
-    term: "bediener"
-    def: >
-      'n Program soos 'n databasisbeheerder of webbediener wat op versoek data aan 'n [kliënt](#client) verskaf.
+    term: server
+    def: 'Typically, a program such as a database manager or web server that provides
+      data to a [client](#client) upon request.
 
+      '
+  af:
+    term: bediener
+    def: '''n Program soos ''n databasisbeheerder of webbediener wat op versoek data
+      aan ''n [kliënt](#client) verskaf.
+
+      '
+- slug: set
+  ref:
+  - data_structure
+  - collection
+  en:
+    term: set
+    def: 'A data structure that stores a collection of unique elements with no particular
+      order. Sets efficiently support operations like membership testing, union, intersection,
+      and difference.
+
+      '
 - slug: shader
   ref:
-    - compute_shader
-    - gpu
-    - fragment_shader
-    - vertex_shader
-    - geometry_shader
-    - tessellation_shader
+  - compute_shader
+  - gpu
+  - fragment_shader
+  - vertex_shader
+  - geometry_shader
+  - tessellation_shader
   en:
-    term: "shader"
-    def: >
-      A program designed to run on the [GPU][gpu]. Generally used in graphics to calculate lighting or position vertices
-      in a scene, though can be used for more general programming through the use of [compute shaders][#compute_shader].
-  uk:
-    term: "шейдер"
-    def: >
-      Програма, призначена для виконання на [GPU](#gpu). Загалом, використовується у графіці для розрахунку освітлення
-      або позиціонування вершин у сцені, також може використовуватися для більш загального програмування 
-      за допомогою [обчислювальних шейдерів](#compute_shader).
+    term: shader
+    def: 'A program designed to run on the [GPU][gpu]. Generally used in graphics
+      to calculate lighting or position vertices in a scene, though can be used for
+      more general programming through the use of [compute shaders][#compute_shader].
 
+      '
+  uk:
+    term: шейдер
+    def: 'Програма, призначена для виконання на [GPU](#gpu). Загалом, використовується
+      у графіці для розрахунку освітлення або позиціонування вершин у сцені, також
+      може використовуватися для більш загального програмування  за допомогою [обчислювальних
+      шейдерів](#compute_shader).
+
+      '
 - slug: shebang
   en:
-    term: "shebang"
-    def: >
-      In Unix, a character sequence such as `#!/usr/bin/python` in the first line of an
-      executable file that tells the [shell](#shell) what program to use to run that file.
+    term: shebang
+    def: 'In Unix, a character sequence such as `#!/usr/bin/python` in the first line
+      of an executable file that tells the [shell](#shell) what program to use to
+      run that file.
 
-
+      '
 - slug: shell
   en:
-    term: "shell"
-    def: >
-      A [command-line interface](#cli) that allows a user to interact with the
-      [operating system](#operating_system), such as Bash (for Unix and MacOS) or PowerShell (for Windows).
+    term: shell
+    def: 'A [command-line interface](#cli) that allows a user to interact with the
+      [operating system](#operating_system), such as Bash (for Unix and MacOS) or
+      PowerShell (for Windows).
+
+      '
   uk:
-    term: "командна оболонка"
-    def: >
-      [Інтерфейс командного рядка](#cli), який дозволяє користувачеві взаємодіяти з
-      [операційною системою](#operating_system), наприклад Bash (для Unix та MacOS)
+    term: командна оболонка
+    def: '[Інтерфейс командного рядка](#cli), який дозволяє користувачеві взаємодіяти
+      з [операційною системою](#operating_system), наприклад Bash (для Unix та MacOS)
       або PowerShell (для Windows).
 
+      '
 - slug: shell_script
   en:
-    term: "shell script"
-    def: >
-      A set of commands for the [shell](#shell) stored in a file so that they can be
-      re-executed. A shell script is effectively a program.
+    term: shell script
+    def: 'A set of commands for the [shell](#shell) stored in a file so that they
+      can be re-executed. A shell script is effectively a program.
 
-
+      '
 - slug: shell_variable
   en:
-    term: "shell variable"
-    def: >
-      A variable set and used in the [Unix shell](#shell). Commonly used shell
-      variables include `HOME` (the user's home directory) and `PATH` (their [search path](#search_path)).
+    term: shell variable
+    def: 'A variable set and used in the [Unix shell](#shell). Commonly used shell
+      variables include `HOME` (the user''s home directory) and `PATH` (their [search
+      path](#search_path)).
 
-
+      '
 - slug: shiny
   en:
-    term: "Shiny"
-    def: >
-      A [R](#r_language) [package](#package) that makes it simple to build web applications to
-      interactively visualise and manipulate data. Often used to make interactive [graphs](graph)
-      and [tables](#table) straight from [R](#r_language) without having
-      to know [HTML](#html), [CSS](#css) or JavaScript.
+    term: Shiny
+    def: 'A [R](#r_language) [package](#package) that makes it simple to build web
+      applications to interactively visualise and manipulate data. Often used to make
+      interactive [graphs](graph) and [tables](#table) straight from [R](#r_language)
+      without having to know [HTML](#html), [CSS](#css) or JavaScript.
 
-
+      '
 - slug: short_circuit_test
   ref:
-    - lazy_evaluation
+  - lazy_evaluation
   en:
-    term: "short circuit test"
-    def: >
-      A logical test that only evaluates as many arguments as it needs to. For
-      example, if `A` is [false](#false), then most languages never evaluate `B` in the
-      expression `A and B`.
+    term: short circuit test
+    def: 'A logical test that only evaluates as many arguments as it needs to. For
+      example, if `A` is [false](#false), then most languages never evaluate `B` in
+      the expression `A and B`.
 
-
+      '
 - slug: short_identifier_git
   en:
-    term: "short identifier (of commit)"
-    def: >
-      The first few characters of a [full identifier](#full_identifier_git). Short
+    term: short identifier (of commit)
+    def: 'The first few characters of a [full identifier](#full_identifier_git). Short
       identifiers are easy for people to type and say aloud, and are usually unique
-      within a [repository's](#repository) recent history.
+      within a [repository''s](#repository) recent history.
 
-
+      '
 - slug: short_option
   ref:
-    - long_option
+  - long_option
   en:
-    term: "short option"
-    def: >
-      A single-letter identifier for a [command-line
-      argument](#command_line_argument). Most common flags are a single letter
-      preceded by a dash, such as `-v`.
+    term: short option
+    def: 'A single-letter identifier for a [command-line argument](#command_line_argument).
+      Most common flags are a single letter preceded by a dash, such as `-v`.
 
-
+      '
 - slug: side_effect
   en:
-    term: "side effect"
-    def: >
-      A change made by a function while it runs that is visible after the function
-      finishes, such as modifying a [global variable](#global_variable) or writing to
-      a file. Side effects make programs harder for people to understand, since the
-      effects are not necessarily clear at the point in the program where the function is called.
+    term: side effect
+    def: 'A change made by a function while it runs that is visible after the function
+      finishes, such as modifying a [global variable](#global_variable) or writing
+      to a file. Side effects make programs harder for people to understand, since
+      the effects are not necessarily clear at the point in the program where the
+      function is called.
 
-
+      '
 - slug: signal
   en:
-    term: "signal (a condition)"
-    def: >
-      A way of indicating that something has gone wrong in a program, or that some
-      other unexpected event has occurred. [R](#r_language) prefers "signalling a condition" to
-      "raising an exception". [Python](#python), on the other hand,
+    term: signal (a condition)
+    def: 'A way of indicating that something has gone wrong in a program, or that
+      some other unexpected event has occurred. [R](#r_language) prefers "signalling
+      a condition" to "raising an exception". [Python](#python), on the other hand,
       encourages [raising](#raise_exception) and [catching exceptions](#catch_exception),
       and in some situations, requires it.
 
-
+      '
 - slug: single_square_brackets
   ref:
-    - double_square_brackets
+  - double_square_brackets
   en:
-    term: "single square brackets"
-    def: >
-      One set of square brackets `[ ]`, used to select a structure from another structure based
-      on an index value, or range of values, inside the square brackets.
+    term: single square brackets
+    def: 'One set of square brackets `[ ]`, used to select a structure from another
+      structure based on an index value, or range of values, inside the square brackets.
 
-
+      '
 - slug: single_threaded
   en:
-    term: "single-threaded"
-    def: >
-      A model of program execution in which only one thing can happen at a time.
+    term: single-threaded
+    def: 'A model of program execution in which only one thing can happen at a time.
       Single-threaded execution is easier for people to understand, but less efficient
       than [multi-threaded](#multi_threaded) execution.
 
-
+      '
 - slug: singleton
   ref:
-    - singleton_pattern
+  - singleton_pattern
   en:
-    term: "singleton"
-    def: >
-      A set with only one element, or a [class](#class) with only one [instance](#instance).
+    term: singleton
+    def: 'A set with only one element, or a [class](#class) with only one [instance](#instance).
 
-
+      '
 - slug: singleton_pattern
   en:
-    term: "Singleton pattern"
-    def: >
-      A [design pattern](#design_pattern) that creates a [singleton](#singleton)
+    term: Singleton pattern
+    def: 'A [design pattern](#design_pattern) that creates a [singleton](#singleton)
       [object](#object) to manage some resource or service, such as a database or
       [cache](#cache). In [object-oriented programming](#oop), the pattern is usually
-      implemented by hiding the [constructor](#constructor) of the [class](#class) in some way
-      so that it can only be called once.
+      implemented by hiding the [constructor](#constructor) of the [class](#class)
+      in some way so that it can only be called once.
 
-
+      '
 - slug: slug
   en:
-    term: "slug"
-    def: >
-      An abbreviated portion of a page's URL that uniquely identifies it. In the
-      example `https://www.mysite.com/category/post-name`, the slug is `post-name`.
+    term: slug
+    def: 'An abbreviated portion of a page''s URL that uniquely identifies it. In
+      the example `https://www.mysite.com/category/post-name`, the slug is `post-name`.
 
-
+      '
 - slug: smtp
   ref:
-    - smtps
-    - imap
-    - pop
+  - smtps
+  - imap
+  - pop
   en:
-    term: "Simple Mail Transfer Protocol"
-    acronym: "SMTP"
-    def: >
-      A standard internet communication protocol for transmitting [email](#email).
+    term: Simple Mail Transfer Protocol
+    acronym: SMTP
+    def: 'A standard internet communication protocol for transmitting [email](#email).
 
-
+      '
 - slug: smtps
   ref:
-    - smtp
-    - imap
-    - pop
+  - smtp
+  - imap
+  - pop
   en:
-    term: "Simple Mail Transfer Protocol Secure"
-    acronym: "SMTPS"
-    def: >
-      A method for securing [SMTP](#smtp) using [TLS](#tls).
+    term: Simple Mail Transfer Protocol Secure
+    acronym: SMTPS
+    def: 'A method for securing [SMTP](#smtp) using [TLS](#tls).
 
-
+      '
 - slug: snake_case
   ref:
-    - camel_case
-    - kebab_case
+  - camel_case
+  - kebab_case
   en:
-    term: "snake case"
-    def: >
-      See [pothole case](#pothole_case).
+    term: snake case
+    def: 'See [pothole case](#pothole_case).
 
-
+      '
 - slug: software_distribution
   ref:
-    - distro
+  - distro
   en:
-    term: "software distribution"
-    def: >
-      A set of programs that are built, tested, and distributed as a collection so
-      that they can run together.
+    term: software distribution
+    def: 'A set of programs that are built, tested, and distributed as a collection
+      so that they can run together.
 
+      '
+- slug: sorting
+  ref:
+  - algorithm
+  en:
+    term: sorting
+    def: 'The process of arranging elements in a specific order (typically ascending
+      or descending). Common sorting algorithms include quicksort, mergesort, and
+      heapsort, each with different time and space complexity characteristics.
+
+      '
 - slug: source_code
   en:
-    term: "source code"
-    def: >
-      Source code or, simply, code, is the origin of executed code (either by means of
-      an interpreter or compiler). It's the primarily human-produced series of commands
-      that make up a program. (Note: Automatic code generators exist for some applications)
+    term: source code
+    def: 'Source code or, simply, code, is the origin of executed code (either by
+      means of an interpreter or compiler). It''s the primarily human-produced series
+      of commands that make up a program. (Note: Automatic code generators exist for
+      some applications)
+
+      '
   uk:
-    term: "вихідний код"
-    def: >
-      Вихідний код, або первинний код - це джерело коду, який виконується за допомогою інтерпретатора 
-      або компілятора. Здебільшого, це створена людиною серія команд, з яких 
-      складається програма. (Примітка: для деяких застосунків існують автоматичні генератори коду)
-      
+    term: вихідний код
+    def: 'Вихідний код, або первинний код - це джерело коду, який виконується за допомогою
+      інтерпретатора  або компілятора. Здебільшого, це створена людиною серія команд,
+      з яких  складається програма. (Примітка: для деяких застосунків існують автоматичні
+      генератори коду)
+
+      '
 - slug: source_distribution
   en:
-    term: "source distribution"
-    def: >
-      A [software distribution](#software_distribution) that includes the source code,
-      typically so that programs can be recompiled on the target computer when they
-      are installed.
+    term: source distribution
+    def: 'A [software distribution](#software_distribution) that includes the source
+      code, typically so that programs can be recompiled on the target computer when
+      they are installed.
 
+      '
 - slug: specificity
   en:
-    term: "specificity"
-    def: >
-      Statistical measure of a classification model which gives the True Negative rate.
-      For example, the proportion of people who do not have a disease that test negative.
-      Calculated as Specificity = TN/(TN+FP).
+    term: specificity
+    def: 'Statistical measure of a classification model which gives the True Negative
+      rate. For example, the proportion of people who do not have a disease that test
+      negative. Calculated as Specificity = TN/(TN+FP).
 
+      '
 - slug: spectral_analysis
   ref:
-    - python
-    - data_analysis
-    - bayesian_statistics
+  - python
+  - data_analysis
+  - bayesian_statistics
   en:
-    term: "spectral analysis"
-    def: >
-      From a finite record of a stationary data sequence, estimate how
-      the total power is distributed over frequency. See also "spectrum analysis problem".
+    term: spectral analysis
+    def: 'From a finite record of a stationary data sequence, estimate how the total
+      power is distributed over frequency. See also "spectrum analysis problem".
 
+      '
 - slug: sprint
   en:
-    term: "sprint"
-    def: >
-      A short, intense period of work on a project.
+    term: sprint
+    def: 'A short, intense period of work on a project.
 
-
+      '
 - slug: sql
   en:
-    term: "SQL"
-    def: >
-      The language used for writing queries for a [relational
-      database](#relational_database). The term is an acronym for
-      Structured Query Language.
-  es:
-    term: "SQL"
-    def: >
-      Lenguaje utilizado para escribir consultas para una [base de datos
-      relacional](#relational_database). El término está un acrónimo del
-      inglés Structured Query Language (Lenguage Estructurado de Consulta).
-  fr:
-    term: "SQL"
-    def: >
-      Langage employé pour composer des requêtes dans une
-      [base de données relationnelle](#relational_database).
-      Le terme est l'acronyme de "Structured Query Language" (langage de requête structuré).
+    term: SQL
+    def: 'The language used for writing queries for a [relational database](#relational_database).
+      The term is an acronym for Structured Query Language.
 
+      '
+  es:
+    term: SQL
+    def: 'Lenguaje utilizado para escribir consultas para una [base de datos relacional](#relational_database).
+      El término está un acrónimo del inglés Structured Query Language (Lenguage Estructurado
+      de Consulta).
+
+      '
+  fr:
+    term: SQL
+    def: 'Langage employé pour composer des requêtes dans une [base de données relationnelle](#relational_database).
+      Le terme est l''acronyme de "Structured Query Language" (langage de requête
+      structuré).
+
+      '
 - slug: square_root
   en:
-    term: "Square root"
-    def: >
-      A special case of the [n-th root](#root_math) for which n = 2, i.e. the 2-nd root has the special name "square root".
+    term: Square root
+    def: 'A special case of the [n-th root](#root_math) for which n = 2, i.e. the
+      2-nd root has the special name "square root".
 
+      '
 - slug: ssh
   en:
-    term: "Secure Shell"
-    acronym: "SSH"
-    def: >
-      A protocol and the program that implements it which allows remote access to a server through a secure channel where all information
-      is encrypted.
+    term: Secure Shell
+    acronym: SSH
+    def: 'A protocol and the program that implements it which allows remote access
+      to a server through a secure channel where all information is encrypted.
+
+      '
   es:
-    term: "Secure Shell"
-    acronym: "SSH"
-    def: >
-      Un protocolo y el programa que lo implementa cuya principal función es el
-      acceso remoto a un servidor por medio de un canal seguro en el que toda la
-      información está cifrada.
+    term: Secure Shell
+    acronym: SSH
+    def: 'Un protocolo y el programa que lo implementa cuya principal función es el
+      acceso remoto a un servidor por medio de un canal seguro en el que toda la información
+      está cifrada.
+
+      '
   uk:
-    term: "Secure Shell"
-    acronym: "SSH"
-    def: >
-      Протокол і програма, яка його реалізує, що дозволяє віддалений доступ до
+    term: Secure Shell
+    acronym: SSH
+    def: 'Протокол і програма, яка його реалізує, що дозволяє віддалений доступ до
       сервера через захищений канал, де вся інформація шифрується.
 
+      '
 - slug: ssh_key
   en:
-    term: "SSH key"
-    def: >
-      A string of random bits stored in a file that is used to identify a user for
-      [SSH](#ssh). Each SSH key has separate public and private parts; the public part
-      can safely be shared, but if the private part becomes known, the key is compromised.
-  uk:
-    term: "SSH-ключ"
-    def: >
-      Рядок випадкових бітів, збережений у файлі, який використовується для ідентифікації
-      користувача в [SSH](#ssh). Кожен SSH-ключ має окремі публічну та приватну частини; публічну
-      частину можна безпечно поширювати, але якщо приватна частина стає відомою, ключ вважається скомпрометованим.
+    term: SSH key
+    def: 'A string of random bits stored in a file that is used to identify a user
+      for [SSH](#ssh). Each SSH key has separate public and private parts; the public
+      part can safely be shared, but if the private part becomes known, the key is
+      compromised.
 
+      '
+  uk:
+    term: SSH-ключ
+    def: 'Рядок випадкових бітів, збережений у файлі, який використовується для ідентифікації
+      користувача в [SSH](#ssh). Кожен SSH-ключ має окремі публічну та приватну частини;
+      публічну частину можна безпечно поширювати, але якщо приватна частина стає відомою,
+      ключ вважається скомпрометованим.
+
+      '
+- slug: stack
+  ref:
+  - data_structure
+  - queue
+  en:
+    term: stack
+    def: 'A data structure that follows the Last-In-First-Out (LIFO) principle, where
+      elements are added and removed from the same end (the "top"). Like a stack of
+      plates where you can only add or remove from the top.
+
+      '
 - slug: stack_frame
   en:
-    term: "stack frame"
-    def: >
-      A section of the [call stack](#call_stack) that records details of a single call
-      to a specific function.
+    term: stack frame
+    def: 'A section of the [call stack](#call_stack) that records details of a single
+      call to a specific function.
 
-
+      '
 - slug: stack_overflow
   en:
-    term: "Stack Overflow"
-    def: >
-      A question-and-answer site popular among programmers.
+    term: Stack Overflow
+    def: 'A question-and-answer site popular among programmers.
+
+      '
   pt:
-    term: "Stack Overflow"
-    def: >
-      Um site de perguntas e respostas popular entre pessoas programadoras.
+    term: Stack Overflow
+    def: 'Um site de perguntas e respostas popular entre pessoas programadoras.
+
+      '
   es:
-    term: "Stack Overflow"
-    def: >
-      Un sitio de preguntas y respuestas popular entre personas programadoras.
+    term: Stack Overflow
+    def: 'Un sitio de preguntas y respuestas popular entre personas programadoras.
 
-
+      '
 - slug: standard_deviation
   ref:
-    - 68_95_997_rule
+  - 68_95_997_rule
   en:
-    term: "standard deviation"
-    def: >
-      How widely values in a dataset differ from the [mean](#mean). It is calculated
+    term: standard deviation
+    def: 'How widely values in a dataset differ from the [mean](#mean). It is calculated
       as the square root of the [variance](#variance).
+
+      '
   de:
-    term: "Standardabweichung"
-    def: >
-      Wie weit Werte in einem Datensatz vom [Mittelwert](#mean) abweichen. Die Standardabweichung
-      wird berechnet als Quadratwurzel der [Varianz](#variance).
+    term: Standardabweichung
+    def: 'Wie weit Werte in einem Datensatz vom [Mittelwert](#mean) abweichen. Die
+      Standardabweichung wird berechnet als Quadratwurzel der [Varianz](#variance).
 
+      '
   it:
-    term: "deviazione standard"
-    def: >
-      Misura della distanza dei valori dalla loro [media](#mean). È calcolata come
-      la radice quadrata della [varianza](#variance).
-  es:
-    term: "desviación estándar"
-    def: >
-      En qué medida los valores de un conjunto de datos difieren de la [media](#mean).
-      Se calcula como la raíz cuadrada de la [varianza](#variance).
-  pt:
-    term: "desvio padrão"
-    def: >
-      O quanto os valores de um conjunto de dados diferem da [média](#mean). É calculado
-      como a raiz quadrada da [variância](#variance).
-  uk:
-    term: "стандартне відхилення"
-    def: >
-      Показник того, наскількі широко значення в наборі даних відрізняються від [середнього](#mean). 
-      Обчислюється як квадратний корінь із [дисперсії](#variance).
+    term: deviazione standard
+    def: 'Misura della distanza dei valori dalla loro [media](#mean). È calcolata
+      come la radice quadrata della [varianza](#variance).
 
+      '
+  es:
+    term: desviación estándar
+    def: 'En qué medida los valores de un conjunto de datos difieren de la [media](#mean).
+      Se calcula como la raíz cuadrada de la [varianza](#variance).
+
+      '
+  pt:
+    term: desvio padrão
+    def: 'O quanto os valores de um conjunto de dados diferem da [média](#mean). É
+      calculado como a raiz quadrada da [variância](#variance).
+
+      '
+  uk:
+    term: стандартне відхилення
+    def: 'Показник того, наскількі широко значення в наборі даних відрізняються від
+      [середнього](#mean).  Обчислюється як квадратний корінь із [дисперсії](#variance).
+
+      '
 - slug: standard_normal_distribution
   en:
-    term: "standard normal distribution"
-    def: >
-      A [normal distribution](#normal_distribution) with a [mean](#mean) of 0 and a
-      [standard deviation](#standard_deviation) of 1. Values from normal distributions
+    term: standard normal distribution
+    def: 'A [normal distribution](#normal_distribution) with a [mean](#mean) of 0
+      and a [standard deviation](#standard_deviation) of 1. Values from normal distributions
       with other [parameters](#parameter) can easily be rescaled to be on a standard
       normal distribution.
+
+      '
   es:
-    term: "distribución normal estándar"
-    def: >
-      Una [distribución normal](#normal_distribution) con una [media](#mean) de
-      0 y una [desviación estándar](#standard_deviation) de 1. Valores de
-      distribuciones normales con otros parámetros se puede reescalar fácilmente
-      para obtener una distribución normal estándar.
+    term: distribución normal estándar
+    def: 'Una [distribución normal](#normal_distribution) con una [media](#mean) de
+      0 y una [desviación estándar](#standard_deviation) de 1. Valores de distribuciones
+      normales con otros parámetros se puede reescalar fácilmente para obtener una
+      distribución normal estándar.
+
+      '
   pt:
-    term: "distribuição normal padrão"
-    def: >
-      Uma [distribuição normal](#normal_distribution) com uma média 0 e um
-      [desvio padrão](#standard_deviation) de 1. Valores de distribuições normais
-      com outros parâmetros podem ser facilmente redimensionados para obter-se
-      uma distribuição normal padrão.
+    term: distribuição normal padrão
+    def: 'Uma [distribuição normal](#normal_distribution) com uma média 0 e um [desvio
+      padrão](#standard_deviation) de 1. Valores de distribuições normais com outros
+      parâmetros podem ser facilmente redimensionados para obter-se uma distribuição
+      normal padrão.
 
-
+      '
 - slug: stderr
   ref:
-    - stdin
-    - stdout
+  - stdin
+  - stdout
   en:
-    term: "standard error"
-    def: >
-      A predefined communication channel for a [process](#process), typically used for
-      error messages.
-  es:
-    term: "error estándar"
-    def: >
-      Un canal de comunicación predefinido para un [proceso](#process), usado típicamente 
-      para mensajes de error.
+    term: standard error
+    def: 'A predefined communication channel for a [process](#process), typically
+      used for error messages.
 
+      '
+  es:
+    term: error estándar
+    def: 'Un canal de comunicación predefinido para un [proceso](#process), usado
+      típicamente  para mensajes de error.
+
+      '
 - slug: stdin
   ref:
-    - stderr
-    - stdout
+  - stderr
+  - stdout
   en:
-    term: "standard input"
-    def: >
-      A predefined communication channel for a [process](#process), typically used to
-      read input from the keyboard or from the previous process in a [pipe](#pipe_shell).
-  es:
-    term: "entrada estándar"
-    def: >
-      Un canal de comunicación predefinido para un [proceso](#process), usado típicamente para
-      leer la entrada desde el teclado o desde el proceso anterior en el flujo de trabajo.
+    term: standard input
+    def: 'A predefined communication channel for a [process](#process), typically
+      used to read input from the keyboard or from the previous process in a [pipe](#pipe_shell).
 
+      '
+  es:
+    term: entrada estándar
+    def: 'Un canal de comunicación predefinido para un [proceso](#process), usado
+      típicamente para leer la entrada desde el teclado o desde el proceso anterior
+      en el flujo de trabajo.
+
+      '
 - slug: stdout
   ref:
-    - stderr
-    - stdin
+  - stderr
+  - stdin
   en:
-    term: "standard output"
-    def: >
-      A predefined communication channel for a [process](#process), typically used to
-      send output to the screen or to the next process in a [pipe](#pipe_shell).
+    term: standard output
+    def: 'A predefined communication channel for a [process](#process), typically
+      used to send output to the screen or to the next process in a [pipe](#pipe_shell).
+
+      '
   es:
-    term: "salida estándar"
-    def: >
-      Un canal de communication predefinido para un [proceso](#process), usado típicamente para
-      enviar la salida a la pantalla o al proceso siguiente en un flujo de trabajo.
+    term: salida estándar
+    def: 'Un canal de communication predefinido para un [proceso](#process), usado
+      típicamente para enviar la salida a la pantalla o al proceso siguiente en un
+      flujo de trabajo.
 
-
+      '
 - slug: stratified_sampling
   en:
-    term: "stratified sampling"
-    def: >
-      Selecting values by dividing the overall population into [homogeneous](#homogeneous)
+    term: stratified sampling
+    def: 'Selecting values by dividing the overall population into [homogeneous](#homogeneous)
+
+      '
   es:
-    term: "muestra estratificada"
-    def: >
-      Selecionar valores dividiendo la población general en grupos [homogéneos](#homogeneous)
-      y tomando luego una muestra aleatoria de cada grupo. 
-
-
+    term: muestra estratificada
+    def: "Selecionar valores dividiendo la población general en grupos [homogéneos](#homogeneous)\
+      \ y tomando luego una muestra aleatoria de cada grupo. \n"
 - slug: stream
   en:
-    term: "stream"
-    def: >
-      A sequential flow of data, such as the [bits](#bit) arriving across a network connection
-      or the bytes read from a file.
-  es:
-    term: "flujo"
-    def: >
-      Un flujo secuencial de datos, como los [bits](#bit) que llegan a través de una conexión de red 
-      o los bytes que see lean desde un archivo.
+    term: stream
+    def: 'A sequential flow of data, such as the [bits](#bit) arriving across a network
+      connection or the bytes read from a file.
 
+      '
+  es:
+    term: flujo
+    def: 'Un flujo secuencial de datos, como los [bits](#bit) que llegan a través
+      de una conexión de red  o los bytes que see lean desde un archivo.
+
+      '
 - slug: string
   en:
-    term: "string"
-    def: >
-      A block of text in a program. The term is short for "character string".
-  es:
-    term: "secuencia de caracteres"
-    def: >
-      Bloque de texto en un programa.
-  uk:
-    term: "рядок"
-    def: >
-      У мовах програмування — блок тексту, тобто послідовність символів, яка використовується 
-      для зберігання та маніпуляції текстовими даними.
+    term: string
+    def: 'A block of text in a program. The term is short for "character string".
 
+      '
+  es:
+    term: secuencia de caracteres
+    def: 'Bloque de texto en un programa.
+
+      '
+  uk:
+    term: рядок
+    def: 'У мовах програмування — блок тексту, тобто послідовність символів, яка використовується  для
+      зберігання та маніпуляції текстовими даними.
+
+      '
 - slug: string_interpolation
   en:
-    term: "string interpolation"
-    def: >
-      The process of inserting text corresponding to specified values into a [string](#string),
+    term: string interpolation
+    def: 'The process of inserting text corresponding to specified values into a [string](#string),
       usually to make output human-readable.
 
-
+      '
 - slug: students_t_distribution
   en:
-    term: "student's t-distribution"
-    def: >
-      See [t-distribution](#t_distribution).
+    term: student's t-distribution
+    def: 'See [t-distribution](#t_distribution).
 
-
+      '
 - slug: subcommand
   en:
-    term: "subcommand"
-    def: >
-      A command that is part of a larger family of commands. For example, `git commit`
-      is a subcommand of [Git](#git).
+    term: subcommand
+    def: 'A command that is part of a larger family of commands. For example, `git
+      commit` is a subcommand of [Git](#git).
 
-
+      '
 - slug: subdirectory
   ref:
-    - parent_directory
+  - parent_directory
   en:
-    term: "subdirectory"
-    def: >
-      A directory that is below another directory.
+    term: subdirectory
+    def: 'A directory that is below another directory.
 
-
+      '
 - slug: supervised_learning
   ref:
-    - unsupervised_learning
-    - reinforcement_learning
+  - unsupervised_learning
+  - reinforcement_learning
   en:
-    term: "supervised learning"
-    def: >
-      A [machine learning](#machine_learning) algorithm in which a system is taught to
-      [classify](#classification) values given [training data](#training_data) containing
-      previously-classified values.
-  es:
-    term: "aprendizaje supervisado"
-    def: >
-      Tipo de algoritmos en los que el sistema aprende patrones a partir de [datos de entrenamiento](#training_data) anotados/etiquetados.
+    term: supervised learning
+    def: 'A [machine learning](#machine_learning) algorithm in which a system is taught
+      to [classify](#classification) values given [training data](#training_data)
+      containing previously-classified values.
 
+      '
+  es:
+    term: aprendizaje supervisado
+    def: 'Tipo de algoritmos en los que el sistema aprende patrones a partir de [datos
+      de entrenamiento](#training_data) anotados/etiquetados.
+
+      '
 - slug: svm
   en:
-    term: "support vector machine"
-    acronym: "SVM"
-    def: >
-      A [supervised learning](#supervised_learning) algorithm that seeks to divide
-      points in a dataset so that the empty space between the resultant sets is as wide as possible.
+    term: support vector machine
+    acronym: SVM
+    def: 'A [supervised learning](#supervised_learning) algorithm that seeks to divide
+      points in a dataset so that the empty space between the resultant sets is as
+      wide as possible.
 
-
+      '
 - slug: synchronous
   ref:
-    - asynchronous
+  - asynchronous
   en:
-    term: "synchronous"
-    def: >
-      To happen at the same time. In programming, synchronous operations are ones that
-      have to run simultaneously, or complete at the same time.
+    term: synchronous
+    def: 'To happen at the same time. In programming, synchronous operations are ones
+      that have to run simultaneously, or complete at the same time.
+
+      '
   fr:
     term: synchrone
-    def: >
-      Qui se produit en même temps. En programmation, des opérations synchrones
-      sont des opérations qui doivent s'exécuter simultanémment ou se terminer en même temps.
+    def: 'Qui se produit en même temps. En programmation, des opérations synchrones
+      sont des opérations qui doivent s''exécuter simultanémment ou se terminer en
+      même temps.
 
+      '
 - slug: systematic_error
   en:
-    term: "systematic error"
-    def: >
-      See [bias](#bias).
+    term: systematic error
+    def: 'See [bias](#bias).
 
-
+      '
 - slug: t_distribution
   ref:
-    - students_t_distribution
+  - students_t_distribution
   en:
-    term: "t-distribution"
-    def: >
-      A variation on the [normal distribution](#normal_distribution) that is adjusted
-      to account for estimating [variance](#variance) from the sample instead of
-      knowing it in advance.
+    term: t-distribution
+    def: 'A variation on the [normal distribution](#normal_distribution) that is adjusted
+      to account for estimating [variance](#variance) from the sample instead of knowing
+      it in advance.
 
-
+      '
 - slug: tab_completion
   en:
-    term: "tab completion"
-    def: >
-      A technique implemented by most [REPLs](#repl), [shells](#shell), and
-      programming editors that completes a command, variable name, filename, or other
-      text when the TAB key is pressed.
+    term: tab completion
+    def: 'A technique implemented by most [REPLs](#repl), [shells](#shell), and programming
+      editors that completes a command, variable name, filename, or other text when
+      the TAB key is pressed.
 
-
+      '
 - slug: table
   en:
-    term: "table"
-    def: >
-      A set of [records](#record) in a [relational database](#relational_database) or
-      [observations](#observation) in a [data frame](#data_frame). Tables are usually displayed as
-      rows (each of which represents one record or observation and columns (each of which represents a
-      [field](#field) or [variable](#variable_data).
+    term: table
+    def: 'A set of [records](#record) in a [relational database](#relational_database)
+      or [observations](#observation) in a [data frame](#data_frame). Tables are usually
+      displayed as rows (each of which represents one record or observation and columns
+      (each of which represents a [field](#field) or [variable](#variable_data).
+
+      '
   fr:
-    term: "table"
-    def: >
-      Une série d'entrées dans une [base de données
-      relationnelle](#relational_database) ou d'observations dans une [trame de
-      données](#data_frame). Une table est généralement représentée sous la forme de
-      lignes (où chacune représente une [entrée](#record) ou
-      [observation](#observation)) et colonnes (où chacune représente un
-      [champ](#field) ou une [variable](#variable_data)).
+    term: table
+    def: 'Une série d''entrées dans une [base de données relationnelle](#relational_database)
+      ou d''observations dans une [trame de données](#data_frame). Une table est généralement
+      représentée sous la forme de lignes (où chacune représente une [entrée](#record)
+      ou [observation](#observation)) et colonnes (où chacune représente un [champ](#field)
+      ou une [variable](#variable_data)).
 
-
+      '
 - slug: tag
   en:
-    term: "tag (in version control)"
-    def: >
-      A readable label attached to a specific [commit](#commit) so that it can easily
-      be referenced later.
+    term: tag (in version control)
+    def: 'A readable label attached to a specific [commit](#commit) so that it can
+      easily be referenced later.
 
-
+      '
 - slug: tdd
   en:
-    term: "test-driven development"
-    acronym: "TDD"
-    def: >
-      A programming practice in which tests are written before a new feature is added
-      or a [bug](#bug) is fixed in order to clarify the goal.
+    term: test-driven development
+    acronym: TDD
+    def: 'A programming practice in which tests are written before a new feature is
+      added or a [bug](#bug) is fixed in order to clarify the goal.
 
-
+      '
 - slug: template_method_pattern
   en:
-    term: "Template Method pattern"
-    def: >
-      A [design pattern](#design_pattern) in which a [parent class](#parent_class)
-      defines an overall sequence of operations by calling [abstract
-      methods](#abstract_method) that [child classes](#child_class) must then
-      implement. Each child class then behaves in the same general way, but implements
-      the steps differently.
+    term: Template Method pattern
+    def: 'A [design pattern](#design_pattern) in which a [parent class](#parent_class)
+      defines an overall sequence of operations by calling [abstract methods](#abstract_method)
+      that [child classes](#child_class) must then implement. Each child class then
+      behaves in the same general way, but implements the steps differently.
 
+      '
+- slug: tensorflow
+  ref:
+  - deep_learning
+  - neural_network
+  - machine_learning
+  en:
+    term: TensorFlow
+    def: 'An open-source [machine learning](#machine_learning) framework developed
+      by Google for building and training [neural networks](#neural_network) and other
+      ML models. Provides tools for both research and production deployment.
 
+      '
 - slug: ternary_expression
   ref:
-    - binary_expression
-    - nullary_expression
-    - unary_expression
+  - binary_expression
+  - nullary_expression
+  - unary_expression
   en:
-    term: "ternary expression"
-    def: >
-      An expression that has three parts. [Conditional expressions](#conditional_expression)
+    term: ternary expression
+    def: 'An expression that has three parts. [Conditional expressions](#conditional_expression)
       are the only ternary expressions in most languages.
 
+      '
 - slug: tessellation_shader
   ref:
-    - geometry_shader
-    - gpu
-    - shader
+  - geometry_shader
+  - gpu
+  - shader
   en:
-    term: "tessellation shader"
-    def: >
-      The [shader](#shader) stage in the rendering pipeline designated towards subdividing
-      primitives to increase the resolution of a mesh without impacting memory. Not to be
-      confused with [geometry shaders](#geometry_shader) which change the overall shape.
+    term: tessellation shader
+    def: 'The [shader](#shader) stage in the rendering pipeline designated towards
+      subdividing primitives to increase the resolution of a mesh without impacting
+      memory. Not to be confused with [geometry shaders](#geometry_shader) which change
+      the overall shape.
 
+      '
 - slug: test_data
   en:
-    term: "test data"
-    def: >
-      Test data is a portion of a dataset used to evaluate the correctness of a
-      [machine learning](#machine_learning) algorithm after it has been trained.
-      It should always be separated from the [training data](#training_data) to
-      ensure that the model is properly tested with unseen data.
-  uk:
-    term: "тестові дані"
-    def: >
-      Частина набору даних, яка використовується для оцінки коректності 
-      алгоритму [машинного навчання](#machine_learning) після його тренування.
-      Тестові дані завжди повинні бути відокремлені від [тренувальних даних](#training_data), щоб
-      гарантувати, що модель належним чином протестована на даних, які не використовувалися раніше.
+    term: test data
+    def: 'Test data is a portion of a dataset used to evaluate the correctness of
+      a [machine learning](#machine_learning) algorithm after it has been trained.
+      It should always be separated from the [training data](#training_data) to ensure
+      that the model is properly tested with unseen data.
 
+      '
+  uk:
+    term: тестові дані
+    def: 'Частина набору даних, яка використовується для оцінки коректності  алгоритму
+      [машинного навчання](#machine_learning) після його тренування. Тестові дані
+      завжди повинні бути відокремлені від [тренувальних даних](#training_data), щоб
+      гарантувати, що модель належним чином протестована на даних, які не використовувалися
+      раніше.
+
+      '
 - slug: test_runner
   en:
-    term: "test runner"
-    def: >
-      A program that finds and runs software tests and reports their results.
+    term: test runner
+    def: 'A program that finds and runs software tests and reports their results.
 
+      '
+- slug: test_set
+  ref:
+  - training_set
+  - validation_set
+  - machine_learning
+  en:
+    term: test set
+    def: 'A portion of a [dataset](#dataset) held out from model training and used
+      to evaluate the final model''s performance on unseen data. Unlike a [validation
+      set](#validation_set), the test set should only be used once, at the very end
+      of model development.
 
+      '
 - slug: three_vs
   en:
-    term: "three Vs"
-    def: >
-      The volume, velocity, and variety that distinguish [big data](#big_data).
+    term: three Vs
+    def: 'The volume, velocity, and variety that distinguish [big data](#big_data).
 
-
+      '
 - slug: throw_exception
   en:
-    term: "throw (exception)"
-    def: >
-      Another term for [raising](#raise_exception) an exception.
+    term: throw (exception)
+    def: 'Another term for [raising](#raise_exception) an exception.
 
-
+      '
 - slug: tibble
   en:
-    term: "tibble"
-    def: >
-      A modern replacement for [R](#r_language)'s data frame, which stores tabular data in columns
-      and rows, defined and used in the [tidyverse](#tidyverse).
+    term: tibble
+    def: 'A modern replacement for [R](#r_language)''s data frame, which stores tabular
+      data in columns and rows, defined and used in the [tidyverse](#tidyverse).
+
+      '
   fr:
-    term: "tibble"
-    def: >
-      Une alternative moderne du "data frame" en [R](#r_language) permettant de matérialiser des
-      données tabulaires en colonnes et en lignes. Le "tibble" a été défini et est
-      utilisé dans le [tidyverse](#tidyverse).
+    term: tibble
+    def: 'Une alternative moderne du "data frame" en [R](#r_language) permettant de
+      matérialiser des données tabulaires en colonnes et en lignes. Le "tibble" a
+      été défini et est utilisé dans le [tidyverse](#tidyverse).
+
+      '
   es:
-    term: "tibble"
-    def: >
-      Un remplazo moderno para los data frames de [R](#r_language) que guarda datos tabulares en
-      columnas y filas, definido y usado en el [tidyverse](#tidyverse).
+    term: tibble
+    def: 'Un remplazo moderno para los data frames de [R](#r_language) que guarda
+      datos tabulares en columnas y filas, definido y usado en el [tidyverse](#tidyverse).
 
-
+      '
 - slug: ticket
   en:
-    term: "ticket"
-    def: >
-      See [issue](#issue).
+    term: ticket
+    def: 'See [issue](#issue).
 
-
+      '
 - slug: ticketing_system
   en:
-    term: "ticketing system"
-    def: >
-      See [issue tracking system](#issue_tracking_system).
+    term: ticketing system
+    def: 'See [issue tracking system](#issue_tracking_system).
 
-
+      '
 - slug: tidy_data
   ref:
-    - table
+  - table
   en:
-    term: "tidy data"
-    def: >
-      Tabular data that satisfies [three
-      conditions](https://vita.had.co.nz/papers/tidy-data.pdf) that facilitate initial
-      cleaning, and later exploration and analysis—(1) each variable forms a column,
-      (2) each observation forms a row, and (3) each type of observation unit forms a table.
+    term: tidy data
+    def: 'Tabular data that satisfies [three conditions](https://vita.had.co.nz/papers/tidy-data.pdf)
+      that facilitate initial cleaning, and later exploration and analysis—(1) each
+      variable forms a column, (2) each observation forms a row, and (3) each type
+      of observation unit forms a table.
+
+      '
   es:
-    term: "datos ordenados"
-    def: >
-      Datos tabulares que satisfacen [tres
-      condiciones](https://vita.had.co.nz/papers/tidy-data.pdf) que facilitan su
-      limpieza inicial y su posterior exploración y análisis—(1) cada variable
-      conforma una columna, (2) cada observación conforma una fila y (3) cada tipo de
-      unidad de observación conforma una tabla.
+    term: datos ordenados
+    def: 'Datos tabulares que satisfacen [tres condiciones](https://vita.had.co.nz/papers/tidy-data.pdf)
+      que facilitan su limpieza inicial y su posterior exploración y análisis—(1)
+      cada variable conforma una columna, (2) cada observación conforma una fila y
+      (3) cada tipo de unidad de observación conforma una tabla.
 
-
+      '
 - slug: tidymodels
   en:
-    term: "Tidymodels"
-    def: >
-      A collection of [R](#r_language) [packages](#package) for modeling and statistical analysis designed with a
-      [shared philosophy](https://tidymodels.github.io/model-implementation-principles/index.html).
+    term: Tidymodels
+    def: 'A collection of [R](#r_language) [packages](#package) for modeling and statistical
+      analysis designed with a [shared philosophy](https://tidymodels.github.io/model-implementation-principles/index.html).
+
+      '
   fr:
-    term: "Tidymodels"
-    def: >
-      Une collection de packages [R](#r_language) pour la modélisation et l'analyse statistique,
-      élaborés en prenant en considération une [philosophie partagée](https://tidymodels.github.io/model-implementation-principles/index.html)
+    term: Tidymodels
+    def: 'Une collection de packages [R](#r_language) pour la modélisation et l''analyse
+      statistique, élaborés en prenant en considération une [philosophie partagée](https://tidymodels.github.io/model-implementation-principles/index.html)
 
-
+      '
 - slug: tidyverse
   en:
-    term: "Tidyverse"
-    def: >
-      A collection of [R](#r_language) [packages](#package) for operating on tabular data in consistent ways.
+    term: Tidyverse
+    def: 'A collection of [R](#r_language) [packages](#package) for operating on tabular
+      data in consistent ways.
+
+      '
   fr:
-    term: "Tidyverse"
-    def: >
-      Une collection de packages [R](#r_language) permettant le traitement des données tabulaires
-      d'une manière cohérente.
+    term: Tidyverse
+    def: 'Une collection de packages [R](#r_language) permettant le traitement des
+      données tabulaires d''une manière cohérente.
+
+      '
   es:
-    term: "Tidyverse"
-    def: >
-      Una colección de paquetes de [R](#r_language) para operar de maneras consistentes con datos tabulares.
+    term: Tidyverse
+    def: 'Una colección de paquetes de [R](#r_language) para operar de maneras consistentes
+      con datos tabulares.
+
+      '
   pt:
-    term: "Tidyverse"
-    def: >
-      Uma coleção de pacotes de [R](#r_language) para trabalhar de forma consistente com dados tabulares.
+    term: Tidyverse
+    def: 'Uma coleção de pacotes de [R](#r_language) para trabalhar de forma consistente
+      com dados tabulares.
 
-
+      '
 - slug: time_series
   ref:
-    - moving_average
+  - moving_average
   en:
-    term: "time series"
-    def: >
-      A set of measurements taken at different times, which may or may not be regular intervals.
+    term: time series
+    def: 'A set of measurements taken at different times, which may or may not be
+      regular intervals.
 
-
+      '
 - slug: timestamp
   en:
-    term: "timestamp"
-    def: >
-      A digital identifier showing the time at which something was created or
+    term: timestamp
+    def: 'A digital identifier showing the time at which something was created or
       accessed. Timestamps should use [ISO date format](#iso_date_format) for portability.
 
-
+      '
 - slug: tls
   en:
-    term: "Transport Layer Security"
-    acronym: "TLS"
-    def: >
-      A cryptographic protocol for securing communications over a computer network.
+    term: Transport Layer Security
+    acronym: TLS
+    def: 'A cryptographic protocol for securing communications over a computer network.
 
-
+      '
 - slug: tolerance
   en:
-    term: "tolerance"
-    def: >
-      How closely the [actual result](#actual_result) of a test must agree with the
-      [expected result](#expected_result) in order for the test to pass. Tolerances
+    term: tolerance
+    def: 'How closely the [actual result](#actual_result) of a test must agree with
+      the [expected result](#expected_result) in order for the test to pass. Tolerances
       are usually expressed in terms of [relative error](#relative_error).
 
-
+      '
 - slug: training_data
   en:
-    term: "training data"
-    def: >
-      Training data is a portion of a dataset used to train [machine learning](#machine_learning)
+    term: training data
+    def: 'Training data is a portion of a dataset used to train [machine learning](#machine_learning)
       algorithm to recognise similar data. It should always be separated from the
-      [test data](#test_data) to ensure that the model is properly tested with data it has
-      never seen before.
-  uk:
-    term: "тренувальні дані"
-    def: >
-      Частина набору даних, яка використовується для тренування алгоритму 
-      [машинного навчання](#machine_learning), щоб розпізнувати схожі дані. 
-      Тренувальні дані завжди мають бути відокремлені від [тестових даних](#test_data), 
-      щоб гарантувати, що модель протестована на даних, які не використовувалися раніше.
+      [test data](#test_data) to ensure that the model is properly tested with data
+      it has never seen before.
 
+      '
+  uk:
+    term: тренувальні дані
+    def: 'Частина набору даних, яка використовується для тренування алгоритму  [машинного
+      навчання](#machine_learning), щоб розпізнувати схожі дані.  Тренувальні дані
+      завжди мають бути відокремлені від [тестових даних](#test_data),  щоб гарантувати,
+      що модель протестована на даних, які не використовувалися раніше.
+
+      '
+- slug: training_set
+  ref:
+  - test_set
+  - validation_set
+  - machine_learning
+  en:
+    term: training set
+    def: 'The portion of a [dataset](#dataset) used to train a [machine learning](#machine_learning)
+      model. The model learns patterns from this data by adjusting its parameters
+      to minimize the [loss function](#loss_function).
+
+      '
+- slug: transfer_learning
+  ref:
+  - deep_learning
+  - transfer_learning
+  en:
+    term: transfer learning (deep learning)
+    def: 'Transfer learning is a specific form of deep learning that has 2 stages.
+      First, in the pre-training  phase, a neural network is trained on a (typically
+      large) generic dataset. Second, the  fine-tuning phase, the neural network is
+      adapted to the specifics of a (typically smaller) new  dataset. The idea is
+      that the network will capture generic knowledge in the pre-training phase  that
+      is relevant for learning in the fine-tuning task.
+
+      '
+- slug: transformer
+  ref:
+  - neural_network
+  - deep_learning
+  en:
+    term: transformer
+    def: 'A [neural network](#neural_network) architecture based on attention mechanisms
+      that processes entire sequences simultaneously rather than sequentially. Transformers
+      have become dominant in natural language processing, powering models like BERT
+      and GPT.
+
+      '
 - slug: transitive_dependency
   en:
-    term: "transitive dependency"
-    def: >
-      If A depends on B and B depends on C, C is a transitive dependency of A.
+    term: transitive dependency
+    def: 'If A depends on B and B depends on C, C is a transitive dependency of A.
 
-
+      '
 - slug: tree
   en:
-    term: "tree"
-    def: >
-      A [graph](#graph) in which every node except the [root](#root_tree) has exactly
-      one [parent](#parent_tree).
+    term: tree
+    def: 'A [graph](#graph) in which every node except the [root](#root_tree) has
+      exactly one [parent](#parent_tree).
 
-
+      '
 - slug: triage
   en:
-    term: "triage"
-    def: >
-      To go through the [issues](#issue) associated with a project and decide which
-      are currently priorities. Triage is one of the key responsibilities of a
-      [project manager](#project_manager).
+    term: triage
+    def: 'To go through the [issues](#issue) associated with a project and decide
+      which are currently priorities. Triage is one of the key responsibilities of
+      a [project manager](#project_manager).
 
-
-- slug: "true"
+      '
+- slug: 'true'
   ref:
-    - truthy
-    - falsy
+  - truthy
+  - falsy
   en:
-    term: "true"
-    def: >
-      The logical ([Boolean](#boolean)) state opposite of "[false](#false)". Used in
-      logic and programming to represent a [binary](#binary) state of something.
+    term: 'true'
+    def: 'The logical ([Boolean](#boolean)) state opposite of "[false](#false)". Used
+      in logic and programming to represent a [binary](#binary) state of something.
 
-
+      '
 - slug: true_negative
   ref:
-    - true_positive
-    - false_negative
-    - false_positive
-    - machine_learning
-    - classification
+  - true_positive
+  - false_negative
+  - false_positive
+  - machine_learning
+  - classification
   en:
-    term: "true negative"
-    def: >
-      Data points which are actually [false](#false) and correctly predicted as [false](#false).
+    term: true negative
+    def: 'Data points which are actually [false](#false) and correctly predicted as
+      [false](#false).
+
+      '
   es:
-    term: "verdadero negativo"
-    def: >
-      Resultado en el que el valor real es [negativo](#false) y es correctamente predicho como [negativo](#false).
+    term: verdadero negativo
+    def: 'Resultado en el que el valor real es [negativo](#false) y es correctamente
+      predicho como [negativo](#false).
 
-
+      '
 - slug: true_positive
   ref:
-    - true_negative
-    - false_negative
-    - false_positive
-    - machine_learning
-    - classification
+  - true_negative
+  - false_negative
+  - false_positive
+  - machine_learning
+  - classification
   en:
-    term: "true positive"
-    def: >
-      Data points which are actually [true](#true) and correctly predicted as [true](#true).
+    term: true positive
+    def: 'Data points which are actually [true](#true) and correctly predicted as
+      [true](#true).
+
+      '
   es:
-    term: "verdadero positivo"
-    def: >
-      Resultado en el que el valor real es [verdadero](#true) y es correctamente predicho como [verdadero](#true).
+    term: verdadero positivo
+    def: 'Resultado en el que el valor real es [verdadero](#true) y es correctamente
+      predicho como [verdadero](#true).
 
-
+      '
 - slug: truthy
   ref:
-    - falsy
+  - falsy
   en:
-    term: "truthy"
-    def: >
-      Evaluating to [true](#true) in a [Boolean](#boolean) context.
+    term: truthy
+    def: 'Evaluating to [true](#true) in a [Boolean](#boolean) context.
 
-
+      '
 - slug: tuple
   en:
-    term: "tuple"
-    def: >
-      A data type that has a fixed number of parts, such as the three color components of a
-      red-green-blue color specification. In "[Python](#python)", tuples are immutable (their
-      values cannot be reset.)
+    term: tuple
+    def: 'A data type that has a fixed number of parts, such as the three color components
+      of a red-green-blue color specification. In "[Python](#python)", tuples are
+      immutable (their values cannot be reset.)
+
+      '
   fr:
-    term: "tuple"
-    def: >
-      Un type de donnée correspondant à une collection d'objets en nombre fixé, par exemple
-      les trois composantes de la spécification rouge-vert-bleu d'une couleur. En "[Python](#python)",
-      les tuples sont immuables (leurs valeurs sont fixées à l'initialisation et ne peuvent plus être
-      modifiées par la suite).
+    term: tuple
+    def: 'Un type de donnée correspondant à une collection d''objets en nombre fixé,
+      par exemple les trois composantes de la spécification rouge-vert-bleu d''une
+      couleur. En "[Python](#python)", les tuples sont immuables (leurs valeurs sont
+      fixées à l''initialisation et ne peuvent plus être modifiées par la suite).
       Les tuples contenant n objets sont aussi appelés n-uplets.
 
+      '
 - slug: two_hard_problems
   en:
-    term: "two hard problems in computer science"
-    def: >
-      Refers to a quote by Phil Karlton—"There are only two hard problems in computer
-      science—cache invalidation and naming things." Many variations add a third
-      problem (most often "[off-by-one errors](#off_by_one_error)").
+    term: two hard problems in computer science
+    def: 'Refers to a quote by Phil Karlton—"There are only two hard problems in computer
+      science—cache invalidation and naming things." Many variations add a third problem
+      (most often "[off-by-one errors](#off_by_one_error)").
 
-
+      '
 - slug: type_coercion
   en:
-    term: "type coercion"
-    def: >
-      To convert data from one type to another, e.g., from the integer `4` to the
-      equivalent floating point number `4.0`.
+    term: type coercion
+    def: 'To convert data from one type to another, e.g., from the integer `4` to
+      the equivalent floating point number `4.0`.
 
-
+      '
 - slug: unary_expression
   ref:
-    - binary_expression
-    - nullary_expression
-    - ternary_expression
+  - binary_expression
+  - nullary_expression
+  - ternary_expression
   en:
-    term: "unary expression"
-    def: >
-      An expression with one argument, such as `log 5`.
+    term: unary expression
+    def: 'An expression with one argument, such as `log 5`.
+
+      '
   es:
-    term: "expresión unaria"
-    def: >
-      Una expresión con un único argumento, como `log 5`.
+    term: expresión unaria
+    def: 'Una expresión con un único argumento, como `log 5`.
 
+      '
+- slug: underfitting
+  ref:
+  - overfitting
+  - machine_learning
+  en:
+    term: underfitting
+    def: 'When a [machine learning](#machine_learning) model is too simple to capture
+      the underlying patterns in the data, resulting in poor performance on both training
+      and test data. The opposite of [overfitting](#overfitting).
 
+      '
 - slug: unicode
   en:
-    term: "Unicode"
-    def: >
-      A standard that defines numeric codes for many thousands of characters and
-      symbols. Unicode does not define how those numbers are stored; that is done by
-      standards like [UTF-8](#utf_8).
-  de:
-    term: "Unicode"
-    def: >
-      Ein Standard, der einen numerischen Zeichensatz für viele tausend Zeichen und
-      Symbole definiert. Unicode definiert nicht, wie diese Zahlen gespeichert werden;
-      das geschieht durch Standards wie [UTF-8](#utf_8).
-  fr:
-    term: "Unicode"
-    def: >
-      Une norme qui définit des codes numériques pour plusieurs milliers de caractères
-      et de symboles. Unicode ne définit pas comment ces nombres sont stockés ; cela est
-      fait par des normes comme [UTF-8](#utf_8).
-  uk:
-    term: "Unicode"
-    def: >
-      Промисловий стандарт і специфікація, розроблені для забезпечення цифрового представлення 
-      символів усіх писемностей світу та спеціальних символів. Unicode надає кожному символу
-      його унікальний код. Специфікації Unicode постійно переглядаються й оновлюються для 
-      додавання нових мов і символів. Стандарт не визначає, як ці числові коди зберігаються
-      в пам'яті комп'ютера; для цього існують інші стандарти збереження, такі як [UTF-8](#utf_8).
+    term: Unicode
+    def: 'A standard that defines numeric codes for many thousands of characters and
+      symbols. Unicode does not define how those numbers are stored; that is done
+      by standards like [UTF-8](#utf_8).
 
+      '
+  de:
+    term: Unicode
+    def: 'Ein Standard, der einen numerischen Zeichensatz für viele tausend Zeichen
+      und Symbole definiert. Unicode definiert nicht, wie diese Zahlen gespeichert
+      werden; das geschieht durch Standards wie [UTF-8](#utf_8).
+
+      '
+  fr:
+    term: Unicode
+    def: 'Une norme qui définit des codes numériques pour plusieurs milliers de caractères
+      et de symboles. Unicode ne définit pas comment ces nombres sont stockés ; cela
+      est fait par des normes comme [UTF-8](#utf_8).
+
+      '
+  uk:
+    term: Unicode
+    def: 'Промисловий стандарт і специфікація, розроблені для забезпечення цифрового
+      представлення  символів усіх писемностей світу та спеціальних символів. Unicode
+      надає кожному символу його унікальний код. Специфікації Unicode постійно переглядаються
+      й оновлюються для  додавання нових мов і символів. Стандарт не визначає, як
+      ці числові коди зберігаються в пам''яті комп''ютера; для цього існують інші
+      стандарти збереження, такі як [UTF-8](#utf_8).
+
+      '
 - slug: unit_test
   ref:
-    - integration_test
+  - integration_test
   en:
-    term: "unit test"
-    def: >
-      A test that exercises one function or feature of a piece of software and
+    term: unit test
+    def: 'A test that exercises one function or feature of a piece of software and
       produces [pass](#pass_test), [fail](#fail_test), or [error](#error_test).
 
-
+      '
 - slug: unix
   ref:
-    - operating_system
+  - operating_system
   en:
-    term: "UNIX"
-    def: >
-      UNIX is a family of [operating systems](#operating_system) developed during
+    term: UNIX
+    def: 'UNIX is a family of [operating systems](#operating_system) developed during
       1969 at AT&T Bell Labs. Its main features are simple tools, well-defined functionality
       and being portable by nature.
+
+      '
   es:
-    term: "UNIX"
-    def: >
-      UNIX es una familia de [sistemas operativos](#operating_system) desarrollada en 1969 en AT&T Bell Labs.
-      Sus principales características son herramientas sencillas, funcionalidad bien definida y portabilidad.
+    term: UNIX
+    def: 'UNIX es una familia de [sistemas operativos](#operating_system) desarrollada
+      en 1969 en AT&T Bell Labs. Sus principales características son herramientas
+      sencillas, funcionalidad bien definida y portabilidad.
 
-
+      '
 - slug: unsupervised_learning
   ref:
-    - supervised_learning
-    - reinforcement_learning
+  - supervised_learning
+  - reinforcement_learning
   en:
-    term: "unsupervised learning"
-    def: >
-      Algorithms that [cluster](#clustering) data without knowing in advance what the
-      groups will be.
+    term: unsupervised learning
+    def: 'Algorithms that [cluster](#clustering) data without knowing in advance what
+      the groups will be.
+
+      '
   es:
-    term: "aprendizaje no supervisado"
-    def: >
-      Un tipo de algoritmos que aprenden patrones a partir de datos sin anotar/etiquetar.
+    term: aprendizaje no supervisado
+    def: 'Un tipo de algoritmos que aprenden patrones a partir de datos sin anotar/etiquetar.
 
-
+      '
 - slug: up_vote
   ref:
-    - down_vote
+  - down_vote
   en:
-    term: "up-vote"
-    def: >
-      A vote in favor of something.
+    term: up-vote
+    def: 'A vote in favor of something.
 
-
+      '
 - slug: update_operator
   en:
-    term: "update operator"
-    def: >
-      See [in-place operator](#in_place_operator).
+    term: update operator
+    def: 'See [in-place operator](#in_place_operator).
 
-
+      '
 - slug: upstream_repository
   en:
-    term: "upstream repository"
-    def: >
-      The [remote repository](#remote_repository) from which this [repository](#repository) was derived.
-      Programmers typically save changes in their own repository and then submit
-      a [pull request](#pull_request) to the upstream repository where changes from
-      other programmers are also collected.
+    term: upstream repository
+    def: 'The [remote repository](#remote_repository) from which this [repository](#repository)
+      was derived. Programmers typically save changes in their own repository and
+      then submit a [pull request](#pull_request) to the upstream repository where
+      changes from other programmers are also collected.
 
-
+      '
 - slug: url
   en:
-    term: "Uniform Resource Locator"
-    acronym: "URL"
-    def: >
-      A unique address on the World-Wide Web. URLs originally identified web pages,
-      but may also represent datasets or database queries, particularly if they
-      include a [query string](#query_string).
+    term: Uniform Resource Locator
+    acronym: URL
+    def: 'A unique address on the World-Wide Web. URLs originally identified web pages,
+      but may also represent datasets or database queries, particularly if they include
+      a [query string](#query_string).
 
-
+      '
 - slug: user_interface
   ref:
-    - cli
-    - gui
+  - cli
+  - gui
   en:
-    term: "user interface"
-    acronym: "UI"
-    def: >
-      Platform for interaction between a user and a machine. The interaction may occur via text
-      (a [command line interface](#cli)), graphics and windows (a [graphical user interface](#gui)),
-      or other methods such as voice-driven interfaces.
+    term: user interface
+    acronym: UI
+    def: 'Platform for interaction between a user and a machine. The interaction may
+      occur via text (a [command line interface](#cli)), graphics and windows (a [graphical
+      user interface](#gui)), or other methods such as voice-driven interfaces.
+
+      '
   es:
-    term: "interfaz de usuario"
-    def: >
-      Plataforma para la interacción entre un usuario y una máquina.
-      Una interacción puede ocurrir mediante texto (una [interfaz de línea de comandos](#cli)),
-      gráficamente y con ventanas (una [interfaz gráfica de usuario](#gui)),
-      u otros métodos tal como interfaces manejadas por voz.
+    term: interfaz de usuario
+    def: 'Plataforma para la interacción entre un usuario y una máquina. Una interacción
+      puede ocurrir mediante texto (una [interfaz de línea de comandos](#cli)), gráficamente
+      y con ventanas (una [interfaz gráfica de usuario](#gui)), u otros métodos tal
+      como interfaces manejadas por voz.
 
-
+      '
 - slug: utf_8
   en:
-    term: "UTF-8"
-    def: >
-      A way to store the numeric codes representing [Unicode](#unicode) characters in memory that
-      is [backward-compatible](#backward_compatible) with the older [ASCII](#ascii) standard.
-  uk: 
-    term: "UTF-8"
-    def: >
-      Cпосіб зберігання числових кодів, що представляють символи [Unicode](#unicode) в пам'яті. 
-      UTF-8 є системою кодування зі змінною довжиною, що використовує від одного до чотирьох байтів на символ. 
-      Якщо символ належить до перших 127 символів кодування [ASCII](#ascii), він кодується одним байтом, 
-      забезпечуючи [повну сумісність](#backward_compatible) з ASCII. Для інших символів використовуються два, 
-      три або чотири байти, залежно від конкретного символу. Це дозволяє ефективно зберігати тексти різних мов, 
-      хоча розмір памʼяті, потрібної для зберігання тексту, може збільшуватися.
+    term: UTF-8
+    def: 'A way to store the numeric codes representing [Unicode](#unicode) characters
+      in memory that is [backward-compatible](#backward_compatible) with the older
+      [ASCII](#ascii) standard.
 
+      '
+  uk:
+    term: UTF-8
+    def: 'Cпосіб зберігання числових кодів, що представляють символи [Unicode](#unicode)
+      в пам''яті.  UTF-8 є системою кодування зі змінною довжиною, що використовує
+      від одного до чотирьох байтів на символ.  Якщо символ належить до перших 127
+      символів кодування [ASCII](#ascii), він кодується одним байтом,  забезпечуючи
+      [повну сумісність](#backward_compatible) з ASCII. Для інших символів використовуються
+      два,  три або чотири байти, залежно від конкретного символу. Це дозволяє ефективно
+      зберігати тексти різних мов,  хоча розмір памʼяті, потрібної для зберігання
+      тексту, може збільшуватися.
+
+      '
+- slug: validation_set
+  ref:
+  - training_set
+  - test_set
+  - machine_learning
+  en:
+    term: validation set
+    def: 'A portion of a [dataset](#dataset) held out during training to tune model
+      hyperparameters and make decisions about model architecture. Unlike the [test
+      set](#test_set), the validation set can be used multiple times during model
+      development.
+
+      '
 - slug: variable_arguments
   ref:
-    - keyword_argument
-    - named_argument
+  - keyword_argument
+  - named_argument
   en:
-    term: "variable arguments"
-    def: >
-      In a function, the ability to take any number of arguments. [R](#r_language) uses `...` to
-      capture the "extra" arguments. [Python](#python) uses `*args` and `**kwargs` to capture
-      unnamed, and named, "extra" arguments, respectively.
+    term: variable arguments
+    def: 'In a function, the ability to take any number of arguments. [R](#r_language)
+      uses `...` to capture the "extra" arguments. [Python](#python) uses `*args`
+      and `**kwargs` to capture unnamed, and named, "extra" arguments, respectively.
+
+      '
   fr:
-    term: "arguments en nombre variable"
-    def: >
-      La possibilité d'intégrer n'importe quel nombre d'arguments dans une fonction. [R](#r_language)
-      utilise `...` afin de capturer les arguments "additionnels". [Python](#python) utilise `*args`
-      et `**kwargs` pour capturer respectivement les paramètres "additionnels" nommés et non nommés.
+    term: arguments en nombre variable
+    def: 'La possibilité d''intégrer n''importe quel nombre d''arguments dans une
+      fonction. [R](#r_language) utilise `...` afin de capturer les arguments "additionnels".
+      [Python](#python) utilise `*args` et `**kwargs` pour capturer respectivement
+      les paramètres "additionnels" nommés et non nommés.
 
-
+      '
 - slug: variable_data
   ref:
-    - continuous_random_variable
-    - discrete_random_variable
+  - continuous_random_variable
+  - discrete_random_variable
   en:
-    term: "variable (data)"
-    def: >
-      Some attribute of a population that can be measured or observed.
+    term: variable (data)
+    def: 'Some attribute of a population that can be measured or observed.
 
-
+      '
 - slug: variable_program
   ref:
-    - constant
+  - constant
   en:
-    term: "variable (program)"
-    def: >
-      A name in a program that has some data associated with it. A variable's value
-      can be changed after definition.
-  es:
-    term: "variable (programa)"
-    def: >
-      Un nombre en un programa que tiene algunos datos asociados. El valor de una
-      variable se puede cambiar después de su definición.
-  fr:
-    term: "variable (programme)"
-    def: >
-      Un nom associé à des données au niveau d'un programme. La valeur d'une variable
-      peut être modifiée après l'avoir définie.
-  ar:
-    term: "المتغير"
-    def: >
-      المُتغير هو موقع يٌخزِن البيانات المؤقتة داخل البرنامج ويمكن تعديله وتخزينه وعرضه
-      عند الحاجة.
-  ja:
-    term: "変数 (プログラム)"
-    def: >
-      プログラム内で使用される、データが関連付けられる箱のようなものの総称。変数の値は定義した後で変更が可能。
-  uk:
-    term: "змінна (програмування)"
-    def: >
-      У мовах програмування - імʼя, якє має асоційоване з ним значення. Значення змінної 
-      може бути змінено після її створення.
+    term: variable (program)
+    def: 'A name in a program that has some data associated with it. A variable''s
+      value can be changed after definition.
 
+      '
+  es:
+    term: variable (programa)
+    def: 'Un nombre en un programa que tiene algunos datos asociados. El valor de
+      una variable se puede cambiar después de su definición.
+
+      '
+  fr:
+    term: variable (programme)
+    def: 'Un nom associé à des données au niveau d''un programme. La valeur d''une
+      variable peut être modifiée après l''avoir définie.
+
+      '
+  ar:
+    term: المتغير
+    def: 'المُتغير هو موقع يٌخزِن البيانات المؤقتة داخل البرنامج ويمكن تعديله وتخزينه
+      وعرضه عند الحاجة.
+
+      '
+  ja:
+    term: 変数 (プログラム)
+    def: 'プログラム内で使用される、データが関連付けられる箱のようなものの総称。変数の値は定義した後で変更が可能。
+
+      '
+  uk:
+    term: змінна (програмування)
+    def: 'У мовах програмування - імʼя, якє має асоційоване з ним значення. Значення
+      змінної  може бути змінено після її створення.
+
+      '
 - slug: variance
   en:
-    term: "variance"
-    def: >
-      How widely values in a dataset differ from the [mean](#mean). It is calculated
+    term: variance
+    def: 'How widely values in a dataset differ from the [mean](#mean). It is calculated
       as the average of the squared differences between the values and the mean. The
       [standard deviation](#standard_deviation) is often used instead, since it has
       the same units as the data, while the variance is expressed in units squared.
+
+      '
   de:
-    term: "Varianz"
-    def: >
-      Wie weit Werte in einem Datensatz vom [Mittelwert](#mean) entfernt sind. Die Varianz wird
-      berechnet als die Differenz eines Wertes und des Mittelwerts im Quadrat. Stattdessen wird oft auch
-      die [Standardabweichung](#standard_deviation) verwendet, da sie dieselbe Einheit wie die Daten
-      hat, während die Varianz in der Einheit zum Quadrat ausgedrückt wird.
+    term: Varianz
+    def: 'Wie weit Werte in einem Datensatz vom [Mittelwert](#mean) entfernt sind.
+      Die Varianz wird berechnet als die Differenz eines Wertes und des Mittelwerts
+      im Quadrat. Stattdessen wird oft auch die [Standardabweichung](#standard_deviation)
+      verwendet, da sie dieselbe Einheit wie die Daten hat, während die Varianz in
+      der Einheit zum Quadrat ausgedrückt wird.
+
+      '
   it:
-    term: "varianza"
-    def: >
-      Misura della distanza dei valori dalla loro [media](#mean). È calcolata
-      come la media dei quadrati delle differenze tra i valori e la loro media. La [deviazione
-      standard](#standard_deviation) è spesso usata al posto della varianza, perché ha
-      la stessa unità di misura dei dati, mentre la varianza è misurata nell'unità al quadrato.
+    term: varianza
+    def: 'Misura della distanza dei valori dalla loro [media](#mean). È calcolata
+      come la media dei quadrati delle differenze tra i valori e la loro media. La
+      [deviazione standard](#standard_deviation) è spesso usata al posto della varianza,
+      perché ha la stessa unità di misura dei dati, mentre la varianza è misurata
+      nell''unità al quadrato.
+
+      '
   es:
-    term: "varianza"
-    def: >
-      En qué medida los valores de un conjunto de datos difieren de la [media](#mean).
+    term: varianza
+    def: 'En qué medida los valores de un conjunto de datos difieren de la [media](#mean).
       Se calcula como el promedio de las diferencias al cuadrado entre los valores
       y la media. La [desviación estándar](#standard_deviation) se usa a menudo en
-      su lugar, ya que tiene las mismas unidades que los datos, mientras que la
-      varianza se expresa en unidades al cuadrado.
-  sw:
-    term: "achano"
-    def: >
-      Mraba ya mbali ya kawaida kutoka [wastani](#mean). Kuipata, tengua nambari na
-      wastani ya nambari hizo, halafu kokotoa wastani ya mraba.
+      su lugar, ya que tiene las mismas unidades que los datos, mientras que la varianza
+      se expresa en unidades al cuadrado.
 
+      '
+  sw:
+    term: achano
+    def: 'Mraba ya mbali ya kawaida kutoka [wastani](#mean). Kuipata, tengua nambari
+      na wastani ya nambari hizo, halafu kokotoa wastani ya mraba.
+
+      '
+- slug: variance_ml
+  ref:
+  - variance
+  - machine_learning
+  en:
+    term: variance (ML context)
+    def: 'In [machine learning](#machine_learning), variance refers to the model''s
+      sensitivity to small fluctuations in the training data. High variance can lead
+      to [overfitting](#overfitting), where the model performs well on training data
+      but poorly on new data. See also [variance](#variance) in statistics.
+
+      '
 - slug: vector
   en:
-    term: "vector"
-    def: >
-      A sequence of values, usually of [homogeneous](#homogeneous) type. Vectors are
-      the fundamental data structure in [R](#r_language); a [scalar](#scalar) is just a vector with
-      exactly one [element](#element).
+    term: vector
+    def: 'A sequence of values, usually of [homogeneous](#homogeneous) type. Vectors
+      are the fundamental data structure in [R](#r_language); a [scalar](#scalar)
+      is just a vector with exactly one [element](#element).
+
+      '
   es:
-    term: "vector"
-    def: >
-      Una secuencia de valores, normalmente de tipo [homogéneo](#homogeneous). Los
-      vectores son la estructura de datos fundamental en [R](#r_language); un [escalar](#scalar) es
-      solo un vector con exactamente un elemento.
+    term: vector
+    def: 'Una secuencia de valores, normalmente de tipo [homogéneo](#homogeneous).
+      Los vectores son la estructura de datos fundamental en [R](#r_language); un
+      [escalar](#scalar) es solo un vector con exactamente un elemento.
 
-
+      '
 - slug: vectorize
   en:
-    term: "vectorize"
-    def: >
-      To write code so that operations are performed on entire vectors, rather than
-      element-by-element within loops.
+    term: vectorize
+    def: 'To write code so that operations are performed on entire vectors, rather
+      than element-by-element within loops.
+
+      '
   es:
-    term: "vectorizar"
-    def: >
-      Escribir código de modo que las operaciones se ejecuten en vectores completos,
+    term: vectorizar
+    def: 'Escribir código de modo que las operaciones se ejecuten en vectores completos,
       más que elemento por elemento dentro de un bucle.
 
-
+      '
 - slug: version_control_system
   ref:
-    - git
+  - git
   en:
-    term: "version control system"
-    def: >
-      A system for managing changes made to software during its development.
-  es:
-    term: "sistema de control de versión"
-    def: >
-      Un sistema para manejar los cambios hechos durante el desarollo de software.
-  fr:
-    term: "système de gestion des versions"
-    def: >
-      Un système qui permet de gérer les modifications effectuées sur un programme
-      durant son développement.
-  pt:
-    term: "sistema de controle de versão"
-    def: >
-      Um sistema para gerenciar as mudanças feitas em um software durante o seu desenvolvimento.
-  uk:
-    term: "система контрою версій"
-    def: >
-      Система для запису історїї змін, внесених до програмного забезпечення під час його розробки.
+    term: version control system
+    def: 'A system for managing changes made to software during its development.
 
+      '
+  es:
+    term: sistema de control de versión
+    def: 'Un sistema para manejar los cambios hechos durante el desarollo de software.
+
+      '
+  fr:
+    term: système de gestion des versions
+    def: 'Un système qui permet de gérer les modifications effectuées sur un programme
+      durant son développement.
+
+      '
+  pt:
+    term: sistema de controle de versão
+    def: 'Um sistema para gerenciar as mudanças feitas em um software durante o seu
+      desenvolvimento.
+
+      '
+  uk:
+    term: система контрою версій
+    def: 'Система для запису історїї змін, внесених до програмного забезпечення під
+      час його розробки.
+
+      '
 - slug: vertex_shader
   ref:
-    - gpu
-    - fragment_shader
-    - geometry_shader
-    - shader
+  - gpu
+  - fragment_shader
+  - geometry_shader
+  - shader
   en:
-    term: "vertex shader"
-    def: >
-      The [shader](#shader) stage in the rendering pipeline designated towards handling
-      operations on individual vertices in a scene. A vertex shader can be used to calculate
-      properties of a single vertex, such as position and per-vertex lighting. Not to be
-      confused with [fragment shaders](#fragment_shader) which are used to determine the
-      actual colour being rendered to each pixel of the screen.
+    term: vertex shader
+    def: 'The [shader](#shader) stage in the rendering pipeline designated towards
+      handling operations on individual vertices in a scene. A vertex shader can be
+      used to calculate properties of a single vertex, such as position and per-vertex
+      lighting. Not to be confused with [fragment shaders](#fragment_shader) which
+      are used to determine the actual colour being rendered to each pixel of the
+      screen.
 
-
+      '
 - slug: vignette
   en:
-    term: "vignette"
-    def: >
-      A long-form guide used to provide details of a [package](#package) beyond the README.md or
-      function documentation.
-  es:
-    term: "viñeta"
-    def: >
-      Una guía de formato extenso utilizada para proporcionar detalles de un [paquete](#package) más allá del README.md o de la documentación de una función.
+    term: vignette
+    def: 'A long-form guide used to provide details of a [package](#package) beyond
+      the README.md or function documentation.
 
+      '
+  es:
+    term: viñeta
+    def: 'Una guía de formato extenso utilizada para proporcionar detalles de un [paquete](#package)
+      más allá del README.md o de la documentación de una función.
+
+      '
 - slug: vim
   en:
-    term: "Vim (editor)"
-    def: >
-      The default text editor on Unix. Vim is a very powerful text editor, with a steeper
-      learning curve than [nano](#nano_editor), but that allows the user to execute shell
-      commands and use [regular expressions](#regular_expression) to alter files programmatically.
+    term: Vim (editor)
+    def: 'The default text editor on Unix. Vim is a very powerful text editor, with
+      a steeper learning curve than [nano](#nano_editor), but that allows the user
+      to execute shell commands and use [regular expressions](#regular_expression)
+      to alter files programmatically.
+
+      '
   es:
-    term: "Vim (editor)"
-    def: >
-      El editor de texto por defecto en Unix. Vim es un poderoso editor de texto
-      que permite al usuario ejecutar comandos de shell y usar [expresiones regulares](#regular_expression) para
-      editar archivos programáticamente.
+    term: Vim (editor)
+    def: 'El editor de texto por defecto en Unix. Vim es un poderoso editor de texto
+      que permite al usuario ejecutar comandos de shell y usar [expresiones regulares](#regular_expression)
+      para editar archivos programáticamente.
 
-
+      '
 - slug: virtual_environment
   en:
-    term: "virtual environment"
-    def: >
-      In [Python](#python), the `virtualenv` [package](#package) allows you to create virtual,
-      disposable, [Python](#python) software environments containing only the packages
-      and versions of packages you want to use for a particular project or task, and
-      to install new packages into the environment without affecting other virtual
-      environments, or the system-wide default environment.
-  es:
-    term: "entorno virtual"
-    def: >
-      En [Python](#python), el [paquete](#package) `virtualenv` permite crear entornos virtuales de Python
-      para contener paquetes y versiones de esos paquetes que uno quiere usar para un proyecto o tarea particular
-      sin afectar otros entornos virtuales o el entorno por defecto del sistema.
+    term: virtual environment
+    def: 'In [Python](#python), the `virtualenv` [package](#package) allows you to
+      create virtual, disposable, [Python](#python) software environments containing
+      only the packages and versions of packages you want to use for a particular
+      project or task, and to install new packages into the environment without affecting
+      other virtual environments, or the system-wide default environment.
 
+      '
+  es:
+    term: entorno virtual
+    def: 'En [Python](#python), el [paquete](#package) `virtualenv` permite crear
+      entornos virtuales de Python para contener paquetes y versiones de esos paquetes
+      que uno quiere usar para un proyecto o tarea particular sin afectar otros entornos
+      virtuales o el entorno por defecto del sistema.
+
+      '
 - slug: virtual_machine
   en:
-    term: "virtual machine"
-    def: >
-      A program that pretends to be a computer. This may seem a bit redundant, but VMs
-      are quick to create and start up, and changes made inside the virtual machine
-      are contained within that VM so we can install new [packages](#package) or run a completely
-      different operating system without affecting the underlying computer.
+    term: virtual machine
+    def: 'A program that pretends to be a computer. This may seem a bit redundant,
+      but VMs are quick to create and start up, and changes made inside the virtual
+      machine are contained within that VM so we can install new [packages](#package)
+      or run a completely different operating system without affecting the underlying
+      computer.
+
+      '
   es:
-    term: "máquina virtual"
-    def: >
-      Un programa que pretende ser una computadora. Aunque puede parecer redundante,
+    term: máquina virtual
+    def: 'Un programa que pretende ser una computadora. Aunque puede parecer redundante,
       las máquinas virtuales (MV) se crean y se inician rápidamente, y los cambios
       hechos dentro de la máquina virtual quedan contenidos dentro de esa VM, esto
       permite que podamos instalar nuevos paquetes o ejecutar un sistema operativo
       diferente sin afectar la computadora subyacente.
 
-
+      '
 - slug: visitor_pattern
   ref:
-    - iterator_pattern
+  - iterator_pattern
   en:
-    term: "Visitor pattern"
-    def: >
-      A [design pattern](#design_pattern) in which the operation to be done is taken
-      to each element of a data structure in turn. It is usually implemented by having
-      a generator "visitor" that knows how to reach the structure's elements,
-      which is given a function or method to call for each in turn, and that carries out
-      the specific operation.
+    term: Visitor pattern
+    def: 'A [design pattern](#design_pattern) in which the operation to be done is
+      taken to each element of a data structure in turn. It is usually implemented
+      by having a generator "visitor" that knows how to reach the structure''s elements,
+      which is given a function or method to call for each in turn, and that carries
+      out the specific operation.
 
-
+      '
 - slug: walk_tree
   en:
-    term: "walk (a tree)"
-    def: >
-      To visit each [node](#node) in a [tree](#tree) in some order, typically
+    term: walk (a tree)
+    def: 'To visit each [node](#node) in a [tree](#tree) in some order, typically
       [depth-first](#depth_first) or [breadth-first](#breadth_first).
 
-
+      '
 - slug: while_loop
   ref:
-    - for_loop
+  - for_loop
   en:
-    term: "while loop"
-    def: >
-      A statement in a program that repeats one or more other statements (the [loop
-      body](#loop_body)) as long as a condition is [true](#true).
+    term: while loop
+    def: 'A statement in a program that repeats one or more other statements (the
+      [loop body](#loop_body)) as long as a condition is [true](#true).
+
+      '
   es:
-    term: "ciclo while"
-    def: >
-      También conocido como bucle while. Estructura dentro de un programa que repite
-      una o más instrucciones (el [cuerpo del ciclo o bucle](#loop_body))
-      mientras una condición sea [verdadera](#true).
+    term: ciclo while
+    def: 'También conocido como bucle while. Estructura dentro de un programa que
+      repite una o más instrucciones (el [cuerpo del ciclo o bucle](#loop_body)) mientras
+      una condición sea [verdadera](#true).
 
-
+      '
 - slug: whitespace
   en:
-    term: "whitespace"
-    def: >
-      The space, newline, carriage return, and horizontal and vertical tab characters
+    term: whitespace
+    def: 'The space, newline, carriage return, and horizontal and vertical tab characters
       that take up space but do not create a visible mark. The name comes from their
       appearance on a printed page in the era of typewriters.
-  de:
-    term: "whitespace"
-    def: >
-      Auch als "Leerraum" bekannt, eine Bezeichnung für Zeichen ohne sichtbares Symbol.
-      Typischerweise beinhaltet dies Leerzeichen, Tabulatorzeichen und Zeilenumbrüche.
-  pt:
-    term: "espaço em branco"
-    def: >
-      O espaço, nova linha, quebra de linha, ou tabulação horizontal ou vertical que ocupe
-      um espaço mas não crie uma marca visível. O nome vem de sua aparência em um papel impresso
-      da era das das máquinas de escrever.
-  uk:
-    term: "недруковані символи"
-    def: >
-      У текстових процесорах - символи, які займають місце, але не створюють видимої позначки, 
-      такі як пробіл, новий рядок, розрив рядка або горизонтальна чи вертикальна табуляція. 
 
+      '
+  de:
+    term: whitespace
+    def: 'Auch als "Leerraum" bekannt, eine Bezeichnung für Zeichen ohne sichtbares
+      Symbol. Typischerweise beinhaltet dies Leerzeichen, Tabulatorzeichen und Zeilenumbrüche.
+
+      '
+  pt:
+    term: espaço em branco
+    def: 'O espaço, nova linha, quebra de linha, ou tabulação horizontal ou vertical
+      que ocupe um espaço mas não crie uma marca visível. O nome vem de sua aparência
+      em um papel impresso da era das das máquinas de escrever.
+
+      '
+  uk:
+    term: недруковані символи
+    def: "У текстових процесорах - символи, які займають місце, але не створюють видимої\
+      \ позначки,  такі як пробіл, новий рядок, розрив рядка або горизонтальна чи\
+      \ вертикальна табуляція. \n"
 - slug: wildcard
   de:
-    term: "Wildcard"
-    def: >
-      Ein Zeichenausdruck, der mit Text übereinstimmen kann, wie z.B. das `*` in `*.csv` (das
-      passt auf jeden Dateinamen, der mit `.csv`) endet.
+    term: Wildcard
+    def: 'Ein Zeichenausdruck, der mit Text übereinstimmen kann, wie z.B. das `*`
+      in `*.csv` (das passt auf jeden Dateinamen, der mit `.csv`) endet.
+
+      '
   en:
-    term: "wildcard"
-    def: >
-      A character expression that can match text, such as the `*` in `*.csv` (which
+    term: wildcard
+    def: 'A character expression that can match text, such as the `*` in `*.csv` (which
       matches any filename whose name ends with `.csv`).
+
+      '
   nl:
-    term: "joker"
-    def: >
-      Een teken dat gebruikt kan worden om een overeenkomst met een reeks van tekens
-      uit te drukken. Bijvoorbeeld, de `*` in `*.csv` (welke overeenkomt met elke bestandsnaam
-      die eindigt in `.csv`).
+    term: joker
+    def: 'Een teken dat gebruikt kan worden om een overeenkomst met een reeks van
+      tekens uit te drukken. Bijvoorbeeld, de `*` in `*.csv` (welke overeenkomt met
+      elke bestandsnaam die eindigt in `.csv`).
+
+      '
   pt:
-    term: "curinga"
-    def: >
-      Um curinga, ou caracter curinga, é um caracter que corresponde a qualquer texto,
-      como o `*` em `*.csv` (que corresponde a qualquer arquivo cujo nome termina em `*.csv`).
+    term: curinga
+    def: 'Um curinga, ou caracter curinga, é um caracter que corresponde a qualquer
+      texto, como o `*` em `*.csv` (que corresponde a qualquer arquivo cujo nome termina
+      em `*.csv`).
 
-
+      '
 - slug: workflow
   en:
-    term: "workflow"
-    def: >
-      A way of describing work to be done as a set of tasks, typically with dependencies on
-      external inputs or the outputs of other tasks, which can later be executed by a program.
-      An example is a Makefile which can be executed by the make Unix command.
+    term: workflow
+    def: 'A way of describing work to be done as a set of tasks, typically with dependencies
+      on external inputs or the outputs of other tasks, which can later be executed
+      by a program. An example is a Makefile which can be executed by the make Unix
+      command.
 
-
+      '
 - slug: xml
   de:
-    term: "XML"
-    def: >
-      Eine Reihe von Regeln zur Definition von [HTML](#html)-ähnlichen Tags und deren
-      Verwendung zur Formatierung von Dokumenten (typischerweise Daten). XML war in den
-      frühen 2000er Jahren populär, aber seine Komplexität veranlasste
+    term: XML
+    def: 'Eine Reihe von Regeln zur Definition von [HTML](#html)-ähnlichen Tags und
+      deren Verwendung zur Formatierung von Dokumenten (typischerweise Daten). XML
+      war in den frühen 2000er Jahren populär, aber seine Komplexität veranlasste
       viele Programmierer, stattdessen [JSON](#json) zu verwenden.
+
+      '
   en:
-    term: "XML"
-    def: >
-      A set of rules for defining [HTML](#html)-like tags and using them to format
-      documents (typically data). XML was popular in the early 2000s, but its
-      complexity led many programmers to adopt [JSON](#json), instead.
+    term: XML
+    def: 'A set of rules for defining [HTML](#html)-like tags and using them to format
+      documents (typically data). XML was popular in the early 2000s, but its complexity
+      led many programmers to adopt [JSON](#json), instead.
+
+      '
   es:
-    term: "XML"
-    def: >
-      Un conjunto de reglas para definir etiquetas similares a [HTML](#html) y usarlas
-      para darle formato a documentos (normalmente datos). XML alcanzó popularidad a
-      principios de la década de 2000, pero su complejidad llevó a muchos
-      programadores a adoptar [JSON](#json) en su lugar.
+    term: XML
+    def: 'Un conjunto de reglas para definir etiquetas similares a [HTML](#html) y
+      usarlas para darle formato a documentos (normalmente datos). XML alcanzó popularidad
+      a principios de la década de 2000, pero su complejidad llevó a muchos programadores
+      a adoptar [JSON](#json) en su lugar.
+
+      '
   fr:
-    term: "XML"
-    def: >
-      Un format de représentation de données qui définit des balises similaires à
-      celles utilisées en [HTML](#html). XML était populaire au début des années 2000
-      mais sa complexité a conduit de nombreux dévelopeurs à utiliser [JSON](#json) à
-      la place.
+    term: XML
+    def: 'Un format de représentation de données qui définit des balises similaires
+      à celles utilisées en [HTML](#html). XML était populaire au début des années
+      2000 mais sa complexité a conduit de nombreux dévelopeurs à utiliser [JSON](#json)
+      à la place.
+
+      '
   pt:
-    term: "XML"
-    def: >
-      Um conjunto de regras para se definir etiquetas similares a [HTML](#html) e usá-las
-      para formatar documentos (normalmente, dados). XML foi popular no início dos anos 2000,
-      mas sua complexidade fez com que muitas pessoas programadoras adotassem [JSON](#json) em
-      seu lugar.
+    term: XML
+    def: 'Um conjunto de regras para se definir etiquetas similares a [HTML](#html)
+      e usá-las para formatar documentos (normalmente, dados). XML foi popular no
+      início dos anos 2000, mas sua complexidade fez com que muitas pessoas programadoras
+      adotassem [JSON](#json) em seu lugar.
 
-
+      '
 - slug: yaml
   de:
-    term: "YAML"
-    def: >
-      Abkürzung für "YAML Ain't Markup Language", eine Methode zur Darstellung
-      verschachtelter Daten mit Einrückung statt der Klammern und Kommas
-      von [JSON](#json). YAML wird oft in Konfigurationsdateien und zur Definition
-      von Parametern in verschiedenen Varianten von [Markdown](#markdown)-Dokumenten verwendet.
+    term: YAML
+    def: 'Abkürzung für "YAML Ain''t Markup Language", eine Methode zur Darstellung
+      verschachtelter Daten mit Einrückung statt der Klammern und Kommas von [JSON](#json).
+      YAML wird oft in Konfigurationsdateien und zur Definition von Parametern in
+      verschiedenen Varianten von [Markdown](#markdown)-Dokumenten verwendet.
+
+      '
   en:
-    term: "YAML"
-    def: >
-      Short for "YAML Ain't Markup Language", a way to represent nested data using
-      indentation rather than the parentheses and commas of [JSON](#json). YAML is
-      often used in configuration files and to define [parameters](#parameter) for various flavours
-      of [Markdown](#markdown) documents.
+    term: YAML
+    def: 'Short for "YAML Ain''t Markup Language", a way to represent nested data
+      using indentation rather than the parentheses and commas of [JSON](#json). YAML
+      is often used in configuration files and to define [parameters](#parameter)
+      for various flavours of [Markdown](#markdown) documents.
+
+      '
   fr:
-    term: "YAML"
-    def: >
-      Acronyme récursif de "YAML Ain't Markup Language" ("YAML n'est pas un langage de
-      balisage"), YAML est un format de représentation de données hiérarchiques qui
-      utilise des indentations au lieu de signes typographiques, comme les parenthèses
+    term: YAML
+    def: 'Acronyme récursif de "YAML Ain''t Markup Language" ("YAML n''est pas un
+      langage de balisage"), YAML est un format de représentation de données hiérarchiques
+      qui utilise des indentations au lieu de signes typographiques, comme les parenthèses
       et virgules en [JSON](#json). YAML est souvent utilisé dans les fichiers de
       configuration et pour définir les paramètres de documents [Markdown](#markdown).
+
+      '
   pt:
-    term: "YAML"
-    def: >
-      Acrônimo recursivo de "YAML Ain't Markup Language" (YAML não é uma linguagem de marcação),
-      é uma maneira de representar dados aninhados usando recuos (também chamados de indentações)
-      no lugar de parênteses e vírgulas usados em [JSON](#json). YAML é frequentemente usado em
-      arquivos de configuração e na definição de [parâmetros](#parameter) para vários estilos
-      de documentos em [Markdown](#markdown).
+    term: YAML
+    def: 'Acrônimo recursivo de "YAML Ain''t Markup Language" (YAML não é uma linguagem
+      de marcação), é uma maneira de representar dados aninhados usando recuos (também
+      chamados de indentações) no lugar de parênteses e vírgulas usados em [JSON](#json).
+      YAML é frequentemente usado em arquivos de configuração e na definição de [parâmetros](#parameter)
+      para vários estilos de documentos em [Markdown](#markdown).
+
+      '
   es:
-    term: "YAML"
-    def: >
-      Acrónimo recursivo de "YAML Ain't Markup Language" (YAML no es un lenguaje de marcación),
-      es una manera de representar datos anidados usando identación en lugar de paréntesis   
-      y comillas usadas en [JSON](#json). YAML es usado frequentemente en    
-      archivos de configuración y para definir [parámetros](#parameter) en varios estilos
-      de documentos en [Markdown](#markdown).
+    term: YAML
+    def: 'Acrónimo recursivo de "YAML Ain''t Markup Language" (YAML no es un lenguaje
+      de marcación), es una manera de representar datos anidados usando identación
+      en lugar de paréntesis    y comillas usadas en [JSON](#json). YAML es usado
+      frequentemente en     archivos de configuración y para definir [parámetros](#parameter)
+      en varios estilos de documentos en [Markdown](#markdown).
+
+      '
   af:
-    term: "YAML"
-    def: >
-      Kort vir "YAML Ain't Markup Language", 'n manier om geneste data te gebruik deur middel van indentasies in plaas van
-      hakkies en kommas of [JSON](#json). YAML word dikwels in konfigurasielêers gebruik en om [parameters](#parameter) vir
-      verskeie geure te definieer van [Markdown](#markdown) dokumente.
+    term: YAML
+    def: 'Kort vir "YAML Ain''t Markup Language", ''n manier om geneste data te gebruik
+      deur middel van indentasies in plaas van hakkies en kommas of [JSON](#json).
+      YAML word dikwels in konfigurasielêers gebruik en om [parameters](#parameter)
+      vir verskeie geure te definieer van [Markdown](#markdown) dokumente.
+
+      '
   id:
-    term: "YAML"
-    def: >
-      Kependekan dari "YAML Ain't Markup Language", adalah cara menyatakan nested data menggunakan
-      indentasi alih-alih menggunakan tanda kurung dan koma pada [JSON] (#json). YAML sering kali
-      digunakan pada berkas konfigurasi dan untuk mendefinisikan [parameter](#parameter)
-      untuk beragam tipe dokumen [Markdown](#markdown).
+    term: YAML
+    def: 'Kependekan dari "YAML Ain''t Markup Language", adalah cara menyatakan nested
+      data menggunakan indentasi alih-alih menggunakan tanda kurung dan koma pada
+      [JSON] (#json). YAML sering kali digunakan pada berkas konfigurasi dan untuk
+      mendefinisikan [parameter](#parameter) untuk beragam tipe dokumen [Markdown](#markdown).
 
-
-- slug: parametric_statistics
-  ref:
-    - nonparametric_statistics
-  en:
-    term: "parametric (statistics)"
-    def: >
-      A branch of statistical tests which assume a known distribution of the population which the samples were taken from (ANOVA and Student’s t-tests are examples of parametric tests).
-
-
-- slug: nonparametric_statistics
-  ref:
-    - parametric_statistics
-  en:
-    term: "non-parametric (statistics)"
-    def: >
-      A branch of statistical tests which do not assume a known distribution of the population which the samples were taken from (Kruskal-Wallis and Dunn test are examples of non-parametric tests).
-
-
-- slug: cnn
-  ref:
-    - deep_learning
-    - backpropagation
-    - perceptron
-    - neural_network
-    - machine_learning
-  en:
-    term: "convolutional neural network (cnn)"
-    def: >
-      A class of artificial neural network that is primarily used to analyze images. A CNN has layers
-      that perform convolutions, where a filter is shifted over the data, instead of the general
-      matrix multiplications that we see in fully connected neural network layers.
-
-- slug: rnn
-  ref:
-    - deep_learning
-    - backpropagation
-    - perceptron
-    - neural_network
-    - machine_learning
-  en:
-    term: recurrent neural network
-    def: >
-      A class of [artificial neural networks](#neural_network) where connections between nodes can
-      create a cycle. This allows the network to exhibit behavior that is dynamic over time. This
-      type of network is applicable to tasks like speech and handwriting recognition.
-
-- slug: epoch_dl
-  ref:
-    - deep_learning
-    - backpropagation
-    - perceptron
-    - neural_network
-    - machine_learning
-  en:
-    term: epoch (deep learning)
-    def: >
-      In [deep learning](#deep_learning), an epoch is one cycle in the deep learning process where all
-      the training data has been fed to the algorithm once. Training a deep neural networks usually
-      consists of multiple epochs.
-  es:
-    term: epoch (aprendizaje profundo)
-    def: > 
-      En [aprendizaje profundo](#deep_learning), un epoch es un ciclo completo en el proceso del aprendizaje profundo 
-      en el que todos los datos de entrenamiento se han introducido una vez en el algoritmo. 
-      El entrenamiento de una red neuronal profunda consiste en varios epoch.    
-
-
-- slug: learning_rate
-  ref:
-    - deep_learning
-    - backpropagation
-    - perceptron
-    - neural_network
-    - machine_learning
-  en:
-    term: learning rate (deep learning)
-    def: >
-      In [artificial neural networks](#neural_network), the learning rate is a hyper-parameter that
-      determines the pace at which the network adjusts the weights to move down the loss gradient.
-      A large learning rate can speed up training, but the network might overshoot and miss the
-      minimum. A small learning rate will overshoot less, but will be slower. It can also get more
-      easily stuck in local minima.
-  es:
-    term: tasa de aprendizaje (aprendizaje profundo)
-    def: >
-      En [redes neuronales artificiales](#neural_network), la tasa de aprendizaje es un hiperparámetro que 
-      determina el ritmo al que la red ajusta los pesos para poder dar cada vez una mejor aproximación. 
-      Una tasa de aprendizaje grande puede acelerar el entrenamiento, pero la red se puede sobrepasar y 
-      perder el mínimo global. Una tasa de aprendizaje pequeña se sobrepasará menos, pero será más lenta. 
-      También puede caer más fácilmente en mínimos locales.
-
-
-- slug: class_imbalance
-  ref:
-    - machine_learning
-  en:
-    term: class imbalance
-    def: >
-      Class imbalance refers to the problem in [machine learning](machine_learning) where there is an
-      unequal distribution of classes in the dataset.
-
-
-- slug: hidden_layer
-  ref:
-    - neural_network
-    - machine_learning
-    - deep_learning
-    - perceptron
-  en:
-    term: hidden layer (deep learning)
-    def: >
-      A hidden layer in a [neural network](#neural_network) refers to the layers of neurons that are
-      not directly connected to input or output. The layers are "hidden" because you do not directly
-      observe their input and output values.
-  es:
-    term: capa oculta (deep learning)
-    def: >
-      Una capa oculta en una [red neuronal](#neural_network) hace referencia a las capas de neuronas que
-      no están directamente conectadas al ingreso o salida de información. Las capas están "escondidas" porque
-      no puedes observar directamente el ingreso y salida de valores.
-
-
-- slug: roc_curve
-  ref:
-    - machine_learning
-    - classification
-  en:
-    term: "ROC Curve"
-    def: >
-      A ROC curve (Receiver Operating Characteristic curve) is a graph that displays the performance
-      of a binary classifier at different [classification](#classification) thresholds. The curve is
-      obtained by plotting the True Positive Rate (also known as Recall or [Sensitivity](#sensitivity))
-      along the vertical axis and the False Positive Rate along the horizontal axis.
-
-  es:
-    term: "Curva ROC"
-    def: >
-      Una curva ROC (acrónimo de Receiver Operating Characteristic, o Característica Operativa del Receptor) 
-      es un gráfico que muestra el desempeño de un clasificador binario con diferentes umbrales de [clasificación](#classification)
-      La curva se obtiene graficando la tasa de verdaderos positivos (también conocida como Recall o [Sensibilidad](#sensitivity))
-      a lo largo del eje vertical y la taza de falsos positivos a lo largo del eje horizontal.
-
-- slug: fine_tuning
-  ref:
-    - deep_learning
-    - neural_network
-    - transfer_learning
-  
-  en:
-    term: fine-tuning (deep learning)
-    def: >
-      Fine-tuning is an approach to transfer learning in which a pre-trained network is adapted to the 
-      specifics of a new dataset. 
-
-- slug: transfer_learning
-  ref: 
-    - deep_learning
-    - transfer_learning
-  
-  en:
-    term: transfer learning (deep learning)
-    def: >
-      Transfer learning is a specific form of deep learning that has 2 stages. First, in the pre-training 
-      phase, a neural network is trained on a (typically large) generic dataset. Second, the 
-      fine-tuning phase, the neural network is adapted to the specifics of a (typically smaller) new 
-      dataset. The idea is that the network will capture generic knowledge in the pre-training phase 
-      that is relevant for learning in the fine-tuning task.
-      
+      '


### PR DESCRIPTION
- Added 52 new English term definitions covering:
  * Data structures (array, binary_tree, heap, linked_list, queue, set, stack)
  * Algorithms (backtracking, divide_and_conquer, dynamic_programming, greedy_algorithm, hashing, memoization, searching, sorting)
  * Data preparation (data_analysis, data_analytics, data_cleaning, data_preprocessing, dataset, missing_data)
  * Statistics and ML basics (bayesian_statistics, hypothesis_testing, probability)
  * ML concepts (activation_function, batch_size, label, loss_function, learning_rate)
  * ML models (knn, lstm, pca, recurrent_neural_network, regression, transformer)
  * Evaluation metrics (auc, f1_score, precision, recall)
  * ML workflow (model_evaluation, model_training, test_set, training_set, validation_set)
  * Other concepts (aliased, tensorflow, underfitting, variance_ml)

- All entries include proper cross-references to related terms
- Glossary validated and sorted alphabetically by slug
- Definitions written for data science learners

Addresses [#1032](https://github.com/carpentries/glosario/issues/1032)